### PR TITLE
CSS tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Condense Before You Begin page for NOFO: CDC-RFA-PS-25-0008
   - This will be a sole-source thing, but for now it's just for this one
+- Tighter line-lengths for `<a>` tags in the application checklist table
+  - Helps to visually distinguish several multi-line anchor tags in the same cell
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Add script to pull links from all non-archived NOFOs
 - Add inline image for CDC-RFA-JG-25-0055
 - New cover images for HRSA-25-036, HRSA-25-080
+- Add dash (⁃) as bullet for all quadruple nested bullets
 
 ### Changed
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -472,16 +472,40 @@ body.cms-white table td img.usa-icon--check_box_outline_blank {
   box-shadow: inset 0px 0px 5px 3px var(--color--table-blue);
 }
 
-.section--step-5-submit-your-application table tr td.usa-icon__td > div {
+.section--step-5-submit-your-application
+  .section--content
+  table
+  tr
+  td.usa-icon__td
+  > div {
   display: flex;
 }
 
-.section--step-5-submit-your-application table tr td.usa-icon__td {
+.section--step-5-submit-your-application
+  .section--content
+  table
+  tr
+  td.usa-icon__td {
   vertical-align: top;
 }
 
-.section--step-5-submit-your-application table tr td.usa-icon__td span {
+.section--step-5-submit-your-application
+  .section--content
+  table
+  tr
+  td.usa-icon__td
+  span {
   line-height: 1.25;
+}
+
+/* Cinch up the lines on individual <a> tags in the application checklist */
+.section--step-5-submit-your-application .section--content table td a {
+  display: inline-block;
+  line-height: 1.3;
+}
+
+.section--step-5-submit-your-application .section--content table td > br + a {
+  margin-top: 5px;
 }
 
 ul,

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -535,6 +535,16 @@ ol ol ol {
   list-style-type: lower-roman;
 }
 
+ul ul ul ul {
+  list-style-type: none;
+  padding-left: 20px;
+}
+
+ul ul ul ul > li:before {
+  content: "⁃";
+  margin-right: 5px;
+}
+
 img.usa-icon--check_box_outline_blank {
   height: 17px;
   width: 17px;


### PR DESCRIPTION
## Summary

This PR includes 2 small CSS tweaks that make the NOFO look a bit nicer:

1. More space between multi-line anchors in the application checklist
2. Add a dash (`⁃`) character for quadruple nested bullets.

#### 1. More space between multi-line anchors in the application checklist

Previously, several multiline anchor tags in a row would just show up one after another with equal spaces between all lines, leading to an unclear separation between individual `<a>` elements. 

Make the line length a bit smaller and add some bottom margin to stacked anchors fixes this.

| before | after  |
|--------|--------|
|   Unclear where line breaks are in second cell with 4 anchor lines     |  Line breaks are more evident       |
| <img width="691" alt="Screenshot 2024-11-27 at 3 49 13 PM" src="https://github.com/user-attachments/assets/ea434939-4758-4a00-8f3e-55a625d18ad3"> | <img width="691" alt="Screenshot 2024-11-27 at 3 48 26 PM" src="https://github.com/user-attachments/assets/7b397547-da4f-4f90-8cdb-9fa354d8738d"> |

#### 2. Add a dash (`⁃`) character for quadruple nested bullets

It's crazy how many bullets some people need. 

Once you went past 3, they would repeat themselves. Now, we have a 4th level for visual differentiation.

| before | after  |
|--------|--------|
| <img width="578" alt="Screenshot 2024-11-27 at 3 59 37 PM" src="https://github.com/user-attachments/assets/fe32c385-bd43-48c8-95d3-70b79ab7e660"> | <img width="578" alt="Screenshot 2024-11-27 at 3 59 07 PM" src="https://github.com/user-attachments/assets/41c3c2e2-9a27-42af-b14b-0c8b961ce0b3"> |


