### PR TITLE
More HRSA updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Allow users to remove subagency and subagency 2
 - HRSA tagline is now HRSA blue!
 - Show subagency under the logo on the small image page, not subagency 2
+  - For HRSA, show the agency, not the subagency
 - Reimporting a NOFO that already has a cover image won't replace the image
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - For HRSA, show the agency, not the subagency
 - Reimporting a NOFO that already has a cover image won't replace the image
 - Change heading links on NOFO view page
+- "Other required forms" is a sublist heading in application table
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Show subagency under the logo on the small image page, not subagency 2
   - For HRSA, show the agency, not the subagency
 - Reimporting a NOFO that already has a cover image won't replace the image
+- Change heading links on NOFO view page
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Allow users to remove subagency and subagency 2
 - HRSA tagline is now HRSA blue!
 - Show subagency under the logo on the small image page, not subagency 2
 - Reimporting a NOFO that already has a cover image won't replace the image

--- a/bloom_nofos/nofos/forms.py
+++ b/bloom_nofos/nofos/forms.py
@@ -40,8 +40,12 @@ NofoGroupForm = create_nofo_form_class(["group"])
 NofoNumberForm = create_nofo_form_class(["number"])
 NofoOpDivForm = create_nofo_form_class(["opdiv"])
 NofoStatusForm = create_nofo_form_class(["status"])
-NofoSubagency2Form = create_nofo_form_class(["subagency2"])
-NofoSubagencyForm = create_nofo_form_class(["subagency"])
+NofoSubagencyForm = create_nofo_form_class(
+    ["subagency"], not_required_field_labels=["Subagency"]
+)
+NofoSubagency2Form = create_nofo_form_class(
+    ["subagency2"], not_required_field_labels=["Subagency 2"]
+)
 NofoTaglineForm = create_nofo_form_class(["tagline"])
 NofoThemeForm = create_nofo_form_class(["theme"])
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -87,7 +87,7 @@
             <p>{{ nofo.agency }}</p>
             <p>{% if nofo.subagency %}{{ nofo.subagency }}{% endif %}</p>
           {% else %}
-            <p>{% if nofo.subagency %}{{ nofo.subagency }}{% else %}{{ nofo.agency }}{% endif %}</p>
+            <p>{% if nofo.subagency and nofo_opdiv != 'hrsa' %}{{ nofo.subagency }}{% else %}{{ nofo.agency }}{% endif %}</p>
           {% endif %}
         </div>
       </div>

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -41,7 +41,7 @@
       <div class="usa-navbar">
         <div class="usa-logo" style="margin-top: 1rem;">
           <em class="usa-logo__text">
-            <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-nav-link">← Edit this NOFO</a>
+            <a href="{% url 'nofos:nofo_index' %}" class="usa-nav-link">NOFO Builder</a>
           </em>
           {% if user.is_authenticated %}
             <a class="inline-block usa-tag--link" href="{% url 'test_mode' %}">
@@ -57,7 +57,7 @@
       <nav aria-label="Primary navigation" class="usa-nav">
         <ul class="usa-nav__primary usa-accordion">
           <li class="usa-nav__primary-item usa-nav__primary-item__right-padding">
-            <a href="{% url 'nofos:nofo_index' %}" class="usa-nav-link">All NOFOs</a>
+            <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-nav-link">Edit this NOFO</a>
           </li>
         </ul>
         {% include "includes/print_button.html" %}

--- a/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
+++ b/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
@@ -55,6 +55,9 @@ def is_list_heading(td):
     if td.find("strong") and ":" in td.get_text():
         return True
 
+    if td.text.lower() == "other required forms":
+        return True
+
     return False
 
 


### PR DESCRIPTION
## Summary

This PR does 3 things:

1. Uses the `agency` not the `subagency` on the cover page for HRSA
2. Allow users to remove Subagency and Subagency 2
3.  Reverses the links on the NOFO view page

#### 1. Uses the `agency` not the `subagency` on the cover page for HRSA

This is something Betty asked us for: 

> Change the name under the HRSA logo from Division of Maternal and Child Health Workforce Development to “Maternal and Child Health Bureau”

| before | after |
|--------|-------|
|  <img width="194" alt="Screenshot 2024-10-25 at 1 07 40 PM" src="https://github.com/user-attachments/assets/603fc7b1-478f-4cd5-a8ce-4ba605107c7e">   |   <img width="194" alt="Screenshot 2024-10-25 at 1 06 54 PM" src="https://github.com/user-attachments/assets/770e2fbd-56ab-47b1-95fe-450b9fdf0edb">  |

#### 2. Allow users to remove Subagency and Subagency 2

If they were ever entered, we don't let users delete them. Ultimately, we don't have a strong reason for this, so let's user needs this.

#### 3.  Reverses the links on the NOFO view page

On the nofo view page, we didn't have the heading link pointing to "NOFO Builder", like it does on every other page. It was driving me nuts, so I fixed it.

### Why are we doing this?

User needs (client request)

### How to test this

- Look at the HRSA cover page
- Submit a blank string for Subagency or Subagency 2