### PR TITLE
Contain "Page break" hit area to just the radio button and label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Reduce horizontal hit area for radio buttons (was previously full-width)
 - Link to NOFO in success message for JSON import
 
 ## [1.38.0] - 2023-11-29

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -43,12 +43,20 @@ a:visited {
   color: var(--color--usa-link-visited);
 }
 
-footer .usa-footer__primary-link:visited {
-  color: var(--color--text-default);
+/* Util classes */
+
+.inline-block {
+  display: inline-block;
 }
 
 .small-caps {
   font-variant: small-caps;
+}
+
+/* General USDS CSS */
+
+footer .usa-footer__primary-link:visited {
+  color: var(--color--text-default);
 }
 
 .usa-combo-box__input,
@@ -835,14 +843,18 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   margin-bottom: 16px;
 }
 
-fieldset {
+.subsection_edit fieldset {
   margin: 0;
   padding: 0;
   border: none;
 }
 
-fieldset legend:not(.legend--bootstrap) {
+.subsection_edit fieldset legend:not(.legend--bootstrap) {
   margin-bottom: -0.5rem;
+}
+
+.subsection_edit fieldset .usa-legend.legend--bootstrap {
+  margin-bottom: 0.85rem;
 }
 
 .table--callout-box {

--- a/bloom_nofos/nofos/templates/nofos/subsection_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_edit.html
@@ -131,7 +131,7 @@
       {% endif %}
 
       <!-- html_class -->
-      <div class="form-group">
+      <div class="form-group inline-block">
         <fieldset class="usa-fieldset">
           <legend class="usa-legend legend--bootstrap">Has page break{% if 'landscape' in nofo.theme %} or column break{% endif %}?</legend>
           {% if form.html_class.value %}


### PR DESCRIPTION
## Summary

This PR fixes a bug where the hit area was full-page width before, which meant that you could select "page break" without intending to do it.

Now it is the same length as the longest label, which will reduce unintentional clicks.

See below for a visual illustration of how much space was actually being given to the radio buttons/labels.

| before | after  |
|--------|--------|
|  containing box is full-width, meaning you can easily select it unintentionally      |   containing box is only as long as the longest radio button label     |
| <img width="1557" alt="Screenshot 2024-12-02 at 12 33 39 PM" src="https://github.com/user-attachments/assets/ac5f5565-a75f-4230-b94f-0eca411cd9bf"> | <img width="1557" alt="Screenshot 2024-12-02 at 12 33 26 PM" src="https://github.com/user-attachments/assets/55f62eeb-5fc5-45ed-b467-4fa8a51805a5"> |



