### PR TITLE
Remove stroke in CDC logo, add left padding to callout lists, manual CSS fixes for application table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 
 - Remove stroke on CDC logo svg
+- Add CSS class to add bullets to lists
 
 ### Fixed
 
 - More left padding on callout box lists that are NOT in the right hand column
+- More specific CSS selector for application table divs
 
 ## [1.30.0] - 2023-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- More left padding on callout box lists that are NOT in the right hand column
+
 ## [1.30.0] - 2023-10-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Remove stroke on CDC logo svg
+
 ### Fixed
 
 ## [1.30.0] - 2023-10-28

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -447,7 +447,7 @@ body.cms-white table td img.usa-icon--check_box_outline_blank {
   box-shadow: inset 0px 0px 5px 3px var(--color--table-blue);
 }
 
-.section--step-5-submit-your-application table tr td.usa-icon__td div {
+.section--step-5-submit-your-application table tr td.usa-icon__td > div {
   display: flex;
 }
 
@@ -495,6 +495,13 @@ img.usa-icon--check_box_outline_blank {
 td.usa-icon__td ul,
 td.usa-icon__td ol {
   list-style: none;
+}
+
+ul.disc,
+ol.disc,
+td.usa-icon__td ul.disc,
+td.usa-icon__td ol.disc {
+  list-style: disc;
 }
 
 td.usa-icon__td p + ul,

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -1006,7 +1006,13 @@ section.section .section--title-page::before {
   font-size: 10pt;
 }
 
-.callout-box .callout-box--contents ul {
+.callout-box .callout-box--contents ul,
+.callout-box .callout-box--contents ol {
+  padding-left: 24px;
+}
+
+.section--absolute--right-col .callout-box .callout-box--contents ul,
+.section--absolute--right-col .callout-box .callout-box--contents ol {
   padding-left: 14px;
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-blue.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-blue.css
@@ -89,7 +89,6 @@ h1 {
 }
 
 .nofo--cover-page--medium .nofo--cover-page--header--logo svg .cls-6 {
-  stroke: var(--color--white);
   fill: var(--color--cdc-blue);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-white.css
@@ -17,7 +17,6 @@
 }
 
 .nofo--cover-page--header--logo svg .cls-6 {
-  stroke: var(--color--white);
   fill: var(--color--cdc-blue);
 }
 
@@ -40,7 +39,6 @@
 }
 
 .nofo--cover-page--hero .nofo--cover-page--header--logo svg .cls-6 {
-  stroke: var(--color--cdc-blue);
   fill: var(--color--white);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc.css
@@ -93,7 +93,6 @@ h6 {
 
 .nofo--cover-page--header--logo svg .cls-6 {
   fill: var(--color--white);
-  stroke: var(--color--cdc-blue);
 }
 
 .portrait .nofo--cover-page--medium .nofo--cover-page--title {


### PR DESCRIPTION
## Summary 

This PR does 3 things:

1. removes stroke styling for the CDC logo. 
2. adds some left padding to callout box lists
3. small CSS changes that let us manually fix application table checkbox lists

#### 1. Remove stroke styling for the CDC logo.

I had added the stroke styling to fix what looked like a font rendering issue. But actually it was overcorrecting for a CSS rule that I didn't need, so now all the stroke rules are gone.

##### CDC default (blue)

| before | after |
|--------|-------|
|   <img width="436" alt="Screenshot 2024-10-28 at 4 53 19 PM" src="https://github.com/user-attachments/assets/fda0b9bb-5b64-4116-828f-e67598ccb6dc">    |    <img width="436" alt="Screenshot 2024-10-28 at 4 53 28 PM" src="https://github.com/user-attachments/assets/a225ff36-0ed2-4319-9e51-c83ccb02e8bb">   |

##### CDC light (white)

| before | after |
|--------|-------|
| <img width="436" alt="Screenshot 2024-10-28 at 4 54 02 PM" src="https://github.com/user-attachments/assets/b275521f-5cbf-403a-b63b-46aeaa53d438">    |    <img width="436" alt="Screenshot 2024-10-28 at 4 53 54 PM" src="https://github.com/user-attachments/assets/a2e2414b-43de-41a4-8572-508996e994d7">     |

#### 2. adds left padding to callout box lists

I had previously removed the left padding on lists in callout boxes because we were trying to save space for those ones in the right column at the beginning of the NOFO. But for normal callout boxes, we don't need to do that.

| before | after |
|--------|-------|
|     <img width="611" alt="Screenshot 2024-10-28 at 6 19 00 PM" src="https://github.com/user-attachments/assets/88fcd69e-940e-46a1-b392-951284dd742c">   |    <img width="611" alt="Screenshot 2024-10-28 at 6 18 26 PM" src="https://github.com/user-attachments/assets/4a3b201c-383b-4d2c-bcba-3e49152376a4">   |

#### 3. Small CSS changes that allow manual fixes

This is kind of a weird one but it lets us to manually fix a tricky edge case we are running into with the application checklist table.

### Why are we doing this?

Make the CDC NOFO look way better.

### How to test this

It will just show up on CDC nofos.