### PR TITLE
Even smaller font sizes for NOFOs with titles over 230 characters long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Smallen the font size (even more) for NOFOs with very, very long titles (> 230 chars)
+
 ### Fixed
 
 ## [1.34.0] - 2023-11-18

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -114,6 +114,12 @@ section.nofo--cover-page.nofo--cover-page--text {
   font-size: 24pt;
 }
 
+.nofo--cover-page--medium
+  .nofo--cover-page--title
+  h1.nofo--cover-page--title--h1--very-very-smol {
+  font-size: 23pt;
+}
+
 .nofo--cover-page--text .nofo--cover-page--hero-image,
 .nofo--cover-page--text .nofo--cover-page--title .nofo--cover-page--title--logo,
 .nofo--cover-page--text

--- a/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
+++ b/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
@@ -14,6 +14,9 @@ def add_classes_to_headings(html_string):
 
 @register.filter()
 def add_classes_to_nofo_title(nofo_title):
+    if len(nofo_title) > 230:
+        return "nofo--cover-page--title--h1--very-very-smol"
+
     if len(nofo_title) > 170:
         return "nofo--cover-page--title--h1--very-smol"
 


### PR DESCRIPTION
## Summary

We made titles smaller in #42, but we have been seeing even longer titles sometimes. 

This PR adds another, even smaller font size for super long titles (> 230 chars).

This is hopefully the last time we have to do this.

| before | after  |
|--------|--------|
| `24pt` font | `23pt` font |
|    <img width="879" alt="Screenshot 2024-11-18 at 1 59 27 PM" src="https://github.com/user-attachments/assets/897c71df-b551-455a-8796-aa745310cc74">    |  <img width="879" alt="Screenshot 2024-11-18 at 1 59 19 PM" src="https://github.com/user-attachments/assets/0a19f937-a009-42d3-8c4a-e9a81514e024">    |

