### PR TITLE
Smaller callout text + better table headings + smaller titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Make text in right hand callout box smaller if too many words
+
 ### Fixed
 
 ## [1.36.0] - 2023-11-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Do not bold paragraph in th that follows a strong
+
 ## [1.36.0] - 2023-11-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 
 - Make text in right hand callout box smaller if too many words
+- Titles with 166 chars or more now get the smaller classname
 
 ### Fixed
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -414,8 +414,8 @@ table tbody tr:first-of-type th p {
   font-weight: 400;
 }
 
-table thead th p:first-of-type,
-table tbody tr:first-of-type th p:first-of-type {
+table thead th p:first-child,
+table tbody tr:first-of-type th p:first-child {
   font-weight: 600;
 }
 
@@ -423,6 +423,11 @@ table thead th > p,
 table tbody tr:first-of-type th > p {
   margin-top: 0;
   margin-bottom: 8px;
+}
+
+table thead th > strong + p:first-of-type,
+table tbody tr:first-of-type th > strong + p:first-of-type {
+  margin-top: 8px;
 }
 
 table thead th > p:last-of-type,

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -274,6 +274,19 @@ section.before-you-begin {
   font-size: 10pt;
 }
 
+.section--content--right-col.section--content--right-col--smaller
+  .callout-box--questions
+  .callout-box--contents
+  p,
+.section--content--right-col.section--content--right-col--smaller
+  .callout-box--contents {
+  font-size: 9.5pt;
+}
+
+.section--content--right-col .callout-box--contents p {
+  padding-right: 5px;
+}
+
 .section--content--right-col .callout-box--questions .callout-box--contents p {
   font-size: 10pt;
 }

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -363,7 +363,7 @@
           {% if nofo_theme_orientation == 'portrait' %}
             {% with callouts=section|get_floating_callout_boxes_from_section %}
               {% if callouts %}
-                <div class="section--content--right-col">
+                <div class="section--content--right-col{% if callouts|get_combined_wordcount_for_subsections > 85 %} section--content--right-col--smaller{% endif %}">
                   {% for subsection in callouts %}
                     {% include "includes/callout_box.html" with subsection=subsection nofo=nofo break_colons=True only %}
                   {% endfor %}

--- a/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
+++ b/bloom_nofos/nofos/templatetags/add_classes_to_headings.py
@@ -2,6 +2,8 @@ from django import template
 
 register = template.Library()
 
+from .utils import add_class_to_nofo_title
+
 
 @register.filter()
 def add_classes_to_headings(html_string):
@@ -14,13 +16,4 @@ def add_classes_to_headings(html_string):
 
 @register.filter()
 def add_classes_to_nofo_title(nofo_title):
-    if len(nofo_title) > 230:
-        return "nofo--cover-page--title--h1--very-very-smol"
-
-    if len(nofo_title) > 170:
-        return "nofo--cover-page--title--h1--very-smol"
-
-    if len(nofo_title) > 120:
-        return "nofo--cover-page--title--h1--smaller"
-
-    return "nofo--cover-page--title--h1--normal"
+    return add_class_to_nofo_title(nofo_title)

--- a/bloom_nofos/nofos/templatetags/get_floating_callout_boxes_from_section.py
+++ b/bloom_nofos/nofos/templatetags/get_floating_callout_boxes_from_section.py
@@ -12,3 +12,12 @@ def get_floating_callout_boxes_from_section(section):
         for subsection in section.subsections.all().order_by("order")
         if subsection.callout_box and is_floating_callout_box(subsection)
     ]
+
+
+@register.filter()
+def get_combined_wordcount_for_subsections(subsections):
+    word_count = 0
+    for subsection in subsections:
+        word_count += len(subsection.body.split())
+
+    return word_count

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -64,6 +64,19 @@ def add_class_to_list(html_list):
             )
 
 
+def add_class_to_nofo_title(nofo_title):
+    if len(nofo_title) > 225:
+        return "nofo--cover-page--title--h1--very-very-smol"
+
+    if len(nofo_title) > 165:
+        return "nofo--cover-page--title--h1--very-smol"
+
+    if len(nofo_title) > 120:
+        return "nofo--cover-page--title--h1--smaller"
+
+    return "nofo--cover-page--title--h1--normal"
+
+
 def _get_total_word_count(table_cells):
     word_count = 0
 

--- a/bloom_nofos/nofos/tests/test_templatetags.py
+++ b/bloom_nofos/nofos/tests/test_templatetags.py
@@ -9,6 +9,7 @@ from nofos.templatetags.utils import (
     _add_class_if_not_exists_to_tags,
     add_caption_to_table,
     add_class_to_list,
+    add_class_to_nofo_title,
     add_class_to_table,
     add_class_to_table_rows,
     convert_paragraph_to_searchable_hr,
@@ -212,6 +213,58 @@ class AddClassToListsTests(TestCase):
         soup = BeautifulSoup(html_content, "html.parser")
         add_class_to_list(soup.ul)
         self.assertEqual(soup.find_all("li")[-1]["class"], ["avoid-page-break-before"])
+
+
+class AddClassToNofoTitleTest(TestCase):
+    def test_normal_title_length(self):
+        title = "Tribal Management Grant (TMG) Program"
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--normal")
+
+    def test_smaller_title_length(self):
+        title = "Improving quality of care and health outcomes through innovative systems and technologies in Malawi under the President’s Emergency Plan for AIDS Relief (PEPFAR)"
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--smaller")
+
+    def test_very_smol_title_length(self):
+        title = "Strengthening economic analysis and capacity in support of program management for HIV, TB, and related health threats in South Africa (SA) under the President's Emergency Plan for AIDS Relief (PEPFAR)"
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--very-smol")
+
+    def test_very_very_smol_title_length(self):
+        title = "Strengthening the Botswana Ministry of Health (MOH) laboratory and health systems through technical assistance (TA) to effectively manage and sustain a quality HIV/TB program in Botswana under the President’s Emergency Plan for AIDS Relief (PEPFAR)"
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--very-very-smol")
+
+    def test_edge_case_exact_120(self):
+        title = "x" * 120
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--normal")
+
+    def test_edge_case_just_over_120(self):
+        title = "x" * 121
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--smaller")
+
+    def test_edge_case_exact_165(self):
+        title = "x" * 165
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--smaller")
+
+    def test_edge_case_just_over_165(self):
+        title = "x" * 166
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--very-smol")
+
+    def test_edge_case_exact_225(self):
+        title = "x" * 225
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--very-smol")
+
+    def test_edge_case_just_over_225(self):
+        title = "x" * 226
+        result = add_class_to_nofo_title(title)
+        self.assertEqual(result, "nofo--cover-page--title--h1--very-very-smol")
 
 
 class HTMLTableClassTests(TestCase):


### PR DESCRIPTION
## Summary 

This PR does 3 things:

1. Makes the text in the right-col callout box smaller if it exceeds a certain word count
2. Adds some corrective CSS for multi-line table headings
3. Lowers the character limit needed for large titles to have a smaller font styling applied

### 1. Right-col callout box smaller text

We have been seeing these callout boxes split across 2 pages pretty regularly for the PEPFAR NOFOs. I've added a function that counts how many words are in the callout boxes and then applies styling based on that. Maybe a character count would be more exact, but let's try this for now.

| before | after  |
|--------|--------|
| `10pt` font for callout boxes | `9.5pt` font for callout boxes |
|   <img width="861" alt="Screenshot 2024-11-20 at 10 35 51 AM" src="https://github.com/user-attachments/assets/36fd86ca-5edf-4c35-9197-107959628524">     |  <img width="861" alt="Screenshot 2024-11-20 at 10 35 38 AM" src="https://github.com/user-attachments/assets/7d6289db-9a9e-48ea-88dd-30edd7946ab4">      |

### Corrective CSS for multiline table headings

Previously, we wanted every multi-line table heading to contain paragraph tags:

```html
<th>
  <p><strong>Line 1</strong></p>
  <p>Line 2</p>
</th>
```

Which meant that this would break everything:

```html
<th>
 <strong>Line 1</strong> <!-- no <p> tag -->
  <p>Line 2</p>
</th>
```

Now, the strong tag as the first line is accommodated.

| before | after  |
|--------|--------|
| 2nd and 3rd cells both bold |  2nd and 3rd cells look good |
|   <img width="691" alt="Screenshot 2024-11-20 at 10 04 26 AM" src="https://github.com/user-attachments/assets/ed2c2f18-7228-47f0-852c-fe6ed4a487f9">    |  <img width="691" alt="Screenshot 2024-11-20 at 10 04 45 AM" src="https://github.com/user-attachments/assets/7e8d3344-bbde-4260-a3c2-04a2a563a3a2">      |


### 3. Lowers the character limit for NOFO titles

Used to kick in at 170 chars, now at 165 chars.