### PR TITLE
Smallen shorter titles (still long though)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
-- Smallen the font size (again) for NOFOs with very long titles (> 190 chars)
+- Smallen the font size (again) for NOFOs with very long titles (> 170 chars)
 
 ### Fixed
 
@@ -92,7 +92,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Find ranges for numbered sublists
   - Match for "8-15.", "8 - 15.", "8 through 15."
   - Remove the border under "Attachments"
-- # ids inserted using markdown attributes should not show up as 'broken links'
+- ids inserted using markdown attributes should not show up as 'broken links'
 - Added more known styles for the mammoth style map
   > > > > > > > 6592cc6 (Add button to copy broken links on nofo_edit page)
 

--- a/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
+++ b/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
@@ -14,7 +14,7 @@ def add_classes_to_headings(html_string):
 
 @register.filter()
 def add_classes_to_nofo_title(nofo_title):
-    if len(nofo_title) > 190:
+    if len(nofo_title) > 170:
         return "nofo--cover-page--title--h1--very-smol"
 
     if len(nofo_title) > 120:


### PR DESCRIPTION
## Summary

I had assumed that titles move ~200 characters were the issue but we have seen then breaking at shorter lengths, so now we are saying 170.

This has been described already in #42, it's just we are lowering the character limit.