### PR TITLE
Create single-source Before You Begin page variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Condense Before You Begin page for NOFO: CDC-RFA-PS-25-0008
+  - This will be a sole-source thing, but for now it's just for this one
+
 ### Removed
 
 - Remove admin-only view to export all NOFO links

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -882,6 +882,19 @@ div[role="heading"] {
   font-weight: 600;
 }
 
+.before-you-begin--sole-source .section--before-you-begin--psuedo-header {
+  font-size: 14pt;
+}
+
+.before-you-begin--sole-source
+  .section--before-you-begin--psuedo-header:first-of-type {
+  margin-bottom: 20px;
+}
+
+.before-you-begin--sole-source .callout-box--keyboard {
+  margin-top: 30px;
+}
+
 /* Section title page */
 
 .section--title-page {

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -217,7 +217,7 @@
     {% endspaceless %}
   </section>
 
-  <section id="section--before-you-begin" class="before-you-begin">
+  <section id="section--before-you-begin" class="before-you-begin{% if nofo.number|lower == 'cdc-rfa-ps-25-0008' %} before-you-begin--sole-source{% endif %}">
     <div class="section--before-you-begin--icon">
       {% if "thin" in nofo.icon_style %}
         {% include "includes/icons/thin/0-before.svg" %}
@@ -228,14 +228,18 @@
     <h2 id="section--before-you-begin--heading">Before you begin</h2>
     <div class="before-you-begin--content">
 
-      <p>If you believe you are a good candidate for this funding opportunity, secure your <a href="https://sam.gov">SAM.gov</a> and <a href="https://grants.gov">Grants.gov</a> registrations now. If you are already registered, make sure your registrations are active and up-to-date.</p>
-      <p class="section--before-you-begin--psuedo-header">SAM.gov registration (this can take several weeks)</p>
-      <p>You must have an active account with SAM.gov. This includes having a Unique Entity Identifier (UEI).</p>
-      <a href="#step-2-get-ready-to-apply">See Step 2: Get Ready to Apply</a>
+      {% if nofo.number|lower == 'cdc-rfa-ps-25-0008' %}
+        <p class="section--before-you-begin--psuedo-header">Make sure you are an approved applicant for this funding opportunity.</p>
+      {% else %}
+        <p>If you believe you are a good candidate for this funding opportunity, secure your <a href="https://sam.gov">SAM.gov</a> and <a href="https://grants.gov">Grants.gov</a> registrations now. If you are already registered, make sure your registrations are active and up-to-date.</p>
+        <p class="section--before-you-begin--psuedo-header">SAM.gov registration (this can take several weeks)</p>
+        <p>You must have an active account with SAM.gov. This includes having a Unique Entity Identifier (UEI).</p>
+        <a href="#step-2-get-ready-to-apply">See Step 2: Get Ready to Apply</a>
 
-      <p class="section--before-you-begin--psuedo-header">Grants.gov registration (this can take several days)</p>
-      <p>You must have an active Grants.gov registration. Doing so requires a Login.gov registration as well.</p>
-      <a href="#step-2-get-ready-to-apply">See Step 2: Get Ready to Apply</a>
+        <p class="section--before-you-begin--psuedo-header">Grants.gov registration (this can take several days)</p>
+        <p>You must have an active Grants.gov registration. Doing so requires a Login.gov registration as well.</p>
+        <a href="#step-2-get-ready-to-apply">See Step 2: Get Ready to Apply</a>
+      {% endif %}
 
       <p class="section--before-you-begin--psuedo-header">Apply by the application due date</p>
       {% if "|" in nofo.application_deadline %}
@@ -249,8 +253,6 @@
         <p>Applications are due by 11:59 p.m. Eastern Time on {{ nofo.application_deadline|split_char_and_remove:"-" }}.</p>
       {% endif %}
 
-      {# Show "Adobe Reader" callout box in this section on non-HRSA 014 NOFOs #}
-      {% if nofo.number|lower != 'hrsa-24-014' %}
       <div class="callout-box callout-box--icon callout-box--keyboard">
         <div class="callout-box--contents">
             {% if "thin" in nofo.icon_style %}
@@ -261,7 +263,6 @@
             <p>To help you find what you need, this NOFO uses internal links. In Adobe Reader, you can go back to where you were by pressing Alt + Left Arrow (Windows) or Command + Left Arrow (Mac) on your keyboard.</p>
         </div>
       </div>
-      {% endif %}
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

This PR creates a "single-source" BYB page variant for NOFO CDC 0008.

In the future, this needs to be more general purpose, but for TODAY it will work.

| before | after  |
|--------|--------|
|  <img width="831" alt="Screenshot 2024-11-22 at 4 38 59 PM" src="https://github.com/user-attachments/assets/a411af89-18c2-4f44-919e-878be49daa14">     |    <img width="831" alt="Screenshot 2024-11-22 at 4 37 38 PM" src="https://github.com/user-attachments/assets/684ced55-90ee-4cf5-bf35-c85773b50f65">  |

