### PR TITLE
Stop bolding multi-line table headers by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Un-bold paragraphs in table headings
+  - Means that multi-line table headings are unbolded by default
 - Remove stroke on CDC logo svg
 - Add CSS class to add bullets to lists
 - "Adam 👀" is now "Ready for QA"
@@ -24,6 +26,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- H7 elements are properly recognized as subsections
 - Add migration to fix previous "PRINT..." audit events that were not JSON formatted
 - Convert literal asterisks to `&ast;` inside of HTML lists in table cells
 - More left padding on callout box lists that are NOT in the right hand column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.31.0] - 2023-11-08
+
+### Added
+
 - Add new view to verify individual external URL responses
 - Add button to copy list of broken links on nofo_edit page
 - Add new coaches and designers

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -491,6 +491,11 @@ details > summary > span:hover {
   word-break: break-word;
 }
 
+.nofo-edit-table--subsection--body table thead th p,
+.nofo-edit-table--subsection--body table tbody tr:first-of-type th p {
+  font-weight: 400;
+}
+
 .nofo_edit .nofo-edit-table--subsection--body a.nofo_edit--broken-link,
 .nofo_edit
   .nofo-edit-table--subsection--name.nofo_edit--heading-error

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -409,6 +409,11 @@ table tbody tr:first-of-type th {
   text-align: left;
 }
 
+table thead th p,
+table tbody tr:first-of-type th p {
+  font-weight: 400;
+}
+
 table thead th > p,
 table tbody tr:first-of-type th > p {
   margin-top: 0;

--- a/bloom_nofos/bloom_nofos/templates/base_barebones.html
+++ b/bloom_nofos/bloom_nofos/templates/base_barebones.html
@@ -7,7 +7,6 @@
 
     {% project_version as VERSION %}
     <meta name="version" content="{{ VERSION }}" >
-    <!-- 2024-11-08T14:52:31+00:00 fix-fix -->
 
     <title>{% block title %}It’s NOFOs, baby{% endblock %}</title>
     {% block metadata %}{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bloom-nofos"
-version = "1.30.0"
+version = "1.31.0"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

It used to be that we would just bold all table headings. But sometimes we have more complex table headings with several lines, typically the first line would be bold and then the ones after wouldn't be. 

Here's an example:

![Screenshot 2024-11-08 at 6 29 09 PM](https://github.com/user-attachments/assets/d2f8cc63-6f3e-492c-9e9f-f48e25ec5197)

The update in this PR is to stop bolding paragraph tags inside of table headings. Mechanically, how the app works is that we leave the content of table headings in paragraph tags if there are hard returns in there. 

Here are some examples:

```html
<th>Heading 1</th> <!-- bold -->
```

```html
<th>
  <p>Heading 1:</p>  <!-- not bold -->
  <p>This is the first heading</p> <!-- not bold -->
</th>
```

```html
<th>
   Heading 1:  <!-- bold -->
  <p><strong>Important:</strong> This is the first heading</p> <!-- bold, then not bold -->
</th>
```