### PR TITLE
Light blue table rows + fix asterisks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Convert literal asterisks to `&ast;` inside of HTML lists in table cells
 - More left padding on callout box lists that are NOT in the right hand column
 - More specific CSS selector for application table divs
 - Application list checkbox cells that are not sublists have bottom borders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - More left padding on callout box lists that are NOT in the right hand column
 - More specific CSS selector for application table divs
 - Application list checkbox cells that are not sublists have bottom borders
+- "Adam 👀" status needs yellow highlight background
 
 ## [1.30.0] - 2023-10-28
 

--- a/bloom_nofos/bloom_nofos/static/shared.css
+++ b/bloom_nofos/bloom_nofos/static/shared.css
@@ -4,13 +4,13 @@
   --color--white: #ffffff;
   --color--table-grey: #edf1f3;
   --color--table-blue: #f2f6fc;
+  --color--light-table-blue: #e8f5ff;
   --color--light-grey: #dde2e8;
   --color--med-grey: #5c5c5c;
   --color--dark-blue: #00345e;
   --color--med-blue: #336a90;
   --color--cdc-blue: #0057b7;
   --color--hhs-blue: #005ea2;
-  --color--light-blue: #bdd9ed;
   --color--pale-blue: #e8f0f3;
   --color--med-brown: #c0b0a2;
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -148,8 +148,8 @@ details > summary > span:hover {
   width: 1%;
 }
 
-.nofo_index table tr.ready_for_adam th,
-.nofo_index table tr.ready_for_adam td {
+.nofo_index table tr.ready-for-adam th,
+.nofo_index table tr.ready-for-adam td {
   background: #f2e4d4;
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -357,8 +357,10 @@ table.table--with-caption caption {
   break-inside: avoid-column;
 }
 
-table tr.table-row--light-blue-bg td {
-  background-color: #c5d7f1;
+table tr.light-blue-bg td,
+table tr td.light-blue-bg,
+table tr td.light-blue-bg ~ td {
+  background-color: var(--color--light-table-blue);
 }
 
 table th,

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -63,7 +63,7 @@ class TablesAndStuffInTablesConverter(MarkdownConverter):
         for parent in el.parents:
             if parent.name == "td":
                 self._remove_classes_recursive(el)
-                return str(el)
+                return str(el).replace("*", "&ast;")
 
         # save the footnote list as HTML so that the ids aren't lost
         first_li = el.find("li")
@@ -80,7 +80,7 @@ class TablesAndStuffInTablesConverter(MarkdownConverter):
         for parent in el.parents:
             if parent.name == "td":
                 self._remove_classes_recursive(el)
-                return str(el)
+                return str(el).replace("*", "&ast;")
 
         return super().convert_ul(el, text, convert_as_inline)
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_index.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_index.html
@@ -57,7 +57,7 @@
 			</thead>
 			<tbody>
 				{% for nofo in nofo_list %}
-					<tr {% if nofo.status == 'ready_for_adam' %}class="ready_for_adam"{% endif %}>
+					<tr {% if nofo.status == 'ready-for-adam' %}class="ready-for-adam"{% endif %}>
 						<th scope="row"><a href="{% url 'nofos:nofo_edit' nofo.id %}">{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}</a></th>
 						<td>{% if nofo.number %}{{ nofo.number }}{% else %}—{% endif %}</td>
 						{% if user.group == 'bloom' %}

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -268,6 +268,52 @@ class TablesAndStuffInTablesConverterOLSTest(TestCase):
         md_body = md(html)
         self.assertEqual(md_body.strip(), pretty_html)
 
+    def test_ol_start_one(self):
+        html = '<ol start="1"><li>Item 1</li><li>Item 2</li></ol>'
+        expected_markdown = "1. Item 1\n2. Item 2"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_ol_asterisk_list(self):
+        html = '<ol start="2"><li>Item 1*</li><li>Item 2</li></ol>'
+        expected_markdown = '<ol start="2"><li>Item 1*</li><li>Item 2</li></ol>'
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_ol_asterisk_table(self):
+        html = "<table><tr><th>Header 1</th><th>Header 2</th></tr><tr><td><ol><li>Item 1*</li><li>Item 2</li></ol></td><td>Cell 2</td></tr></table>"
+        expected_markdown = "| Header 1 | Header 2 |\n| --- | --- |\n| <ol><li>Item 1&ast;</li><li>Item 2</li></ol> | Cell 2 |"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_ol_asterisk_table_colspan(self):
+        html = '<table><tr><th colspan="2">Header 1</th></tr><tr><td><ol><li>Item 1*</li><li>Item 2</li></ol></td><td>Cell 2</td></tr></table>'
+        expected_markdown = '<table>\n <tr>\n  <th colspan="2">\n   Header 1\n  </th>\n </tr>\n <tr>\n  <td>\n   <ol>\n    <li>\n     Item 1*\n    </li>\n    <li>\n     Item 2\n    </li>\n   </ol>\n  </td>\n  <td>\n   Cell 2\n  </td>\n </tr>\n</table>'
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+
+class TablesAndStuffInTablesConverterULSTest(TestCase):
+    maxDiff = None
+
+    def test_ul_asterisk_list(self):
+        html = "<ul><li>Item 1*</li><li>Item 2</li></ul>"
+        expected_markdown = "* Item 1\\*\n* Item 2"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_ul_asterisk_table(self):
+        html = "<table><tr><th>Header 1</th><th>Header 2</th></tr><tr><td><ul><li>Item 1*</li><li>Item 2</li></ul></td><td>Cell 2</td></tr></table>"
+        expected_markdown = "| Header 1 | Header 2 |\n| --- | --- |\n| <ul><li>Item 1&ast;</li><li>Item 2</li></ul> | Cell 2 |"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_ul_asterisk_table_colspan(self):
+        html = '<table><tr><th colspan="2">Header 1</th></tr><tr><td><ul><li>Item 1*</li><li>Item 2</li></ul></td><td>Cell 2</td></tr></table>'
+        expected_markdown = '<table>\n <tr>\n  <th colspan="2">\n   Header 1\n  </th>\n </tr>\n <tr>\n  <td>\n   <ul>\n    <li>\n     Item 1*\n    </li>\n    <li>\n     Item 2\n    </li>\n   </ul>\n  </td>\n  <td>\n   Cell 2\n  </td>\n </tr>\n</table>'
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
 
 class TablesAndStuffInTablesConverterASTest(TestCase):
     maxDiff = None


### PR DESCRIPTION
## Summary

This PR does 3 things:

1. Adds in a new background colour for table cells
2. Fixes CSS for the "Adam 👀" status (self-explanatory)
3. Fixes the asterisk problem we are seeing in table cells

#### 1. Adds new background colour for table cells
This PR adds in a new background colour for tables so that we can have secondary header-like rows. 

| adding a new background colour |
|-------|
|    <img width="606" alt="Screenshot 2024-10-30 at 11 44 28 AM" src="https://github.com/user-attachments/assets/22dac2a0-6755-43d4-9219-8b4b5f787332">   |
| Adds the new light blue colour |

#### 3. Fixes the asterisk problem we are seeing in table cells

Sometimes we see asterisks cause text to be italicized inside of tables, when what we want is a literal asterisk. 

Here's an example.

| bad | good |
|--------|-------|
| italics are NOT intentional | literal asterisks showing up (*) |
| <img width="627" alt="Screenshot 2024-10-30 at 5 21 26 PM" src="https://github.com/user-attachments/assets/713c383e-2050-4f7d-8b79-e963446db95c">  |   <img width="627" alt="Screenshot 2024-10-30 at 5 21 18 PM" src="https://github.com/user-attachments/assets/c51ee894-e58f-4a66-bb32-b6a0edc8dd73"> |

What I realized after monkeying around with them was:

Sometimes we have regular asterisks and it's no problem:

```
* this is a list item
* this is a list item with an asterisk*
* this is a list item also
```

That works.

Other times, we have markdown tables with an asterisk.

```
| before | after |
|--------|-------|
| before* | after* |
```

That works.

Other times, we have HTML tables with HTML inside of the cells.

```
<table><tr><th>Header 1</th><th>Header 2</th></tr><tr><td><ul><li>Item 1*</li><li>Item 2</li></ul></td><td>Cell 2</td></tr></table>
```

That works.

FINALLY, we can have markdown tables with HTML in the table cells.

```
| before | after |
|--------|-------|
| <ul><li>Item 1*</li><li>Item 2</li></ul> | Cell 2 |
```

THAT is the one that causes problems for us.

So, if we intervene in the markdown conversion, specifically for lists in table cells, then we can convert only those astersiks into HTML entities.

The result is that we don't have these broad rulesets that cause weird
side effects, and everything will be solved from now on.