### PR TITLE
H7s create subsections

### DIFF
--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -437,6 +437,16 @@ def get_subsections_from_sections(sections, top_heading_level="h1"):
 
         return newTags[tag_name]
 
+    def is_h7(tag):
+        if (
+            tag.name == "div"
+            and tag.get("role") == "heading"
+            and tag.has_attr("aria-level")
+        ):
+            return True
+
+        return False
+
     def extract_first_header(td):
         for tag_name in heading_tags:
             header_element = td.find(tag_name)
@@ -447,14 +457,18 @@ def get_subsections_from_sections(sections, top_heading_level="h1"):
 
     def get_subsection_dict(heading_tag, order, is_callout_box, body=None):
         if heading_tag:
+            tag_name = (
+                _demote_tag(heading_tag.name)
+                if if_demote_headings
+                else heading_tag.name
+            )
+            if tag_name == "div" and is_h7(heading_tag):
+                tag_name = "h7"
+
             return {
                 "name": clean_string(heading_tag.text),
                 "order": order,
-                "tag": (
-                    _demote_tag(heading_tag.name)
-                    if if_demote_headings
-                    else heading_tag.name
-                ),
+                "tag": tag_name,
                 "html_id": heading_tag.get("id", ""),
                 "is_callout_box": is_callout_box,
                 "body": body or [],
@@ -499,7 +513,7 @@ def get_subsections_from_sections(sections, top_heading_level="h1"):
                 )
                 section["subsections"].append(callout_box_subsection)
 
-            elif tag.name in heading_tags:
+            elif tag.name in heading_tags or is_h7(tag):
                 # create new subsection
                 heading_subsection = get_subsection_dict(
                     heading_tag=tag,

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -1085,6 +1085,30 @@ class HTMLSubsectionTestsH1(TestCase):
         subsection = sections[0].get("subsections")[0]
         self.assertEqual(subsection.get("tag"), "h7")
 
+    def test_get_subsections_from_soup_section_heading_true_h6(self):
+        # starts with h2, so the h6 does not get demoted
+        soup = BeautifulSoup(
+            '<h2>Section 1</h2><h6 id="subsection-1">Subsection 1</h6><p>Section 1 body</p>',
+            "html.parser",
+        )
+        sections = get_subsections_from_sections(
+            get_sections_from_soup(soup, top_heading_level="h2"), top_heading_level="h2"
+        )
+        subsection = sections[0].get("subsections")[0]
+        self.assertEqual(subsection.get("tag"), "h6")
+
+    def test_get_subsections_from_soup_section_heading_h7(self):
+        # starts with h2, so the h7 does not get demoted
+        soup = BeautifulSoup(
+            '<h2>Section 1</h2><div aria-level="7" role="heading">Subsection 1</div><p>Section 1 body</p>',
+            "html.parser",
+        )
+        sections = get_subsections_from_sections(
+            get_sections_from_soup(soup, top_heading_level="h2"), top_heading_level="h2"
+        )
+        subsection = sections[0].get("subsections")[0]
+        self.assertEqual(subsection.get("tag"), "h7")
+
     def test_get_subsections_from_soup_with_whitespace(self):
         soup = BeautifulSoup(
             "<h1><span>Section 1 </span></h1><h2><span>Subsection 1 </span> </h2><p>Section 1 body</p>",


### PR DESCRIPTION
## Summary

This PR makes it so that when we see H7 headings come in (which we shim as `<div>` elements), that they are recognized as headings so that they create subsections as we expect.

Previously, these h7s were getting imported correctly, but they would just be part of the body of a section, they wouldn't actually be separated off as subsections like the other headings would.