### PR TITLE
Add button to copy list of broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- Add button to copy list of broken links on nofo_edit page
 - Add new coaches and designers
   - Remove a couple of retired coaches
 
@@ -48,10 +49,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Restructure HTML in the Application Checklists for better styling
   - Previously, I was using a CSS hack because I didn't have enough elements to style
 - 'Criterion' tables are always small
+  <<<<<<< HEAD
 - Find ranges for numbered sublists
   - Match for "8-15.", "8 - 15.", "8 through 15."
   - Remove the border under "Attachments"
-- ids inserted using markdown attributes should not show up as 'broken links'
+- # ids inserted using markdown attributes should not show up as 'broken links'
+- Added more known styles for the mammoth style map
+  > > > > > > > 6592cc6 (Add button to copy broken links on nofo_edit page)
 
 ## [1.29.0] - 2023-10-19
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -301,6 +301,14 @@ details > summary > span:hover {
   margin-bottom: 0;
 }
 
+.nofo_edit .usa-site-alert .usa-button-icon--copy-button {
+  padding: 0.75rem 1rem 0.75rem 0.9rem;
+  position: absolute;
+  right: 0;
+  top: 2rem;
+  margin-right: 4rem; /* match the padding on usa-alert__body */
+}
+
 .nofo_edit .usa-site-alert--heading-errors .usa-alert {
   border-left-color: var(--color--usa-error-bg-dark);
 }
@@ -387,6 +395,20 @@ details > summary > span:hover {
     brightness(102%) contrast(79%);
   width: 18px;
   height: 17px;
+}
+
+.nofo_edit .usa-alert__body .usa-button-icon--copy-button::before {
+  content: "";
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  display: inline-flex;
+  background-image: url("/static/img/usa-icons/content_copy.svg");
+  filter: invert(99%) sepia(100%) saturate(207%) hue-rotate(194deg)
+    brightness(111%) contrast(100%);
+  width: 13px;
+  height: 12px;
+  margin-right: 4px;
 }
 
 .nofo_edit

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -105,6 +105,7 @@ Edit “{{ nofo|nofo_name }}”
   <div class="usa-alert">
     <div class="usa-alert__body">
       <h3 class="usa-alert__heading">Warning: some internal links are broken</h3>
+      <button class="usa-button usa-button--outline usa-button--inverse usa-button-icon--copy-button font-sans-2xs" type="button">Copy links</button>
       <div>
         <details>
           <summary>
@@ -423,9 +424,9 @@ Edit “{{ nofo|nofo_name }}”
 {% block js_footer %}
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    const buttons = document.querySelectorAll('.usa-button-icon--copy-button');
-
-    buttons.forEach(button => {
+    // Copy buttons for the heading ids
+    const tableButtons = document.querySelectorAll('.table--section .usa-button-icon--copy-button');
+    tableButtons.forEach(button => {
         button.addEventListener('click', function() {
             // Copy data-section-id to clipboard
             navigator.clipboard.writeText(`#${this.getAttribute('data-section-id')}`);
@@ -441,6 +442,44 @@ Edit “{{ nofo|nofo_name }}”
                 this.classList.remove('usa-button-icon--copy-button--copied');
                 this.querySelector('span').textContent = 'Copy section id';
             }, 1000);
+        });
+    });
+
+    // Copy buttons inside of the alert boxes (eg, copy broken links)
+    const alertButtons = document.querySelectorAll('.usa-site-alert .usa-button-icon--copy-button');
+    alertButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            // Find the nearest parent with the class '.usa-site-alert'
+            const alertBox = this.closest('.usa-site-alert');
+            if (!alertBox) {
+                return console.error('Error: no alert box.');
+            }
+
+            const detailsElement = alertBox.querySelector('details');
+
+            const wasClosed = !detailsElement.open;
+            // Temporarily open the <details> element if it's closed
+            if (wasClosed) {
+                detailsElement.open = true;
+            }
+
+            const summaryText = alertBox.querySelector('summary').innerText;
+            const listText = Array.from(alertBox.querySelectorAll('ol li'))
+                .map((item, i) => `${i + 1}. ${item.innerText}`)
+                .join('\n');
+
+            navigator.clipboard.writeText(`${summaryText}\n\n${listText}`)
+                .then(() => {
+                    // Change button text on success
+                    button.innerHTML = 'Copied!';
+                    // Revert text after 1 second
+                    setTimeout(() => button.innerHTML = 'Copy links', 1000);
+                })
+                .catch(err => console.error('Failed to copy text: ' + err));
+
+            if (wasClosed) {
+                detailsElement.open = false;
+            }
         });
     });
   });

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -178,6 +178,16 @@ style_map_manager.add_style(
     note="Don't do anything: regular body text.",
 )
 style_map_manager.add_style(
+    style_rule="p[style-name='Body Text'] => p:fresh",
+    location_in_nofo="Step 1 > Program description > Overview",
+    note="Don't do anything: regular body text.",
+)
+style_map_manager.add_style(
+    style_rule="p[style-name='pf0'] => p:fresh",
+    location_in_nofo="Step 1 > Program description > Overview",
+    note="Don't do anything: regular body text.",
+)
+style_map_manager.add_style(
     style_rule="p[style-name='Main Heading'] => p",
     location_in_nofo="Step 1 > Key facts > number",
     note="Don't do anything: regular body text (may not be true for all, but let's assume).",

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -101,9 +101,39 @@ style_map_manager.add_style(
     note="Don't do anything, just whitespace",
 )
 style_map_manager.add_style(
+    style_rule="r[style-name='contentcontrolboundarysink'] => span",
+    location_in_nofo="Step 6 > Post-award requirements and administration > Reporting",
+    note="Don't do anything, just whitespace",
+)
+style_map_manager.add_style(
     style_rule="r[style-name='criteria-linked-element_data-mode=export_criteria-score'] => span.linked-element",
     location_in_nofo="Step 4 > Maximum points > 20",
     note="Don't do anything: body text",
+)
+style_map_manager.add_style(
+    style_rule="r[style-name='cf01'] => span",
+    location_in_nofo="It's just in body text",
+    note="Just plain body text",
+)
+style_map_manager.add_style(
+    style_rule="r[style-name='cf11'] => span",
+    location_in_nofo="It's just in body text",
+    note="Just plain body text",
+)
+style_map_manager.add_style(
+    style_rule="r[style-name='scxw144559721'] => span",
+    location_in_nofo="It's just in body text",
+    note="Just plain body text",
+)
+style_map_manager.add_style(
+    style_rule="r[style-name='Style6 Char'] => span",
+    location_in_nofo="Step 1 > Program description > Purpose",
+    note="Just plain body text",
+)
+style_map_manager.add_style(
+    style_rule="r[style-name='url'] => span",
+    location_in_nofo="It's a url in the footnotes body text",
+    note="It's a URL but it should be formatted as body text",
 )
 style_map_manager.add_style(
     style_rule="r[style-name='ui-provider'] => span:fresh",
@@ -126,6 +156,11 @@ style_map_manager.add_style(
     note="Bold is safe, but they might possibly be headings.",
 )
 style_map_manager.add_style(
+    style_rule="r[style-name='Heading 1 Char'] => span",
+    location_in_nofo="Step 1 > Program description > Core Component approach > Core Component strategies and activities",
+    note="Do nothing, it's whitespace",
+)
+style_map_manager.add_style(
     style_rule="r[style-name='Heading 3 Char'] => h3:fresh",
     location_in_nofo="Step 1 > Program description > Four core functions",
     note="This signifies an h3",
@@ -139,11 +174,6 @@ style_map_manager.add_style(
     style_rule="r[style-name='Heading 5 Char'] => h5:fresh",
     location_in_nofo="Step 1 > Cost-sharing commitments > Reduced Match",
     note="This signifies an h5",
-)
-style_map_manager.add_style(
-    style_rule="r[style-name='cf01'] => span",
-    location_in_nofo="It's just in body text",
-    note="Just plain body text",
 )
 
 # paragraph styles


### PR DESCRIPTION
## Summary

This PR does 2 things, but only 1 of them is important.

1. (Not important) Adding style maps for Word conversions
2. (Important) Adding a "copy links" button on the nofo_edit page

<details>

<summary>
Style maps explainer
</summary>

When we import .doc/docx files, we use [mammoth](https://github.com/mwilliamson/python-mammoth) to convert them to HTML first. It does a pretty good job, but sometimes it doesn't know what to do with specific formatting (you can see how text is formatted using the styles pane in Word). 

[Style maps](https://github.com/mwilliamson/python-mammoth?tab=readme-ov-file#styles) are explicit conversion rules that we can add. As an example: 

```
style_map_manager.add_style(
    style_rule="p[style-name='Emphasis A'] => strong.emphasis",
    location_in_nofo="Step 2 > Grants.gov > Need Help?",
    note="Just bold the entire sentence",
)
```

This style looks for text formatted with "Emphasis A" and will convert it to a `<strong>` tag with a classname of "emphasis". I've written a little container class around them, but the actual rule itself is the `style_rule`.

If you don't specify a style tag, mammoth does a 'best guess' conversion.

There are usually new style tags that come in when we get sent new documents and I initially thought we should capture them all so that all of our conversions were explicit rather than implicit.

However, 2 problems with this idea:

1. Style tags are literally just strings, so anyone can create a new style at any time (there is no 'full list' of Word styles). So we will forever be malleting groundhogs if this is the idea.
2. The 'best guess' conversion is sometimes better than a style map. For example, the level nested bullets can't be detected with style maps, but they work with implicit conversions.

Given all that, it's still generally a reasonable idea to add explicit conversions if they aren't doing anything too complex, so this PR contains some that have come in recently.
</details>

This PR adds a 'Copy links' button to the broken links alert box on the nofo_edit page. If you click the button, the number of broken links and a list of broken links is copied to your clipboard. The use case here is that you can click the button and then email the list to someone.

The button works whether the `<details>` element in the alert box is open or closed. 

The JS is added to a script tag near the page footer. This app has very minimal JS needs (deliberately), so there is no sophisticated JS build pipeline, and I'd prefer to keep it that was as long as possible. This means there is some duplication with JS here and there but I think it's okay.

The button styling comes from the 'outline inverse' version of [the US Web Design System (USWDS) button component](https://designsystem.digital.gov/components/button/). 

#### gif

![Screen Recording 2024-10-23 at 10 44 49 AM](https://github.com/user-attachments/assets/efcebff9-7bac-4762-be67-2ff18ebe8a48)

### Why are we doing this?

Adam has asked about this because sometimes he sends back NOFOs with too many broken links to the writing teams and he pulls out the list of links for them to fix up.

Also, recently, Betty asked for this same thing. Here is the ticket on Airtable: https://airtable.com/appdaa5AqUwI8jdOo/tblziL3G1qZkr0oV3/viwQ7YCJq9yxJq21f/recvgcYiBgNfhHWL7?blocks=hide

### How to test this

1. Have an imported NOFO with broken links
2. Click the "copy links" button
3. Paste into empty document/note
4. They should match