### PR TITLE
Hrsa fixes 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - For HRSA, show the agency, not the subagency
 - Reimporting a NOFO that already has a cover image won't replace the image
 - Change heading links on NOFO view page
-- "Other required forms" is a sublist heading in application table
+- "Other required forms" and "attachments" are sublist headings in application table
 
 ### Fixed
 

--- a/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
+++ b/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
@@ -55,7 +55,7 @@ def is_list_heading(td):
     if td.find("strong") and ":" in td.get_text():
         return True
 
-    if td.text.lower() == "other required forms":
+    if td.text.lower() == "other required forms" or td.text.lower() == "attachments":
         return True
 
     return False


### PR DESCRIPTION
## Summary

This PR does 4 things:

1. Uses the `agency` not the `subagency` on the cover page for HRSA
2. "Other required forms" is a sublist heading in application checklist
3. Allow users to remove Subagency and Subagency 2
4.  Reverses the links on the NOFO view page

#### 1. Uses the `agency` not the `subagency` on the cover page for HRSA

This is something Betty asked us for: 

> Change the name under the HRSA logo from Division of Maternal and Child Health Workforce Development to “Maternal and Child Health Bureau”

| before | after |
|--------|-------|
|  <img width="194" alt="Screenshot 2024-10-25 at 1 07 40 PM" src="https://github.com/user-attachments/assets/603fc7b1-478f-4cd5-a8ce-4ba605107c7e">   |   <img width="194" alt="Screenshot 2024-10-25 at 1 06 54 PM" src="https://github.com/user-attachments/assets/770e2fbd-56ab-47b1-95fe-450b9fdf0edb">  |

#### 2. "Other required forms" is a sublist heading in application checklist

But normally sublists aren’t predictable, so we look for a 'sublist heading' type of cell. So if you have a link, or if it’s bolded and has a colon, it’s a subheading. 

But since this doesn't work for HRSA, we are hardcoding "Other required forms" and "attachments" as a sublist heading.

| before | after |
|--------|-------|
|  <img width="694" alt="Screenshot 2024-10-25 at 1 24 04 PM" src="https://github.com/user-attachments/assets/7b0124c5-419f-4898-9463-4c13d6f51216">   | <img width="694" alt="Screenshot 2024-10-25 at 1 23 44 PM" src="https://github.com/user-attachments/assets/becf9918-3818-4724-8950-270432b67f61">  |


#### 3. Allow users to remove Subagency and Subagency 2

If they were ever entered, we don't let users delete them. Ultimately, we don't have a strong reason for this, so let's user needs this.

#### 4.  Reverses the links on the NOFO view page

On the nofo view page, we didn't have the heading link pointing to "NOFO Builder", like it does on every other page. It was driving me nuts, so I fixed it.

### Why are we doing this?

User needs (client request)

### How to test this

- Look at the HRSA cover page
- Submit a blank string for Subagency or Subagency 2