### PR TITLE
Convert literal asterisks into HTML entities in paragraphs in table cells.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Convert literal asterisks to `&ast;` inside of HTML PARAGRAPHS in table cells
+  - We did this for lists already but paragraphs need the same treatment
+
 ## [1.32.0] - 2023-11-09
 
 ### Changed

--- a/bloom_nofos/nofos/nofo_markdown.py
+++ b/bloom_nofos/nofos/nofo_markdown.py
@@ -69,7 +69,7 @@ class NofoMarkdownConverter(MarkdownConverter):
         # if we are in a table cell, and that table cell contains multiple children, return the string
         if el.parent.name == "td" or el.parent.name == "th":
             if len(list(el.parent.children)) > 1:
-                return str(el)
+                return str(el).replace("*", "&ast;")
 
         # if the paragraph has an id that includes the string "bookmark", keep the paragraph as-is
         p_id = el.attrs.get("id") if el else None

--- a/bloom_nofos/nofos/tests/test_nofo_markdown.py
+++ b/bloom_nofos/nofos/tests/test_nofo_markdown.py
@@ -296,9 +296,27 @@ class NofoMarkdownConverterPTest(TestCase):
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_markdown.strip())
 
+    def test_regular_p_asterisk(self):
+        html = "<p>Regular Paragraph with asterisk *</p>"
+        expected_markdown = "Regular Paragraph with asterisk \*"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
     def test_regular_p_in_td(self):
         html = "<table><tr><th><p>Header</p></th></tr><tr><td><p>Content</p></td></tr></table>"
         expected_markdown = "| Header |\n| --- |\n| Content |"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_regular_p_asterisk_in_td(self):
+        html = "<table><tr><th><p>Header</p></th></tr><tr><td><p>Content *</p></td></tr></table>"
+        expected_markdown = "| Header |\n| --- |\n| Content \* |"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_regular_p_asterisk_in_th(self):
+        html = "<table><tr><th><p>Header *</p></th></tr><tr><td><p>Content</p></td></tr></table>"
+        expected_markdown = "| Header \* |\n| --- |\n| Content |"
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_markdown.strip())
 
@@ -308,9 +326,25 @@ class NofoMarkdownConverterPTest(TestCase):
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_markdown.strip())
 
+    def test_two_ps_in_th_asterisk(self):
+        html = "<table><tr><th><p>Header 1</p><p>Header 2 *</p></th></tr><tr><td><p>Content</p></td></tr></table>"
+        expected_markdown = (
+            "| <p>Header 1</p><p>Header 2 &ast;</p> |\n| --- |\n| Content |"
+        )
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
     def test_two_ps_in_td(self):
         html = "<table><tr><th><p>Header</p></th></tr><tr><td><p>Content 1</p><p>Content 2</p></td></tr></table>"
         expected_markdown = "| Header |\n| --- |\n| <p>Content 1</p><p>Content 2</p> |"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_markdown.strip())
+
+    def test_two_ps_in_td_asterisk(self):
+        html = "<table><tr><th><p>Header</p></th></tr><tr><td><p>Content 1</p><p>Content 2 *</p></td></tr></table>"
+        expected_markdown = (
+            "| Header |\n| --- |\n| <p>Content 1</p><p>Content 2 &ast;</p> |"
+        )
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_markdown.strip())
 


### PR DESCRIPTION
## Summary

Sometimes we have tables that include content ending in asterisks that are meant to reference something at the bottom. 

In certain cases, the asterisks are interpreted as italics, not as the literal asterisk, which is what we want. 

[In a previous commit](https://github.com/HHS/simpler-grants-pdf-builder/commit/24449c4459b354a09627cab5705956fe26b2d772), I solved this for list items in table cells, but overlooked paragraphs.

This PR fixes that, so now — _I think_ — we are all set.

| before | after  |
|--------|--------|
|  asterisks are being interpreted as markdown formatting, which is why some items are italicized (bad 👎)    | asterisks are preserved, as intended (good 👍) |
| <img width="715" alt="Screenshot 2024-11-13 at 3 41 56 PM" src="https://github.com/user-attachments/assets/96632911-6e6f-4b86-a1e0-9c5c4aa2c676"> | <img width="715" alt="Screenshot 2024-11-13 at 3 41 47 PM" src="https://github.com/user-attachments/assets/6f4e3e22-6489-4395-829f-23e59bd7bad7"> |
