### PR TITLE
List H7s in an alert box + show all heading levels in edit_nofo page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- New alert box for NOFOs that have H7 headings
+  - H7 headings need to be manually fixed in the PDF
+- New column for the heading level in the nofo_edit view
+  - Slight change to subsection_edit page to match new heading tag styling
+
 ### Changed
 
 ### Fixed

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -8,6 +8,7 @@
   --color--usa-error-message: #b50909;
   --color--usa-error-bg-light: #f3e1e4;
   --color--usa-error-bg-dark: #8b0a03;
+  --color--usa-error-bg-darker: #775540;
 }
 
 html {
@@ -320,6 +321,18 @@ details > summary > span:hover {
   margin-right: 4rem; /* match the padding on usa-alert__body */
 }
 
+.nofo_edit .usa-site-alert--broken-links a,
+.nofo_edit .usa-site-alert--heading-errors a,
+.nofo_edit .usa-site-alert--h7-headers a {
+  color: var(--color--white);
+}
+
+.nofo_edit .usa-site-alert--broken-links li,
+.nofo_edit .usa-site-alert--heading-errors li,
+.nofo_edit .usa-site-alert--h7-headers li {
+  margin-bottom: 0.75em;
+}
+
 .nofo_edit .usa-site-alert--heading-errors .usa-alert {
   border-left-color: var(--color--usa-error-bg-dark);
 }
@@ -328,14 +341,12 @@ details > summary > span:hover {
   background-color: var(--color--usa-error-bg-dark);
 }
 
-.nofo_edit .usa-site-alert--broken-links a,
-.nofo_edit .usa-site-alert--heading-errors a {
-  color: var(--color--white);
+.nofo_edit .usa-site-alert--h7-headers .usa-alert {
+  border-left-color: var(--color--usa-error-bg-darker);
 }
 
-.nofo_edit .usa-site-alert--broken-links li,
-.nofo_edit .usa-site-alert--heading-errors li {
-  margin-bottom: 0.75em;
+.nofo_edit .usa-site-alert--h7-headers .usa-alert__body {
+  background-color: var(--color--usa-error-bg-darker);
 }
 
 .nofo_edit caption,

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -45,6 +45,10 @@ footer .usa-footer__primary-link:visited {
   color: var(--color--text-default);
 }
 
+.small-caps {
+  font-variant: small-caps;
+}
+
 /* Make sure header is evenly spaced */
 @media (min-width: 64em) {
   .usa-logo {
@@ -542,6 +546,10 @@ details > summary > span:hover {
 }
 
 .nofo_edit main table.table--section .nofo-edit-table--subsection--name,
+.nofo_edit
+  main
+  table.table--section
+  .nofo-edit-table--subsection--heading-level,
 .nofo_edit main table.table--section .nofo-edit-table--subsection--copy-button,
 .nofo_edit main table.table--section .nofo-edit-table--subsection--callout-box,
 .nofo_edit main table.table--section .nofo-edit-table--subsection--manage {
@@ -551,6 +559,22 @@ details > summary > span:hover {
 .nofo_edit main table.table--section .nofo-edit-table--subsection--copy-button {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
+}
+
+.nofo_edit
+  main
+  table.table--section
+  .nofo-edit-table--subsection--heading-level,
+.nofo_edit main table.table--section .nofo-edit-table--subsection--callout-box {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.nofo_edit
+  main
+  table.table--section
+  .nofo-edit-table--subsection--heading-level {
+  color: #71767a;
 }
 
 .nofo_edit main table.table--section .floating {

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -3,6 +3,7 @@
 
 :root {
   --color--text-default: #1b1b1b;
+  --color--text-grey: #71767a;
   --color--usa-link: #005ea2;
   --color--usa-link-visited: #54278f;
   --color--usa-error-message: #b50909;
@@ -136,7 +137,7 @@ details > summary > span:hover {
   background-color: #f0f0f0;
   box-shadow: inset 1px 1px 15px 5px #a9aeb1;
   border-radius: 8px;
-  border: 2px solid #71767a;
+  border: 2px solid var(--color--text-grey);
   padding: 20px;
   overflow-y: auto;
 }
@@ -574,7 +575,7 @@ details > summary > span:hover {
   main
   table.table--section
   .nofo-edit-table--subsection--heading-level {
-  color: #71767a;
+  color: var(--color--text-grey);
 }
 
 .nofo_edit main table.table--section .floating {
@@ -739,12 +740,20 @@ main .back-link a::before,
   margin-right: 0;
 }
 
+.subsection_edit #name--hint-1 {
+  font-variant: small-caps;
+}
+
+.subsection_edit #name--hint-1 span {
+  font-variant: none;
+}
+
 .subsection_edit .hint--subsection-id {
-  color: #6c7073;
+  color: var(--color--text-grey);
 }
 
 .subsection_edit .hint--subsection-id:hover {
-  color: #1b1b1b;
+  color: var(--color--text-default);
 }
 
 .subsection_edit .main-martor,

--- a/bloom_nofos/bloom_nofos/templates/includes/_text_input.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/_text_input.html
@@ -1,7 +1,7 @@
 <label class="usa-label" for="{{ id }}">{{ label }}</label>
 {% if hint %}
 <div class="usa-hint" id="{{ id }}--hint-1">
-  {{ hint }}
+  {% if hint_prefix %}<span class="hint-prefix">{{ hint_prefix }}</span>{% endif %} {{ hint }}
 </div>
 {% endif %}
 {% if error %}

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -917,6 +917,30 @@ def find_broken_links(nofo):
     return broken_links
 
 
+def find_h7_headers(nofo):
+    """
+    Identifies and returns a list of H7 headings
+
+    Note that it doesn't work if H7s are created within body text, they have to be subsections.
+    """
+
+    h7_headers = []
+
+    for section in nofo.sections.all().order_by("order"):
+        for subsection in section.subsections.all().order_by("order"):
+            if subsection.tag == "h7":
+                h7_headers.append(
+                    {
+                        "section": section,
+                        "subsection": subsection,
+                        "name": subsection.name,
+                        "html_id": subsection.html_id,
+                    }
+                )
+
+    return h7_headers
+
+
 ###########################################################
 #################### SUGGEST VAR FUNCS ####################
 ###########################################################

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -919,9 +919,22 @@ def find_broken_links(nofo):
 
 def find_h7_headers(nofo):
     """
-    Identifies and returns a list of H7 headings
+    Identifies and returns a list of H7 subsections from a given NOFO.
 
-    Note that it doesn't work if H7s are created within body text, they have to be subsections.
+    This function iterates through all sections and subsections of a NOFO object,
+    identifying subsections tagged as "h7".
+
+    Note:
+    - H7 tags must be directly defined as subsections. H7s created within
+      the body text of a subsection are not identified.
+
+    Returns:
+        list: A list of dictionaries, each containing details of subsections
+              tagged as "h7". Each dictionary includes the following keys:
+                - "section": The parent section object of the H7 subsection.
+                - "subsection": The subsection object tagged as "h7".
+                - "name": The name of the H7 subsection.
+                - "html_id": The HTML ID associated with the H7 subsection.
     """
 
     h7_headers = []

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -166,14 +166,14 @@ Edit “{{ nofo|nofo_name }}”
 <section class="usa-site-alert usa-site-alert--emergency usa-site-alert--h7-headers" aria-label="Warning: {{ h7_headers|length }} H7 headings in this NOFO.">
   <div class="usa-alert">
     <div class="usa-alert__body">
-      <h3 class="usa-alert__heading">Warning: This document contains H7 headings</h3>
+      <h3 class="usa-alert__heading">Warning: This document contains <span class="small-caps">H7</span> headings</h3>
       <div>
         <details>
           <summary>
             {% if h7_headers|length == 1 %}
-            <span>There is 1 H7 heading in this NOFO</span>
+            <span>There is 1 <span class="small-caps">H7</span> heading in this NOFO</span>
             {% else %}
-            <span>There are {{ h7_headers|length }} H7 headings in this NOFO</span>
+            <span>There are {{ h7_headers|length }} <span class="small-caps">H7</span> headings in this NOFO</span>
             {% endif %}
           </summary>
           <div>
@@ -395,6 +395,7 @@ Edit “{{ nofo|nofo_name }}”
     <tr>
       <th scope="col">Heading</th>
       <th scope="col">Heading link</th>
+      <th scope="col">Heading level</th>
       <th scope="col">Is callout box</th>
       <th scope="col">Content</th>
       <th scope="col">Manage</th>
@@ -411,7 +412,7 @@ Edit “{{ nofo|nofo_name }}”
             <span class="floating">
               {% if subsection.name %}
                 <span {% if subsection|has_heading_error:heading_errors %}class="usa-tooltip" data-position="bottom" title="{{ subsection|get_heading_error:heading_errors|split_char_and_remove:":" }}. Fix in Word and reimport."{% endif %}>
-                  {{ subsection.name }} {% if subsection.tag == 'h7' %}(h7){% endif %}
+                  {{ subsection.name }}
                 </span>
               {% else %}
                 <span class="text-base">(#{{ subsection.order}})</span>
@@ -431,11 +432,18 @@ Edit “{{ nofo|nofo_name }}”
               </button>
             </span>
           </td>
+          <td class="nofo-edit-table--subsection--heading-level">
+            {% if subsection.tag %}
+              <span class="floating small-caps">
+                {{ subsection.tag|upper }}
+              </span>
+            {% endif %}
+          </td>
           <td class="nofo-edit-table--subsection--callout-box">
             {% if subsection.callout_box %}
-            <span class="floating">
-              <span role="img" aria-label="Callout box" title="Callout box">📦</span>
-            </span>
+              <span class="floating">
+                <span role="img" aria-label="Callout box" title="Callout box">📦</span>
+              </span>
             {% endif %}
           </td>
           <td class="nofo-edit-table--subsection--body">

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -100,8 +100,9 @@ Edit “{{ nofo|nofo_name }}”
 </div>
 {% endif %}
 
+<!-- WARNING MESSAGE FOR BROKEN LINKS -->
 {% if broken_links|length %}
-<section class="usa-site-alert usa-site-alert--emergency usa-site-alert--broken-links" aria-label="Alert: {{ broken_links|length }} broken links.">
+<section class="usa-site-alert usa-site-alert--emergency usa-site-alert--broken-links" aria-label="Warning: {{ broken_links|length }} broken links.">
   <div class="usa-alert">
     <div class="usa-alert__body">
       <h3 class="usa-alert__heading">Warning: some internal links are broken</h3>
@@ -130,8 +131,9 @@ Edit “{{ nofo|nofo_name }}”
 </section>
 {% endif %}
 
+<!-- WARNING MESSAGE FOR HEADING ERRORS -->
 {% if heading_errors|length %}
-<section class="usa-site-alert usa-site-alert--emergency usa-site-alert--heading-errors" aria-label="Alert: {{ heading_errors|length }} heading errors.">
+<section class="usa-site-alert usa-site-alert--emergency usa-site-alert--heading-errors" aria-label="Warning: {{ heading_errors|length }} heading errors.">
   <div class="usa-alert">
     <div class="usa-alert__body">
       <h3 class="usa-alert__heading">Warning: review headings for accessibility</h3>
@@ -159,22 +161,24 @@ Edit “{{ nofo|nofo_name }}”
 </section>
 {% endif %}
 
+<!-- WARNING MESSAGE LISTING H7 HEADERS -->
 {% if h7_headers|length %}
-<section class="usa-site-alert usa-site-alert--info usa-site-alert--h7-headers" aria-label="Alert: {{ h7_headers|length }} h7s in this NOFO.">
+<section class="usa-site-alert usa-site-alert--emergency usa-site-alert--h7-headers" aria-label="Warning: {{ h7_headers|length }} H7 headings in this NOFO.">
   <div class="usa-alert">
     <div class="usa-alert__body">
-      <h3 class="usa-alert__heading">H7s in this NOFO</h3>
+      <h3 class="usa-alert__heading">Warning: This document contains H7 headings</h3>
       <div>
         <details>
           <summary>
             {% if h7_headers|length == 1 %}
-            <span>There is 1 H7 in this NOFO</span>
+            <span>There is 1 H7 heading in this NOFO</span>
             {% else %}
-            <span>There are {{ h7_headers|length }} H7s in this NOFO</span>
+            <span>There are {{ h7_headers|length }} H7 headings in this NOFO</span>
             {% endif %}
           </summary>
           <div>
-            <p>You should fix them pls k thanks.</p>
+            <p>Level 7 Headings are <strong>not</strong> recognized by default in PDFs, and must be changed from <code>&lt;P&gt;</code> to <code>&lt;H7&gt;</code> manually using the Accessibility Tags panel in Adobe Acrobat.</p>
+            <p>Use this list to help you identify which headings to change.</p>
             <ol class="usa-list usa-list--no-max-width">
               {% for h7 in h7_headers %}
                 <li><a href="#{{ h7.html_id }}">{{ h7.name }}</a> ({{ h7.section.name }}, {{ h7.subsection|subsection_name_or_order }})</li>

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -159,6 +159,35 @@ Edit “{{ nofo|nofo_name }}”
 </section>
 {% endif %}
 
+{% if h7_headers|length %}
+<section class="usa-site-alert usa-site-alert--info usa-site-alert--h7-headers" aria-label="Alert: {{ h7_headers|length }} h7s in this NOFO.">
+  <div class="usa-alert">
+    <div class="usa-alert__body">
+      <h3 class="usa-alert__heading">H7s in this NOFO</h3>
+      <div>
+        <details>
+          <summary>
+            {% if h7_headers|length == 1 %}
+            <span>There is 1 H7 in this NOFO</span>
+            {% else %}
+            <span>There are {{ h7_headers|length }} H7s in this NOFO</span>
+            {% endif %}
+          </summary>
+          <div>
+            <p>You should fix them pls k thanks.</p>
+            <ol class="usa-list usa-list--no-max-width">
+              {% for h7 in h7_headers %}
+                <li><a href="#{{ h7.html_id }}">{{ h7.name }}</a> ({{ h7.section.name }}, {{ h7.subsection|subsection_name_or_order }})</li>
+              {% endfor %}
+            </ol>
+          </div>
+        </details>
+      </div>
+    </div>
+  </div>
+</section>
+{% endif %}
+
 <table class="usa-table usa-table--borderless width-full table--hide-edit-if-published">
   <caption>
     <div>
@@ -378,7 +407,7 @@ Edit “{{ nofo|nofo_name }}”
             <span class="floating">
               {% if subsection.name %}
                 <span {% if subsection|has_heading_error:heading_errors %}class="usa-tooltip" data-position="bottom" title="{{ subsection|get_heading_error:heading_errors|split_char_and_remove:":" }}. Fix in Word and reimport."{% endif %}>
-                  {{ subsection.name }}
+                  {{ subsection.name }} {% if subsection.tag == 'h7' %}(h7){% endif %}
                 </span>
               {% else %}
                 <span class="text-base">(#{{ subsection.order}})</span>

--- a/bloom_nofos/nofos/templates/nofos/subsection_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_edit.html
@@ -51,7 +51,7 @@
       <div class="form-group">
         {% with id="name" label=form.name.label value=form.name.value hint=form.name.help_text error=form.name.errors.0 input_type=form.name|input_type %}
           {% if subsection.tag %}
-            {% include "includes/_text_input.html" with id=id label=label hint="Heading level: "|add:subsection.tag value=value error=error input_type=input_type only %}
+            {% include "includes/_text_input.html" with id=id label=label hint_prefix="Heading level:" hint=subsection.tag|upper value=value error=error input_type=input_type safe_hint=True only %}
             {% if subsection.html_id %}
             <div class="usa-hint margin-top-05 hint--subsection-id" id="{{ id }}--hint-2">
               <span id="subsection-html_id">{{ "#"|add:subsection.html_id  }}</span>

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -124,11 +124,13 @@ class StyleMapManager:
 # Pre-instantiate StyleMapManager with styles to ignore
 style_map_manager = StyleMapManager(
     [
-        "ListParagraph",
         "Bullet2",
+        "customXmlDelRange",
+        "Default",
         "FootnoteReference",
-        "Normal_0",
+        "ListParagraph",
         "non-row element in table",
+        "Normal_0",
     ]
 )
 
@@ -167,6 +169,11 @@ style_map_manager.add_style(
     style_rule="r[style-name='scxw144559721'] => span",
     location_in_nofo="It's just in body text",
     note="Just plain body text",
+)
+style_map_manager.add_style(
+    style_rule="r[style-name='Body Text Char'] => span",
+    location_in_nofo="It's just in body text",
+    note="Don't do anything: regular body text.",
 )
 style_map_manager.add_style(
     style_rule="r[style-name='Style6 Char'] => span",

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -71,6 +71,7 @@ from .nofo import (
     find_broken_links,
     find_external_link,
     find_external_links,
+    find_h7_headers,
     find_incorrectly_nested_heading_levels,
     find_same_or_higher_heading_levels_consecutive,
     get_cover_image,
@@ -190,6 +191,7 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
         context["heading_errors"] = find_same_or_higher_heading_levels_consecutive(
             self.object
         ) + find_incorrectly_nested_heading_levels(self.object)
+        context["h7_headers"] = find_h7_headers(self.object)
 
         context["DOCRAPTOR_TEST_MODE"] = config.DOCRAPTOR_TEST_MODE
 


### PR DESCRIPTION
## Summary 

This PR makes two changes to the NOFO editing experience:

1. Show all heading levels in the nofo_edit page table.
2. List all H7s in the NOFO in an alert box

#### 1. Show all heading levels in the nofo_edit page table.

Because we don't have an automatic fix for shimming `<h7>` elements in the PDF itself, the solution has been to manually add H7 tags to the final PDF, which is a slow and annoying part of our process.

However, a challenge with this has been that the tag level of subheadings has not previously been surfaced to users of the NOFO Builder, leading to strategies like "look for all the h6s". This is clearly something fixable, so I've added a new column to the subsections table on the nofo_edit page which lists the heading level of each subsection (if the subsection has a title).

Now all heading levels can be viewed quickly.

| before | after  |
|--------|--------|
|   Current state: no heading info     |   Now the heading level (eg, `H4`) is visible after the 'copy' button   |
| <img width="1457" alt="Screenshot 2024-11-12 at 10 44 22 AM" src="https://github.com/user-attachments/assets/68283a92-ef1e-4ac5-afbc-4c5fb4f8e089"> | <img width="1457" alt="Screenshot 2024-11-12 at 10 44 24 AM" src="https://github.com/user-attachments/assets/f2b6f9d8-77f1-4493-87c2-43d719c6a860"> |


#### 2. List all H7s in the NOFO in an alert box

RE: can't find the `<h7>`s:

By listing all the H7s at the top in an alert box, we are putting extra emphasis on them. This is basically doubling down on making them visible to users.

| before | after  | after (expanded) |
|--------|--------|--------|
|  NOFO with no H7 alert box     |   NOFO with alert box about H7 headings (closed)    |  NOFO with alert box about H7 headings (expanded). Once opened, it shows the titles and where they are in the doc.   |
| <img width="1457" alt="Screenshot 2024-11-12 at 10 45 41 AM" src="https://github.com/user-attachments/assets/cebe3fcb-c830-4b73-9bf9-eed218254fca"> | <img width="1457" alt="Screenshot 2024-11-12 at 10 45 46 AM" src="https://github.com/user-attachments/assets/7bb3d101-fa30-4211-b6ed-39a5d6cd9d75"> | <img width="1457" alt="Screenshot 2024-11-12 at 10 45 48 AM" src="https://github.com/user-attachments/assets/34a7552b-b17e-4d27-a754-223a17c4d293"> |



