### PR TITLE
Make sure criterion tables are small but other step 4 tables are large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- 'Criterion' tables are always small
+
 ## [1.29.0] - 2023-10-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Once a NOFO is reviewed and approved, our anticipated workflow is:
 
 `python` is a high-level, general-purpose programming language, popular for programming web applications.
 
-This project uses Python >=3.10.
+This project uses Python >=3.11.
 
-### [Install `poetry`](https://www.npmjs.com/get-npm)
+You can find the exact version of python that is being used by referencing the [Dockerfile](https://github.com/HHS/simpler-grants-pdf-builder/blob/main/Dockerfile#L1). If you want to change your Python version, I would recommend [pyenv](https://github.com/pyenv/pyenv).
+
+### [Install `poetry`](https://python-poetry.org/docs/)
 
 `poetry` is a tool for dependency management and packaging in Python. It allows you to declare the libraries your project depends on and it will manage (install/update) them for you.
 

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -291,7 +291,7 @@ body.portrait.cdc
   .section--step-4-learn-about-review-and-award
   .section--content
   p
-  + table:not(.table--small) {
+  + table:not(.table--criterion) {
   width: calc(
     216mm - 40mm
   ); /* large tables in section 4 should be full-width */

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -85,7 +85,7 @@ def add_class_to_table(table):
 
     Secondly, checks for content of table headings:
     - "table--large": th found with "Recommended For"
-    - "table--small": th found with "Criterion"
+    - "table--criterion": th found with "Criterion"
 
     Finally, look at columns and word count:
     - "table--small": fewer than 4 columns and no words
@@ -110,7 +110,7 @@ def add_class_to_table(table):
         return "table--large"
 
     if table.find("th", string="Criterion"):
-        return "table--small"
+        return "table--criterion"
 
     word_count = _get_total_word_count(table.find_all("td"))
 

--- a/bloom_nofos/nofos/test_templatetags.py
+++ b/bloom_nofos/nofos/test_templatetags.py
@@ -300,7 +300,7 @@ class HTMLTableClassTests(TestCase):
         table_html = "<table><thead><tr><th>Criterion</th><th>Heading 2</th><th>Heading 3</th></tr></thead><tbody><tr><td>Cell 1</td><td>Cell 2</td><td>Cell 3</td></tr></tbody></table>"
         soup = BeautifulSoup(table_html, "html.parser")
 
-        self.assertEqual(add_class_to_table(soup.find("table")), "table--small")
+        self.assertEqual(add_class_to_table(soup.find("table")), "table--criterion")
 
 
 class TestAddClassToTableRows(TestCase):


### PR DESCRIPTION
## Summary

This PR: fixes table widths for step 4, and makes some updates to the README.

We have some general rules for table sizes: 
- tables with 3 or more columns are full-width, OR tables with over 100 words

However, for Step 4, we have more specific ideas:
- "Criterion" tables should be col-width
- All other tables should be full-width

This PR fixes our table rules for step 4 to make that work.

| before | after |
|--------|-------|
|    only 2 tables here are full-width    |    all tables full-width except our 2 criterion tables   |
|   <img width="241" alt="Screenshot 2024-10-24 at 1 59 20 PM" src="https://github.com/user-attachments/assets/f0752b72-b4e3-4c3a-abd6-a83a37d26902">    |   <img width="241" alt="Screenshot 2024-10-24 at 1 58 40 PM" src="https://github.com/user-attachments/assets/0d0b4989-ba4e-4819-962d-f61367f153b8">   |

### Why are we doing this

Technically a bug 🐞 

### How to test this 

Try out CDC 0157 in the NOFO Builder and check out step 4.