### PR TITLE
Save some bookmarks 🙏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Preserve bookmark targets that have been getting stripped out
 - Convert literal asterisks to `&ast;` inside of HTML PARAGRAPHS in table cells
   - We did this for lists already but paragraphs need the same treatment
 

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -1550,6 +1550,21 @@ def preserve_bookmark_links(soup):
 
 
 def preserve_bookmark_targets(soup):
+    """
+    This function mutates the soup!
+
+    Adjusts empty bookmark links in an HTML document to preserve their target IDs while cleaning up the document structure.
+
+    This function processes all empty <a> tags in the provided BeautifulSoup object that meet the following criteria:
+    - Have an 'id' attribute (which does not start with an underscore)
+    - Do not contain an 'href' or any text content
+
+    For each matching <a> tag:
+    1. The function prepends "nb_bookmark_" to the <a> tag's 'id'.
+    2. It searches for any other <a> tags in the document with an 'href' attribute pointing to the original 'id' and updates their 'href' to the new prefixed 'id'.
+    3. If the parent of the empty <a> tag does not have an 'id', the new prefixed 'id' is copied to the parent element.
+    4. The original empty <a> tag is then removed from the document.
+    """
     empty_links = soup.find_all(
         "a", id=True, href=False, text=lambda t: not t or not t.strip()
     )

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -1549,6 +1549,29 @@ def preserve_bookmark_links(soup):
             broken_link["href"] = "#__{}".format(bookmark_id)
 
 
+def preserve_bookmark_targets(soup):
+    empty_links = soup.find_all(
+        "a", id=True, href=False, text=lambda t: not t or not t.strip()
+    )
+    for link in empty_links:
+        if not link.get("id", "").startswith("_"):
+            original_id = link.get("id", "")
+            new_id = "nb_bookmark_{}".format(original_id)
+
+            link["id"] = new_id  # Update the id of the empty <a> tag
+
+            matching_links = soup.find_all("a", href="#{}".format(original_id))
+            for matching_link in matching_links:
+                # replace hrefs of existing links to new id
+                matching_link["href"] = "#{}".format(new_id)
+
+            if link.parent and not link.parent.get("id", None):
+                # Copy the id from the <a> tag to the parent
+                link.parent["id"] = new_id
+                # Remove the <a> tag from the document
+                link.decompose()
+
+
 def preserve_heading_links(soup):
     """
     This function mutates the soup!

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -1211,10 +1211,11 @@ def unwrap_empty_elements(soup):
 
     Unwraps empty span, strong, sup, a, and em tags from the BeautifulSoup `soup`.
     """
-    elements = soup.find_all(["em", "span", "strong", "sup"])
+    elements = soup.find_all(
+        ["em", "span", "strong", "sup"], text=lambda t: not t or not t.strip()
+    )
     for el in elements:
-        if not el.get_text().strip():
-            el.unwrap()
+        el.unwrap()
 
 
 def clean_table_cells(soup):
@@ -1676,8 +1677,8 @@ def preserve_table_heading_links(soup):
         paragraph = table.find_previous_sibling("p")
         if paragraph:
             # Find all empty <a> tags within the paragraph
-            for a in paragraph.find_all("a"):
-                if a.get_text(strip=True) == "" and not a.contents:
+            for a in paragraph.find_all("a", text=lambda t: not t or not t.strip()):
+                if not a.contents:
                     table_id_anchors.append(a)
 
     for a in table_id_anchors:

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -129,8 +129,11 @@ style_map_manager = StyleMapManager(
         "Default",
         "FootnoteReference",
         "ListParagraph",
+        "Listpara2",
         "non-row element in table",
         "Normal_0",
+        "v:",
+        "office-word:",
     ]
 )
 

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -80,6 +80,7 @@ from .nofo import (
     join_nested_lists,
     overwrite_nofo,
     preserve_bookmark_links,
+    preserve_bookmark_targets,
     preserve_heading_links,
     preserve_table_heading_links,
     remove_google_tracking_info_from_links,
@@ -327,6 +328,7 @@ def nofo_import(request, pk=None):
         replace_src_for_inline_images(soup)
         add_endnotes_header_if_exists(soup, top_heading_level)
         unwrap_nested_lists(soup)
+        preserve_bookmark_targets(soup)
         soup = add_em_to_de_minimis(soup)
 
         # format all the data as dicts


### PR DESCRIPTION
## Summary 

This one is strange. Most bookmarks are to headings, but sometimes they are to random areas in the middle of a paragraph.

When the document is exported as HTML from Word, the bookmark link _target_ is an `<a>` tag with with an id that matches the href (a normal anchor link).

However, once it goes through mammoth, it looks like they move the text out of the paragraph for some reason and then the (now-empty) link target gets stripped out of the text once the markdown conversion happens.

idk what is going on here, to be honest.

As an example, the Word HTML export will look like this.

```
<p>This is a paragraph link with <a id="my_id">a bookmark target</a>.</p>
```

But in the mammoth export, it looks like this:

```
<p>This is a paragraph link with <a id="my_id"></a> a bookmark target.</p>
```

My fix here is to:
- find these empty id links
- rename the id so that I can track that this happened
- add the id to the parent

The outcome of the earlier example would look like this:

```
<p id="nofo_bookmark_my_id">This is a paragraph link with a bookmark target.</p>
```

Hopefully this resolves this issue, but we will have to see.

Note that the logic is written in a way that modifications to the HTML can happen without all the conditions being met (we can modify the `hrefs` without knowing if the target will be modified), but I am thinking that we will catch those if they come up.