### PR TITLE
Replace broken links on import + add a script to download links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bloom_nofos/static
 
 # debug file
 debug_output.html
+
+# export file
+export_links.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- Add script to pull links from all non-archived NOFOs
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Replace "www.grants.gov/web/grants/search-grants.html" with "grants.gov/search-grants"
+- Replace "www.grants.gov/web/grants/forms/sf-424-family.html" with "grants.gov/forms/forms-repository/sf-424-family"
+- Replace "www.cdc.gov/grants/dictionary/index.html" with "www.cdc.gov/grants/dictionary/index.html"
+
 ## [1.37.0] - 2023-11-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+### Removed
+
+- Remove admin-only view to export all NOFO links
+  - We used this once ever
+
 ### Fixed
 
 - Replace "www.grants.gov/web/grants/search-grants.html" with "grants.gov/search-grants"

--- a/bloom_nofos/nofos/management/commands/export_links.py
+++ b/bloom_nofos/nofos/management/commands/export_links.py
@@ -1,0 +1,97 @@
+import csv
+
+from django.core.management.base import BaseCommand
+from nofos.models import Nofo
+from nofos.nofo import find_external_links
+
+
+class Command(BaseCommand):
+    help = "Extracts external links from NOFO documents and outputs them."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "nofo_id", nargs="?", type=int, help="ID of the NOFO to extract links from"
+        )
+        parser.add_argument(
+            "--all", action="store_true", help="Extract links from all NOFOs"
+        )
+        parser.add_argument(
+            "--output",
+            type=str,
+            default="nofo_links.csv",
+            help="Output file name for the CSV (default: nofo_links.csv)",
+        )
+        parser.add_argument(
+            "--live",
+            type=bool,
+            default=False,
+            help="Specify if links are live",
+        )
+
+    def handle(self, *args, **options):
+        output_file = options["output"]
+        domain = "https://nofo.rodeo" if options["live"] else "http://localhost:8000"
+
+        # Determine which NOFOs to process
+        if options["all"]:
+            nofos = Nofo.objects.all()
+        else:
+            nofo_id = options.get("nofo_id")
+            if nofo_id is None:
+                self.stdout.write(self.style.ERROR("No NOFO ID provided"))
+                return
+            nofos = Nofo.objects.filter(id=nofo_id)
+
+        if not nofos.exists():
+            self.stdout.write(self.style.ERROR("No NOFOs found."))
+            return
+
+        links_count = 0
+
+        # Write the output to a CSV file
+        with open(output_file, mode="w", newline="") as file:
+            writer = csv.writer(file)
+            writer.writerow(
+                [
+                    "nofo_id",
+                    "nofo_number",
+                    "url",
+                    "section_name",
+                    "subsection_name",
+                    "link_to_subsection",
+                ]
+            )
+
+            for nofo in nofos:
+                print("---")
+                print("NOFO: {}".format(nofo.number))
+                links = find_external_links(nofo)
+                print("Links in this NOFO: {}".format(len(links)))
+                links_count += len(links)
+
+                for link in links:
+                    writer.writerow(
+                        [
+                            nofo.id,
+                            nofo.number,
+                            link["url"],
+                            (
+                                link["section"].name if link["section"] else ""
+                            ),  # Section name
+                            (
+                                link["subsection"].name if link["subsection"] else ""
+                            ),  # Subsection name
+                            (
+                                "{}/nofos/{}/section/{}/subsection/{}/edit".format(
+                                    domain,
+                                    nofo.id,
+                                    link["section"].id,
+                                    link["subsection"].id,
+                                )
+                            ),
+                        ]
+                    )
+
+        print("---")
+        print("Total links in all NOFOs: {}".format(links_count))
+        self.stdout.write(self.style.SUCCESS(f"Links extracted to {output_file}"))

--- a/bloom_nofos/nofos/management/commands/export_links.py
+++ b/bloom_nofos/nofos/management/commands/export_links.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--output",
             type=str,
-            default="nofo_links.csv",
+            default="export_links.csv",
             help="Output file name for the CSV (default: nofo_links.csv)",
         )
         parser.add_argument(
@@ -55,6 +55,7 @@ class Command(BaseCommand):
                 [
                     "nofo_id",
                     "nofo_number",
+                    "nofo_status",
                     "url",
                     "section_name",
                     "subsection_name",
@@ -62,7 +63,15 @@ class Command(BaseCommand):
                 ]
             )
 
-            for nofo in nofos:
+            print("---")
+            print("All nofos: {}".format(len(nofos)))
+            print(
+                "All non-archived nofos: {}".format(
+                    len(nofos.exclude(archived__isnull=False))
+                )
+            )
+
+            for nofo in nofos.exclude(archived__isnull=False):
                 print("---")
                 print("NOFO: {}".format(nofo.number))
                 links = find_external_links(nofo)
@@ -74,6 +83,7 @@ class Command(BaseCommand):
                         [
                             nofo.id,
                             nofo.number,
+                            nofo.status,
                             link["url"],
                             (
                                 link["section"].name if link["section"] else ""

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -45,6 +45,29 @@ def replace_chars(file_content):
     return file_content
 
 
+def replace_links(file_content):
+    # grants.gov/web links are broken and don't redirect _and_ say they are 200 🙄
+    replacement_chars = [
+        (
+            "www.grants.gov/web/grants/search-grants.html",
+            "grants.gov/search-grants",
+        ),
+        (
+            "www.grants.gov/web/grants/forms/sf-424-family.html",
+            "grants.gov/forms/forms-repository/sf-424-family",
+        ),
+        (
+            "www.cdc.gov/grants/dictionary/index.html",
+            "www.cdc.gov/grants/dictionary-of-terms/",
+        ),
+    ]
+
+    for _from, _to in replacement_chars:
+        file_content = file_content.replace(_from, _to)
+
+    return file_content
+
+
 @transaction.atomic
 def add_headings_to_nofo(nofo):
     new_ids = []

--- a/bloom_nofos/nofos/templates/admin/nofo_change_form.html
+++ b/bloom_nofos/nofos/templates/admin/nofo_change_form.html
@@ -1,8 +1,5 @@
 {% extends "admin/change_form.html" %}
 
 {% block object-tools-items %}
-    <li>
-        <a href="{% url 'nofos:export_nofo_links' original.id %}">Export URLs</a>
-    </li>
     {{ block.super }}
 {% endblock %}

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -129,9 +129,4 @@ urlpatterns = [
         views.CheckNOFOLinkSingleView.as_view(),
         name="nofo_check_link_single",
     ),
-    path(
-        "<int:nofo_id>/export_nofo_links",
-        views.export_nofo_links,
-        name="export_nofo_links",
-    ),
 ]

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1,4 +1,3 @@
-import csv
 import io
 
 import docraptor
@@ -8,7 +7,6 @@ from constance import config
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
-from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import F
@@ -897,22 +895,3 @@ def insert_order_space_view(request, section_id):
 
     context = {"form": form, "title": "Insert Order Space", "section": section}
     return render(request, "admin/insert_order_space.html", context)
-
-
-@user_passes_test(lambda u: u.is_superuser)
-def export_nofo_links(request, nofo_id):
-    # Create the HttpResponse object with the appropriate CSV header.
-    response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = f'attachment; filename="nofo_{nofo_id}_links.csv"'
-
-    writer = csv.writer(response)
-
-    writer.writerow(["url", "section_name", "nofo_number"])
-
-    nofo = get_object_or_404(Nofo, id=nofo_id)
-
-    urls = find_external_links(nofo)
-    for url in urls:
-        writer.writerow([url.get("url"), url.get("section").name, nofo.number])
-
-    return response

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -85,6 +85,7 @@ from .nofo import (
     preserve_table_heading_links,
     remove_google_tracking_info_from_links,
     replace_chars,
+    replace_links,
     replace_src_for_inline_images,
     suggest_all_nofo_fields,
     suggest_nofo_title,
@@ -297,8 +298,10 @@ def nofo_import(request, pk=None):
             )
             return redirect(view_path, **kwargs)
 
-        # replace problematic characters on import
+        # replace problematic characters/links on import
         cleaned_content = replace_chars(file_content)
+        cleaned_content = replace_links(file_content)
+
         soup = BeautifulSoup(cleaned_content, "html.parser")  # Parse the cleaned HTML
         soup = add_body_if_no_body(soup)
 


### PR DESCRIPTION
## Summary

This PR does 3 things:

1. adds a function to auto-replace known broken links on import
2. adds a script that we can use to grab all links across all NOFOs
3. removes an old view that would download a list of links from an individual NOFO

#### 1. auto-replace known broken links on import

We noticed that some links 404 but still return a 200 level status code. This is very annoying. It is also not something we can do much about, as we only control one website.

However, we can find/replace stuff that we import, so if we know what URLs have this behaviour, we can resolve the problem when the file is imported. Right now there are 3 links we have identified:

| bad link | good link  |
|--------|--------|
|    [www.grants.gov/web/grants/search-grants.html](https://www.grants.gov/web/grants/search-grants.html)    | [grants.gov/search-grants](https://grants.gov/search-grants)    |
| [www.grants.gov/web/grants/forms/sf-424-family.html](https://www.grants.gov/web/grants/forms/sf-424-family.html) | [grants.gov/forms/forms-repository/sf-424-family](https://grants.gov/forms/forms-repository/sf-424-family) |
| [www.cdc.gov/grants/dictionary/index.html](https://www.cdc.gov/grants/dictionary/index.html) | [www.cdc.gov/grants/dictionary-of-terms/](https://www.cdc.gov/grants/dictionary-of-terms/) | 

So that's super and we love it.

#### 2. adds a script that we can use to grab all links across all NOFOs

Pretty simple: added a script that loops through all non-archived NOFOs and will pull all external links. This helps us do analysis on them if we need to for some reason.  (In this case, our reason was to manually replace bad links)

#### 3. Removes an old view that would download a list of links from an individual NOFO

We don't need it! So let's axe it.

