### PR TITLE
Fix styling for the application checkbox tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Restructure HTML in the Application Checklists for better styling
+  - Previously, I was using a CSS hack because I didn't have enough elements to style
 - 'Criterion' tables are always small
 
 ## [1.29.0] - 2023-10-19

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -447,6 +447,18 @@ body.cms-white table td img.usa-icon--check_box_outline_blank {
   box-shadow: inset 0px 0px 5px 3px var(--color--table-blue);
 }
 
+.section--step-5-submit-your-application table tr td.usa-icon__td div {
+  display: flex;
+}
+
+.section--step-5-submit-your-application table tr td.usa-icon__td {
+  vertical-align: top;
+}
+
+.section--step-5-submit-your-application table tr td.usa-icon__td span {
+  line-height: 1.25;
+}
+
 ul,
 ol {
   margin-bottom: 12px;
@@ -477,7 +489,6 @@ ol ol ol {
 img.usa-icon--check_box_outline_blank {
   height: 17px;
   width: 17px;
-  margin-bottom: -3px;
   margin-right: 5px;
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -270,23 +270,6 @@ section.before-you-begin {
   width: calc(216mm - 40mm); /* large tables should be full-width */
 }
 
-table tr td.usa-icon__td--sublist {
-  position: relative;
-  padding-left: 44px;
-  z-index: -1;
-}
-
-table tr td.usa-icon__td--sublist img.usa-icon {
-  position: absolute;
-  top: 7px;
-  left: 22px;
-}
-
-table tr td.usa-icon__td--sublist li.usa-icon__list-element img.usa-icon {
-  left: -22px;
-  top: 0;
-}
-
 body.portrait.cdc
   .section--step-4-learn-about-review-and-award
   .section--content
@@ -295,4 +278,8 @@ body.portrait.cdc
   width: calc(
     216mm - 40mm
   ); /* large tables in section 4 should be full-width */
+}
+
+table tr td.usa-icon__td--sublist {
+  padding-left: 30px;
 }

--- a/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
+++ b/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
@@ -119,6 +119,40 @@ def replace_unicode_with_svg(root_element, icon, svg_html):
         root_element.insert(0, svg_soup)
 
 
+def wrap_text_in_span(td):
+    soup = BeautifulSoup("", "html.parser")
+
+    img = td.find("img")
+    if img and img.next_sibling and isinstance(img.next_sibling, NavigableString):
+        # Get the text after the image
+        text = img.next_sibling.strip()
+
+        if text:
+            # Create a new span element with the text
+            text_wrapped_with_span = soup.new_tag("span")
+            text_wrapped_with_span.string = text
+            img.next_sibling.replace_with(text_wrapped_with_span)
+
+
+def wrap_td_contents_in_div(td):
+    first_child = td.contents[0] if td.contents else None
+    if first_child and first_child.name == "div":
+        return  # If the first child is a div, do nothing
+
+    soup = BeautifulSoup("", "html.parser")
+
+    # Create a new div element
+    new_div = soup.new_tag("div")
+
+    # Move all the contents of td into the new div by iterating over a copy of td.contents
+    for content in list(td.contents):
+        new_div.append(content)
+
+    # Clear the original contents of td and add the new div
+    td.clear()
+    td.append(new_div)
+
+
 @register.filter()
 def replace_unicode_with_icon(html_string):
     """
@@ -197,5 +231,8 @@ def replace_unicode_with_icon(html_string):
                             classname="usa-icon__td--link",
                             tag_name="td",
                         )
+
+                    wrap_text_in_span(parent_td)
+                    wrap_td_contents_in_div(parent_td)
 
     return mark_safe(str(soup))

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -387,7 +387,7 @@ class TablesAndStuffInTablesConverterDIVSTest(TestCase):
 
     def test_div_with_attributes_no_role_heading(self):
         html = '<div class="some-class" id="div1" aria-level="7" role="main">This is a test div</div>'
-        expected_html = 'This is a test div'
+        expected_html = "This is a test div"
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_html)
 


### PR DESCRIPTION
## Summary

This PR fixes the layout of the application checkbox tables.

Here's the issue.

We have this pretty complex checkbox-style of table and we don't want long text lines to go back to the start of the `<td>`. We want to style them so they are more like bullets.

So, for example:

```
◻ item 1
◻ item 2
◻ item 3 a really long item about
another thing
◻ item 4
```

We want to avoid a situation where "another" starts on the same vertical line as the checkboxes.

What we want is this:

```
◻ item 1
◻ item 2
◻ item 3 a really long item about
  another thing
◻ item 4
```

In order to do this in CSS, we have to add some structure, like a flexbox.

Unfortunately, you can't just add flexbox styling to a table cell, because the table cell already has a display: of `table-cell`. If you make them flexboxes, the entire table layout is borked.

However, there weren't really enough HTML elements to style flexibly.

Previously, these td elements looked like this:

```
<td class="usa-icon__td">
   <img alt="Checkbox" class="usa-icon usa-icon--check_box_outline_blank" src="https://bn-ptzepiewjq-uc.a.run.app/static/img/usa-icons/check_box_outline_blank.svg">
   Research &amp; Related Budget
</td>
```

- No element to style for the text
- No element wrapping the img and text other than <td>

Now, it looks like this:

```
<td class="usa-icon__td">
   <div>
      <img alt="Checkbox" class="usa-icon usa-icon--check_box_outline_blank" src="https://bn-ptzepiewjq-uc.a.run.app/static/img/usa-icons/check_box_outline_blank.svg">
      <span>Research &amp; Related Budget</span>
   </div>
</td>
```

This means we can:

- add flexbox to the internal div
- style the text if we need to

So that's what's happening in this commit.

| before | after |
|--------|-------|
|    "form" is vertically aligned with checkbox in the second last row     |   "form" is vertically aligned with "research" in the second last row    |
|   <img width="626" alt="Screenshot 2024-10-24 at 8 42 33 PM" src="https://github.com/user-attachments/assets/5de05ec2-12e5-4062-a661-c5697d70d853"> |    <img width="626" alt="Screenshot 2024-10-24 at 8 42 42 PM" src="https://github.com/user-attachments/assets/662b7193-7d06-4e69-9cda-2a61e6042e68">   |

They look the same but the underlying code changed a lot.