### PR TITLE
Application list checkbox cells that are not sublists have bottom borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - More left padding on callout box lists that are NOT in the right hand column
 - More specific CSS selector for application table divs
+- Application list checkbox cells that are not sublists have bottom borders
 
 ## [1.30.0] - 2023-10-28
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
@@ -206,6 +206,18 @@ table td {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--light-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acl-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acl-white.css
@@ -200,6 +200,18 @@ table td {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--light-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-aspr-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-aspr-white.css
@@ -181,6 +181,18 @@ table td {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--light-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-blue.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-blue.css
@@ -229,6 +229,18 @@ table td a {
   border-right: none;
 }
 
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom-color: white;
+}
+
 .section--step-5-submit-your-application table tr td.usa-icon__td--list-heading,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dop.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dop.css
@@ -280,6 +280,18 @@ table td {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--light-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
@@ -268,6 +268,18 @@ table td a {
   border-right: none;
 }
 
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom-color: white;
+}
+
 .section--step-5-submit-your-application table tr td.usa-icon__td--sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-white.css
@@ -189,6 +189,18 @@ table td {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--light-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cms-blue.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cms-blue.css
@@ -242,6 +242,18 @@ table td {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--light-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cms-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cms-white.css
@@ -153,6 +153,18 @@ table td a {
   border-bottom-color: var(--color--white);
 }
 
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom-color: var(--color--white);
+}
+
 .section--step-5-submit-your-application table tr td.usa-icon__td--list-heading,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-blue.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-blue.css
@@ -208,6 +208,18 @@ table td a {
   border-bottom-color: var(--color--white);
 }
 
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom-color: var(--color--white);
+}
+
 .section--step-5-submit-your-application table tr td.usa-icon__td--list-heading,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
@@ -168,6 +168,18 @@ table td {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--light-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs.css
@@ -136,6 +136,18 @@ div[role="heading"] {
 .section--step-5-submit-your-application
   table
   tr
+  td.usa-icon__td:not(.usa-icon__td--sublist),
+.section--step-5-submit-your-application
+  table
+  tr
+  td.usa-icon__td:not(.usa-icon__td--sublist)
+  ~ td {
+  border-bottom: 2px solid var(--color--ihs-grey);
+}
+
+.section--step-5-submit-your-application
+  table
+  tr
   td.usa-icon__td--before-sublist,
 .section--step-5-submit-your-application
   table


### PR DESCRIPTION
## Summary

This PR adds a bottom border to application checklist table cells that:
- have a checkbox
- are not sublists

Hopefully this styling change is the final one!

| before | after |
|--------|-------|
|   <img width="618" alt="Screenshot 2024-10-29 at 12 17 53 PM" src="https://github.com/user-attachments/assets/b03bf9ae-68ad-4091-9000-1b0b19882c06">    |  <img width="618" alt="Screenshot 2024-10-29 at 12 17 45 PM" src="https://github.com/user-attachments/assets/58a17bc5-5ba6-42fb-8a1c-bb76f9babf28">   |


### Why are we doing this?

This is a final fix to the application table before shipping CDC 0157.

### How to test it

Try out CDC 0157's application table before and after.