### PR TITLE
Bump version to 1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.30.0] - 2023-10-28
+
+### Added
+
 - Convert 'Heading 7' styles from Word
 - Add cover image for CDC-RFA-DD-25-0157
 - Add cover image for CDC-RFA-DP-25-0024

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bloom-nofos"
-version = "1.29.0"
+version = "1.30.0"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
Nothing major in here, but we've added a lot of small changes, so let's up the version.

From the CHANGELOG:

```

- Convert 'Heading 7' styles from Word
- Add cover image for CDC-RFA-DD-25-0157
- Add cover image for CDC-RFA-DP-25-0024
- Add cover image for HRSA-25-068
- Add cover image for HRSA-25-025
- Add cover image for HRSA-25-027

- Allow users to remove subagency and subagency 2
- HRSA tagline is now HRSA blue!
- Show subagency under the logo on the small image page, not subagency 2
  - For HRSA, show the agency, not the subagency
- Reimporting a NOFO that already has a cover image won't replace the image
- Change heading links on NOFO view page
- "Other required forms" and "attachments" are sublist headings in application table

- Restructure HTML in the Application Checklists for better styling
  - Previously, I was using a CSS hack because I didn't have enough elements to style
- 'Criterion' tables are always small
- Find ranges for numbered sublists
  - Match for "8-15.", "8 - 15.", "8 through 15."
  - Remove the border under "Attachments"
- ids inserted using markdown attributes should not show up as 'broken links'
```