### PR TITLE
Smaller title font for larger titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Smallen the font size (again) for NOFOs with very long titles (> 190 chars)
+
 ### Fixed
 
 - Preserve bookmark targets that have been getting stripped out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Preserve bookmark targets that have been getting stripped out
 - Convert literal asterisks to `&ast;` inside of HTML PARAGRAPHS in table cells
   - We did this for lists already but paragraphs need the same treatment
+- Criteria tables with a page break or table in front of them should also be full-width
 
 ## [1.32.0] - 2023-11-09
 

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -108,6 +108,12 @@ section.nofo--cover-page.nofo--cover-page--text {
   font-size: 28pt;
 }
 
+.nofo--cover-page--medium
+  .nofo--cover-page--title
+  h1.nofo--cover-page--title--h1--very-smol {
+  font-size: 24pt;
+}
+
 .nofo--cover-page--text .nofo--cover-page--hero-image,
 .nofo--cover-page--text .nofo--cover-page--title .nofo--cover-page--title--logo,
 .nofo--cover-page--text

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -276,10 +276,20 @@ section.before-you-begin {
   width: calc(216mm - 40mm); /* large tables should be full-width */
 }
 
-body.portrait.cdc
+body.portrait
   .section--step-4-learn-about-review-and-award
   .section--content
   p
+  + table:not(.table--criterion),
+body.portrait
+  .section--step-4-learn-about-review-and-award
+  .section--content
+  div.page-break--hr--container
+  + table:not(.table--criterion),
+body.portrait
+  .section--step-4-learn-about-review-and-award
+  .section--content
+  table
   + table:not(.table--criterion) {
   width: calc(
     216mm - 40mm

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -1,5 +1,5 @@
 {% extends 'base_barebones.html' %}
-{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_captions_to_tables split_char_and_remove add_classes_to_lists convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section %}
+{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_classes_to_lists add_classes_to_headings add_captions_to_tables split_char_and_remove convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section %}
 
 {% block metadata %}
   {% if nofo.author %}
@@ -117,7 +117,7 @@
     </div>
     <div class="nofo--cover-page--title">
       <div class="nofo--cover-page--title--block">
-        <h1 {% if nofo.title|length > 120 %}class="nofo--cover-page--title--h1--smaller"{% endif %}>{{ nofo.title }}</h1>
+        <h1 class="{{ nofo.title|add_classes_to_nofo_title }}">{{ nofo.title }}</h1>
         <div class="nofo--cover-page--title--subheading">
           <span>Opportunity number: {{ nofo.number }}</span>
         </div>

--- a/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
+++ b/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
@@ -10,3 +10,14 @@ def add_classes_to_headings(html_string):
         return "heading--column-span"
 
     return ""
+
+
+@register.filter()
+def add_classes_to_nofo_title(nofo_title):
+    if len(nofo_title) > 190:
+        return "nofo--cover-page--title--h1--very-smol"
+
+    if len(nofo_title) > 120:
+        return "nofo--cover-page--title--h1--smaller"
+
+    return "nofo--cover-page--title--h1--normal"


### PR DESCRIPTION
## Summary

Apparently some NOFO titles try to use the max character width they are allowed to, which is 250 characters. 

I find this puzzling, but as a non-NOFO expert, I try to keep an open mind about these things.

We already have a 'small' font variant, but this is an even smaller font variant.

Now the rule is:

- normal: 32pt
- over 120 chars: 28pt
- over 190 chars: 24 pt

Hopefully this fixes it, but we can tweak as we go.

| before | after  |
|--------|--------|
|  28pt font for title      |  <sub>24 pt font for title</sub>       |
| <img width="1457" alt="Screenshot 2024-11-13 at 7 59 27 PM" src="https://github.com/user-attachments/assets/bf78dee5-a7ae-4f0f-b658-5d5edaa97a24"> | <img width="1457" alt="Screenshot 2024-11-13 at 7 59 32 PM" src="https://github.com/user-attachments/assets/7d1dd698-0487-4fda-ab73-9afa274586da"> | 

