### PR TITLE
Admin external link checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- Add new view to verify individual external URL responses
 - Add button to copy list of broken links on nofo_edit page
 - Add new coaches and designers
   - Remove a couple of retired coaches

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -125,6 +125,17 @@ details > summary > span:hover {
   text-decoration: none;
 }
 
+/* Link check page */
+
+.pre--code-box {
+  background-color: #f0f0f0;
+  box-shadow: inset 1px 1px 15px 5px #a9aeb1;
+  border-radius: 8px;
+  border: 2px solid #71767a;
+  padding: 20px;
+  overflow-y: auto;
+}
+
 /* List page */
 
 .nofo_index .nofo_index--filter a {

--- a/bloom_nofos/bloom_nofos/templates/includes/form_macro.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/form_macro.html
@@ -1,7 +1,7 @@
 {% load input_type %}
 
 {% for field in form %}
-  {% if field|input_type == 'TextInput' or field|input_type == 'Textarea' or field|input_type == 'PasswordInput' or field|input_type == 'EmailInput' %}
+  {% if field|input_type in 'TextInput Textarea PasswordInput EmailInput URLInput' %}
     {% with id=field.name label=field.label value=field.value hint=field.help_text hint2=hint2 hint2for=hint2for error=field.errors.0 disabled=field.field.widget.attrs.is_disabled input_type=field|input_type %}
       {% include "includes/_text_input.html" with id=id label=label hint=hint hint2=hint2 hint2for=hint2for value=value error=error disabled=disabled input_type=input_type only %}
     {% endwith %}

--- a/bloom_nofos/nofos/forms.py
+++ b/bloom_nofos/nofos/forms.py
@@ -168,6 +168,11 @@ class SubsectionCreateForm(forms.ModelForm):
             )
 
 
+# Simple form for URL input
+class CheckNOFOLinkSingleForm(forms.Form):
+    url = forms.URLField(label="Check this URL", max_length=512, required=True)
+
+
 class InsertOrderSpaceForm(forms.Form):
     section = forms.ModelChoiceField(
         queryset=Section.objects.all(), required=True, label="Section", disabled=False

--- a/bloom_nofos/nofos/mixins.py
+++ b/bloom_nofos/nofos/mixins.py
@@ -29,3 +29,11 @@ class GroupAccessObjectMixin:
 
         # Continue with normal processing, which will include deletion
         return super().dispatch(request, *args, **kwargs)
+
+
+class SuperuserRequiredMixin:
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_superuser:
+            raise PermissionDenied("You don’t have permission to view this page.")
+
+        return super().dispatch(request, *args, **kwargs)

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -738,6 +738,7 @@ def find_external_link(url):
             - 'title' (str): The title of the HTML page, or 'No Title Found' if no title is present.
             - 'content' (str): The escaped HTML content of the page.
             or
+            - 'url' (str): The original URL that was fetched.
             - 'error' (str): If an exception occurs, the error message is returned instead of other fields.
 
     This function sends a GET request to the provided URL, extracts and returns key metadata such as the page title,
@@ -778,7 +779,7 @@ def find_external_link(url):
         if not "test" in sys.argv:
             logger.warning("Request failed for URL: {} - {}".format(url, error_string))
 
-        return {"error": error_string}
+        return {"url": url, "error": error_string}
 
 
 def find_external_links(nofo, with_status=False):

--- a/bloom_nofos/nofos/templates/nofos/nofo_check_link_single.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_check_link_single.html
@@ -22,7 +22,7 @@
     <br>
     <hr>
     <h2 class="font-heading-lg">HTTP error</h2>
-    <pre>{{ error }}</pre>
+    <code>{{ error }}</code>
   {% endif %}
 
   {% if url %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_check_link_single.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_check_link_single.html
@@ -1,0 +1,69 @@
+{% extends 'base.html' %}
+
+{% block title %}
+  Check a link TODO add link if link
+{% endblock %}
+
+{% block body_class %}nofo_link{% endblock %}
+
+{% block content %}
+  {% url 'nofos:nofo_edit' nofo.id as back_href %}
+  {% include "includes/page_heading.html" with title="Check a link" back_text="Back to all NOFOs" back_href=back_href only %}
+
+  <form id="nofo-check-link-single--form" method="post">
+    {% csrf_token %}
+
+    {% include "includes/form_macro.html" %}
+
+    <button class="usa-button margin-top-3" type="submit">Check link</button>
+  </form>
+
+  {% if error %}
+    <br>
+    <hr>
+    <h2 class="font-heading-lg">HTTP error</h2>
+    <pre>{{ error }}</pre>
+  {% endif %}
+
+  {% if url %}
+    <br>
+    <hr>
+    <h2 class="font-heading-lg">HTTP response</h2>
+    <table class="usa-table usa-table--font-size-1">
+      <thead class="usa-sr-only">
+        <tr>
+          <th scope="col">Key</th>
+          <th scope="col">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><strong>URL</strong></th>
+          <td>
+            {{ url }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row"><strong>Title</strong></th>
+          <td>
+            {{ title }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row"><strong>Status code</strong></th>
+          <td>
+            {{ status_code }} <span aria-hidden="true">{% if status_code < 300 %}🟢{% elif status_code < 400 %}🔵{% elif status_code < 500 %}⛔️{% elif status_code < 600 %}🟠{% endif %}</span>
+          </td>
+        </tr>
+        
+      </tbody>
+    </table>
+
+    <details>
+      <summary><span class="text-bold font-sans-md">Page content</span></summary>
+      <div>
+        <pre class="pre--code-box">{{ content }}</pre>
+      </div>
+    </details>
+  {% endif %}
+{% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_check_link_single.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_check_link_single.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block title %}
-  Check a link TODO add link if link
+  Check a link: {{ url }}
 {% endblock %}
 
 {% block body_class %}nofo_link{% endblock %}
@@ -25,7 +25,7 @@
     <code>{{ error }}</code>
   {% endif %}
 
-  {% if url %}
+  {% if content %}
     <br>
     <hr>
     <h2 class="font-heading-lg">HTTP response</h2>

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -125,6 +125,11 @@ urlpatterns = [
         name="nofo_check_links",
     ),
     path(
+        "check-link",
+        views.CheckNOFOLinkSingleView.as_view(),
+        name="nofo_check_link_single",
+    ),
+    path(
         "<int:nofo_id>/export_nofo_links",
         views.export_nofo_links,
         name="export_nofo_links",


### PR DESCRIPTION
## Summary

This PR adds an external link checker for superadmin users. 

Sometimes when we use the external link checker, we see that some URL statuses fail even though it is possible to visit them in the browser. When this happens, it is generally not obvious what the issue is.

When I've investigated this in the past, I have been adding code manually to print the entire response and/or save to a file, which has worked but is not a good way to do things. This PR creates an actual page for us to do this in a nicer way, available only to superadmins. I don't expect we will need to use this very often but it is also pretty lightweight and will save me some time.

| page with successful URL | page with bad URL  |
|--------|--------|
|   Shows title, status code, and response if needed.     |   Shows the Error we are getting from requests.  No status code because this is an exception.   |
| <img width="1412" alt="Screenshot 2024-11-05 at 10 16 06 AM" src="https://github.com/user-attachments/assets/a771f397-8026-4658-8821-baf54c66f385"> | <img width="1412" alt="Screenshot 2024-11-05 at 10 16 20 AM" src="https://github.com/user-attachments/assets/6355407f-b677-4cd8-8de1-aafd348b40db"> |




