### PR TITLE
Automatically flip back "LIVE" mode into "TEST" mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Setting "Live" mode is only good for 5 minutes
+  - After 5 minutes have gone by, it will revert to "Test" mode again
+
 ### Fixed
 
 - Reduce horizontal hit area for radio buttons (was previously full-width)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Creating superusers from the terminal doesn't set the 'force_password_reset' flag
 - Reduce horizontal hit area for radio buttons (was previously full-width)
 - Link to NOFO in success message for JSON import
+- Remove borders and left padding from `<fieldset>` elements by default
 
 ## [1.38.0] - 2023-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Creating superusers from the terminal doesn't set the 'force_password_reset' flag
 - Reduce horizontal hit area for radio buttons (was previously full-width)
 - Link to NOFO in success message for JSON import
 

--- a/bloom_nofos/bloom_nofos/context_processors.py
+++ b/bloom_nofos/bloom_nofos/context_processors.py
@@ -1,9 +1,14 @@
 from constance import config
 from django.conf import settings
 
+from .utils import is_docraptor_test_mode_active
+
 
 def add_docraptor_test_mode(request):
-    return {"DOCRAPTOR_TEST_MODE": getattr(config, "DOCRAPTOR_TEST_MODE")}
+    last_updated = getattr(config, "DOCRAPTOR_TEST_MODE")
+    docraptor_test_mode = is_docraptor_test_mode_active(last_updated)
+
+    return {"DOCRAPTOR_TEST_MODE": docraptor_test_mode}
 
 
 def add_github_sha(request):

--- a/bloom_nofos/bloom_nofos/context_processors.py
+++ b/bloom_nofos/bloom_nofos/context_processors.py
@@ -1,14 +1,14 @@
 from constance import config
 from django.conf import settings
 
-from .utils import is_docraptor_test_mode_active
+from .utils import is_docraptor_live_mode_active
 
 
-def add_docraptor_test_mode(request):
-    last_updated = getattr(config, "DOCRAPTOR_TEST_MODE")
-    docraptor_test_mode = is_docraptor_test_mode_active(last_updated)
+def add_docraptor_live_mode(request):
+    last_updated = getattr(config, "DOCRAPTOR_LIVE_MODE")
+    docraptor_live_mode = is_docraptor_live_mode_active(last_updated)
 
-    return {"DOCRAPTOR_TEST_MODE": docraptor_test_mode}
+    return {"DOCRAPTOR_LIVE_MODE": docraptor_live_mode}
 
 
 def add_github_sha(request):

--- a/bloom_nofos/bloom_nofos/forms.py
+++ b/bloom_nofos/bloom_nofos/forms.py
@@ -2,6 +2,6 @@ from django import forms
 
 
 class DocraptorTestModeForm(forms.Form):
-    docraptor_test_mode = forms.BooleanField(
-        required=False, label="Docraptor test mode"
+    docraptor_live_mode = forms.BooleanField(
+        required=False, label="Docraptor Live Mode"
     )

--- a/bloom_nofos/bloom_nofos/settings.py
+++ b/bloom_nofos/bloom_nofos/settings.py
@@ -12,10 +12,12 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 import sys
+from datetime import datetime
 from pathlib import Path
 
 import environ
 import tomli
+from django.utils.timezone import now
 
 from .utils import cast_to_boolean
 
@@ -460,9 +462,9 @@ CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 
 CONSTANCE_CONFIG = {
     "DOCRAPTOR_TEST_MODE": (
-        True,
-        "Whether to print PDFs with watermarks. If True, documents will be watermarked.",
-        bool,
+        now(),
+        "Whether to print PDFs with watermarks. If timestamp is older than 5 mins, documents will be watermarked.",
+        datetime,
     ),
     "WORD_IMPORT_STRICT_MODE": (
         False,

--- a/bloom_nofos/bloom_nofos/settings.py
+++ b/bloom_nofos/bloom_nofos/settings.py
@@ -463,7 +463,7 @@ CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 CONSTANCE_CONFIG = {
     "DOCRAPTOR_LIVE_MODE": (
         now(),
-        "Whether to print PDFs with watermarks. If timestamp is older than 2 mins, documents will be watermarked.",
+        "Whether to print PDFs with watermarks. If timestamp is older than 5 mins, documents will be watermarked.",
         datetime,
     ),
     "WORD_IMPORT_STRICT_MODE": (

--- a/bloom_nofos/bloom_nofos/settings.py
+++ b/bloom_nofos/bloom_nofos/settings.py
@@ -150,7 +150,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "djversion.context_processors.version",
-                "bloom_nofos.context_processors.add_docraptor_test_mode",
+                "bloom_nofos.context_processors.add_docraptor_live_mode",
                 "bloom_nofos.context_processors.add_github_sha",
             ],
         },
@@ -455,15 +455,15 @@ if is_prod:
 # Document IPs for our PDF generating app
 DOCRAPTOR_IPS = env.get_value("DOCRAPTOR_IPS", default="")
 DOCRAPTOR_API_KEY = env.get_value("DOCRAPTOR_API_KEY", default="")
-DOCRAPTOR_TEST_MODE = True
+DOCRAPTOR_LIVE_MODE = True
 
 # Add a field for constance
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 
 CONSTANCE_CONFIG = {
-    "DOCRAPTOR_TEST_MODE": (
+    "DOCRAPTOR_LIVE_MODE": (
         now(),
-        "Whether to print PDFs with watermarks. If timestamp is older than 5 mins, documents will be watermarked.",
+        "Whether to print PDFs with watermarks. If timestamp is older than 2 mins, documents will be watermarked.",
         datetime,
     ),
     "WORD_IMPORT_STRICT_MODE": (

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -843,12 +843,6 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   margin-bottom: 16px;
 }
 
-.subsection_edit fieldset {
-  margin: 0;
-  padding: 0;
-  border: none;
-}
-
 .subsection_edit fieldset legend:not(.legend--bootstrap) {
   margin-bottom: -0.5rem;
 }

--- a/bloom_nofos/bloom_nofos/templates/base.html
+++ b/bloom_nofos/bloom_nofos/templates/base.html
@@ -20,10 +20,10 @@
           </em>
           {% if user.is_authenticated %}
             <a class="inline-block usa-tag--link" href="{% url 'test_mode' %}{% if request.path|slice:"-5:" == "/edit" %}?next={{ request.path }}{% endif %}">
-              {% if DOCRAPTOR_TEST_MODE %}
-                <span class="usa-tag bg-accent-cool-dark">Test</span>
-              {% else %}
+              {% if DOCRAPTOR_LIVE_MODE %}
                 <span class="usa-tag bg-green">Live</span>
+              {% else %}
+                <span class="usa-tag bg-accent-cool-dark">Test</span>
               {% endif %}
             </a>
           {% endif %}

--- a/bloom_nofos/bloom_nofos/templates/docraptor_live_mode.html
+++ b/bloom_nofos/bloom_nofos/templates/docraptor_live_mode.html
@@ -1,18 +1,19 @@
 {% extends 'base.html' %}
 
 {% block title %}
-    NOFO Contstance
+    PDF print mode
 {% endblock %}
 
 {% block content %}
-  <h1 class="font-heading-xl margin-y-0">Docraptor test mode</h1>
-  <p class="font-sans-md">Currently, test mode is <strong>{% if DOCRAPTOR_LIVE_MODE %}OFF{% else %}ON{% endif %}</strong>.</p>
+  <h1 class="font-heading-xl margin-y-0">PDF print mode</h1>
+  <p class="font-sans-md">Currently, the NOFO Builder is in <strong>{% if DOCRAPTOR_LIVE_MODE %}“Live” mode{% else %}“Test” mode{% endif %}</strong>.</p>
   {% if DOCRAPTOR_LIVE_MODE %}
-    <p>In “Live” mode, PDFs are not watermarked, but there is a limit of <a href="https://app.docraptor.com/signup">1,250 a month</a>.</p>
     <p>Use “Live” mode when you have a good-copy PDF ready to send back to our OpDivs.</p>
+    <p>In “Live” mode, PDFs are not watermarked, but there is a limit of <a href="https://app.docraptor.com/signup">1,250 a month</a>.</p>
+    <p>“Live” mode lasts for <strong>5 minutes</strong>, then it flips back to “Test” mode.</p>
   {% else %}
     <p>In “Test” mode, PDFs are watermarked with a DocRaptor banner.</p>
-    <p>Test PDFs are free, so we recommend using test mode until you are ready to send.</p>
+    <p>Generating Test PDFs is unlimited, so we recommend using test mode until you are ready to send.</p>
   {% endif %}
   
   <br />

--- a/bloom_nofos/bloom_nofos/templates/docraptor_live_mode.html
+++ b/bloom_nofos/bloom_nofos/templates/docraptor_live_mode.html
@@ -6,13 +6,13 @@
 
 {% block content %}
   <h1 class="font-heading-xl margin-y-0">Docraptor test mode</h1>
-  <p class="font-sans-md">Currently, test mode is <strong>{% if DOCRAPTOR_TEST_MODE %}ON{% else %}OFF{% endif %}</strong>.</p>
-  {% if DOCRAPTOR_TEST_MODE %}
+  <p class="font-sans-md">Currently, test mode is <strong>{% if DOCRAPTOR_LIVE_MODE %}OFF{% else %}ON{% endif %}</strong>.</p>
+  {% if DOCRAPTOR_LIVE_MODE %}
+    <p>In “Live” mode, PDFs are not watermarked, but there is a limit of <a href="https://app.docraptor.com/signup">1,250 a month</a>.</p>
+    <p>Use “Live” mode when you have a good-copy PDF ready to send back to our OpDivs.</p>
+  {% else %}
     <p>In “Test” mode, PDFs are watermarked with a DocRaptor banner.</p>
     <p>Test PDFs are free, so we recommend using test mode until you are ready to send.</p>
-  {% else %}
-    <p>In “Live” mode, PDFs are not watermarked, but there is a limit of <a href="https://app.docraptor.com/signup">325 a month</a>.</p>
-    <p>Use “Live” mode when you have a good-copy PDF ready to send back to our OpDivs.</p>
   {% endif %}
   
   <br />
@@ -25,27 +25,27 @@
       <div class="usa-radio">
         <input
           class="usa-radio__input"
-          id="docraptor_test_mode--true"
+          id="docraptor_live_mode--true"
           type="radio"
-          name="docraptor_test_mode"
+          name="docraptor_live_mode"
           value="true"
-          {% if DOCRAPTOR_TEST_MODE %}checked="checked"{% endif %}
+          {% if DOCRAPTOR_LIVE_MODE %}checked="checked"{% endif %}
         />
-        <label class="usa-radio__label" for="docraptor_test_mode--true"
-          >Test mode</label
+        <label class="usa-radio__label" for="docraptor_live_mode--true"
+          >Live mode</label
         >
       </div>
       <div class="usa-radio">
         <input
           class="usa-radio__input"
-          id="docraptor_test_mode--false"
+          id="docraptor_live_mode--false"
           type="radio"
-          name="docraptor_test_mode"
+          name="docraptor_live_mode"
           value="false"
-          {% if not DOCRAPTOR_TEST_MODE %}checked="checked"{% endif %}
+          {% if not DOCRAPTOR_LIVE_MODE %}checked="checked"{% endif %}
         />
-        <label class="usa-radio__label" for="docraptor_test_mode--false"
-          >Live mode</label
+        <label class="usa-radio__label" for="docraptor_live_mode--false"
+          >Test mode</label
         >
       </div>
     

--- a/bloom_nofos/bloom_nofos/templates/includes/print_button.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/print_button.html
@@ -2,7 +2,7 @@
   <li class="usa-button-group__item">
     <form method="post" action="{% url 'nofos:print_pdf' nofo.id %}?mode=inline#zoom=100" target="_blank">
       {% csrf_token %}
-      <button type="submit" class="usa-button button-group--primary font-sans-xs" aria-label="View{% if DOCRAPTOR_TEST_MODE %} test{% endif %} NOFO (opens in a new tab)" {% if 'localhost' in request.get_host %}disabled{% endif %}>
+      <button type="submit" class="usa-button button-group--primary font-sans-xs" aria-label="View{% if not DOCRAPTOR_LIVE_MODE %} test{% endif %} NOFO (opens in a new tab)" {% if 'localhost' in request.get_host %}disabled{% endif %}>
         View PDF
       </button>
     </form>

--- a/bloom_nofos/bloom_nofos/utils.py
+++ b/bloom_nofos/bloom_nofos/utils.py
@@ -28,7 +28,11 @@ def cast_to_boolean(value_str):
 
 def is_docraptor_live_mode_active(last_updated):
     # Check if the timestamp is more than 2 minutes old
-    if last_updated and now() - last_updated < timedelta(minutes=2):
+    if last_updated and now() - last_updated < get_timedelta_for_docraptor_live_mode():
         return True
 
     return False
+
+
+def get_timedelta_for_docraptor_live_mode():
+    return timedelta(minutes=5)

--- a/bloom_nofos/bloom_nofos/utils.py
+++ b/bloom_nofos/bloom_nofos/utils.py
@@ -26,9 +26,9 @@ def cast_to_boolean(value_str):
         raise ValueError(f"Value '{value_str}' is not a valid boolean string")
 
 
-def is_docraptor_test_mode_active(last_updated):
-    # Check if the timestamp is more than 5 minutes old
-    if last_updated and now() - last_updated < timedelta(minutes=5):
-        return False
+def is_docraptor_live_mode_active(last_updated):
+    # Check if the timestamp is more than 2 minutes old
+    if last_updated and now() - last_updated < timedelta(minutes=2):
+        return True
 
-    return True
+    return False

--- a/bloom_nofos/bloom_nofos/utils.py
+++ b/bloom_nofos/bloom_nofos/utils.py
@@ -1,3 +1,6 @@
+from django.utils.timezone import now, timedelta
+
+
 def cast_to_boolean(value_str):
     """
     Cast a string value to a boolean.
@@ -21,3 +24,11 @@ def cast_to_boolean(value_str):
         return False
     else:
         raise ValueError(f"Value '{value_str}' is not a valid boolean string")
+
+
+def is_docraptor_test_mode_active(last_updated):
+    # Check if the timestamp is more than 5 minutes old
+    if last_updated and now() - last_updated < timedelta(minutes=5):
+        return False
+
+    return True

--- a/bloom_nofos/bloom_nofos/views.py
+++ b/bloom_nofos/bloom_nofos/views.py
@@ -6,6 +6,7 @@ from django.utils.timezone import now, timedelta
 from django.views.generic import TemplateView
 
 from .forms import DocraptorTestModeForm
+from .utils import get_timedelta_for_docraptor_live_mode
 
 
 def index(request):
@@ -33,16 +34,14 @@ class TestModeView(RedirectURLMixin, TemplateView):
 
             # If LIVE MODE is TRUE, set the timestamp to the current time
             if form.cleaned_data["docraptor_live_mode"]:
-                # Set the timestamp to 5 minutes and 1 second in the past
                 setattr(config, "DOCRAPTOR_LIVE_MODE", now())
 
-            # If LIVE MODE is False, set the timestamp to 2 mins and 1 second
+            # If LIVE MODE is False, set the timestamp to current time minus the timedelta
             else:
-                # Set the timestamp to the current time
                 setattr(
                     config,
                     "DOCRAPTOR_LIVE_MODE",
-                    now() - timedelta(minutes=2, seconds=1),
+                    now() - get_timedelta_for_docraptor_live_mode(),
                 )
 
             next_url = request.GET.get("next")

--- a/bloom_nofos/bloom_nofos/views.py
+++ b/bloom_nofos/bloom_nofos/views.py
@@ -25,24 +25,25 @@ def server_error(request, exception=None):
 
 
 class TestModeView(RedirectURLMixin, TemplateView):
-    template_name = "docraptor_test_mode.html"
+    template_name = "docraptor_live_mode.html"
 
     def post(self, request, *args, **kwargs):
         form = DocraptorTestModeForm(request.POST)
         if form.is_valid():
 
-            # If TEST MODE is TRUE, set an expired timestamp
-            if form.cleaned_data["docraptor_test_mode"]:
+            # If LIVE MODE is TRUE, set the timestamp to the current time
+            if form.cleaned_data["docraptor_live_mode"]:
                 # Set the timestamp to 5 minutes and 1 second in the past
-                setattr(
-                    config,
-                    "DOCRAPTOR_TEST_MODE",
-                    now() - timedelta(minutes=5, seconds=1),
-                )
-            # If TEST MODE is False, set it to LIVE MODE with now()
+                setattr(config, "DOCRAPTOR_LIVE_MODE", now())
+
+            # If LIVE MODE is False, set the timestamp to 2 mins and 1 second
             else:
                 # Set the timestamp to the current time
-                setattr(config, "DOCRAPTOR_TEST_MODE", now())
+                setattr(
+                    config,
+                    "DOCRAPTOR_LIVE_MODE",
+                    now() - timedelta(minutes=2, seconds=1),
+                )
 
             next_url = request.GET.get("next")
             if next_url and url_has_allowed_host_and_scheme(

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -45,10 +45,10 @@
           </em>
           {% if user.is_authenticated %}
             <a class="inline-block usa-tag--link" href="{% url 'test_mode' %}">
-              {% if DOCRAPTOR_TEST_MODE %}
-                <span class="usa-tag bg-accent-cool-dark">Test</span>
-              {% else %}
+              {% if DOCRAPTOR_LIVE_MODE %}
                 <span class="usa-tag bg-green">Live</span>
+              {% else %}
+                <span class="usa-tag bg-accent-cool-dark">Test</span>
               {% endif %}
             </a>
           {% endif %}

--- a/bloom_nofos/nofos/templates/nofos/subsection_create.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_create.html
@@ -28,7 +28,7 @@
 
   <form class="form" method="post">
     {% csrf_token %}
-    <fieldset>
+    <fieldset class="usa-fieldset">
 
       {% if form.non_field_errors %}
         <legend class="legend--bootstrap">

--- a/bloom_nofos/nofos/templates/nofos/subsection_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_edit.html
@@ -34,7 +34,7 @@
 
   <form class="form" method="post">
     {% csrf_token %}
-    <fieldset>
+    <fieldset class="usa-fieldset">
 
       {% if form.non_field_errors %}
         <legend class="legend--bootstrap">
@@ -203,6 +203,7 @@
               None
             </label>
           </div>
+        </fieldset>
       </div>
 
       <!-- body -->

--- a/bloom_nofos/nofos/tests/test_utils.py
+++ b/bloom_nofos/nofos/tests/test_utils.py
@@ -30,8 +30,9 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertEqual(event.object_id, str(self.nofo.id))
         self.assertEqual(event.user, self.user)
 
-    def test_valid_event_type_nofo_print_test(self):
-        with override_config(DOCRAPTOR_TEST_MODE=True):
+    # TODO solve this
+    def x_test_valid_event_type_nofo_print_test(self):
+        with override_config(DOCRAPTOR_LIVE_MODE=True):
             create_nofo_audit_event("nofo_print", self.nofo, self.user)
 
         event = CRUDEvent.objects.last()
@@ -41,7 +42,8 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertEqual(changed_fields["print_mode"], ["test"])
         self.assertTrue("updated" in changed_fields)
 
-    def test_valid_event_type_nofo_print_live(self):
+    # TODO solve this
+    def x_test_valid_event_type_nofo_print_live(self):
         with override_config(DOCRAPTOR_TEST_MODE=False):
             create_nofo_audit_event("nofo_print", self.nofo, self.user)
 
@@ -52,7 +54,8 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertEqual(changed_fields["print_mode"], ["live"])
         self.assertTrue("updated" in changed_fields)
 
-    def test_valid_event_type_nofo_import(self):
+    # TODO solve this
+    def x_test_valid_event_type_nofo_import(self):
         create_nofo_audit_event("nofo_import", self.nofo, self.user)
 
         event = CRUDEvent.objects.last()
@@ -61,7 +64,8 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertNotIn("print_mode", changed_fields)
         self.assertTrue("updated" in changed_fields)
 
-    def test_valid_event_type_nofo_reimport(self):
+    # TODO solve this
+    def x_test_valid_event_type_nofo_reimport(self):
         create_nofo_audit_event("nofo_reimport", self.nofo, self.user)
 
         event = CRUDEvent.objects.last()
@@ -70,7 +74,8 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertNotIn("print_mode", changed_fields)
         self.assertTrue("updated" in changed_fields)
 
-    def test_invalid_event_type_raises_error(self):
+    # TODO solve this
+    def x_test_invalid_event_type_raises_error(self):
         # Test with an invalid event_type
         with self.assertRaises(ValueError) as context:
             create_nofo_audit_event("nofo_deleted", self.nofo, self.user)

--- a/bloom_nofos/nofos/tests/test_utils.py
+++ b/bloom_nofos/nofos/tests/test_utils.py
@@ -1,7 +1,9 @@
 import json
+from datetime import timedelta
 
 from constance.test import override_config
 from django.test import TestCase
+from django.utils.timezone import now
 from easyaudit.models import CRUDEvent
 from nofos.models import Nofo
 from nofos.utils import (
@@ -30,9 +32,11 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertEqual(event.object_id, str(self.nofo.id))
         self.assertEqual(event.user, self.user)
 
-    # TODO solve this
-    def x_test_valid_event_type_nofo_print_test(self):
-        with override_config(DOCRAPTOR_LIVE_MODE=True):
+    def test_valid_event_type_nofo_print_test(self):
+        # Set DOCRAPTOR_LIVE_MODE to a past timestamp to simulate "test" mode
+        with override_config(
+            DOCRAPTOR_LIVE_MODE=now() - timedelta(minutes=5, seconds=1)
+        ):
             create_nofo_audit_event("nofo_print", self.nofo, self.user)
 
         event = CRUDEvent.objects.last()
@@ -42,9 +46,9 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertEqual(changed_fields["print_mode"], ["test"])
         self.assertTrue("updated" in changed_fields)
 
-    # TODO solve this
-    def x_test_valid_event_type_nofo_print_live(self):
-        with override_config(DOCRAPTOR_TEST_MODE=False):
+    def test_valid_event_type_nofo_print_live(self):
+        # Set DOCRAPTOR_LIVE_MODE to current timestamp to simulate "live" mode
+        with override_config(DOCRAPTOR_LIVE_MODE=now()):
             create_nofo_audit_event("nofo_print", self.nofo, self.user)
 
         event = CRUDEvent.objects.last()
@@ -54,8 +58,7 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertEqual(changed_fields["print_mode"], ["live"])
         self.assertTrue("updated" in changed_fields)
 
-    # TODO solve this
-    def x_test_valid_event_type_nofo_import(self):
+    def test_valid_event_type_nofo_import(self):
         create_nofo_audit_event("nofo_import", self.nofo, self.user)
 
         event = CRUDEvent.objects.last()
@@ -64,8 +67,7 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertNotIn("print_mode", changed_fields)
         self.assertTrue("updated" in changed_fields)
 
-    # TODO solve this
-    def x_test_valid_event_type_nofo_reimport(self):
+    def test_valid_event_type_nofo_reimport(self):
         create_nofo_audit_event("nofo_reimport", self.nofo, self.user)
 
         event = CRUDEvent.objects.last()
@@ -74,8 +76,7 @@ class CreateNofoAuditEventTests(TestCase):
         self.assertNotIn("print_mode", changed_fields)
         self.assertTrue("updated" in changed_fields)
 
-    # TODO solve this
-    def x_test_invalid_event_type_raises_error(self):
+    def test_invalid_event_type_raises_error(self):
         # Test with an invalid event_type
         with self.assertRaises(ValueError) as context:
             create_nofo_audit_event("nofo_deleted", self.nofo, self.user)

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -34,7 +34,7 @@ def create_nofo_audit_event(event_type, nofo, user):
     # Add print_mode if the event_type involves printing
     if event_type == "nofo_print":
         changed_fields_json["print_mode"] = [
-            "test" if config.DOCRAPTOR_TEST_MODE else "live"
+            "live" if config.DOCRAPTOR_LIVE_MODE else "test"
         ]
 
     # Create the audit log event

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -8,6 +8,8 @@ from django.utils import timezone
 from easyaudit.models import CRUDEvent
 from slugify import slugify
 
+from bloom_nofos.utils import is_docraptor_live_mode_active
+
 
 def clean_string(string):
     """Cleans the given string by removing extra whitespace."""
@@ -34,7 +36,11 @@ def create_nofo_audit_event(event_type, nofo, user):
     # Add print_mode if the event_type involves printing
     if event_type == "nofo_print":
         changed_fields_json["print_mode"] = [
-            "live" if config.DOCRAPTOR_LIVE_MODE else "test"
+            (
+                "live"
+                if is_docraptor_live_mode_active(config.DOCRAPTOR_LIVE_MODE)
+                else "test"
+            )
         ]
 
     # Create the audit log event

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -26,7 +26,7 @@ from django.views.generic import (
     View,
 )
 
-from bloom_nofos.utils import cast_to_boolean
+from bloom_nofos.utils import cast_to_boolean, is_docraptor_live_mode_active
 
 from .forms import (
     CheckNOFOLinkSingleForm,
@@ -177,7 +177,9 @@ class NofosDetailView(DetailView):
         # get the orientation (eg, "landscape" or "portrait")
         context["nofo_theme_orientation"] = orientation
 
-        context["DOCRAPTOR_TEST_MODE"] = config.DOCRAPTOR_TEST_MODE
+        context["DOCRAPTOR_LIVE_MODE"] = is_docraptor_live_mode_active(
+            config.DOCRAPTOR_LIVE_MODE
+        )
 
         context["nofo_cover_image"] = get_cover_image(self.object)
 
@@ -197,7 +199,9 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
         ) + find_incorrectly_nested_heading_levels(self.object)
         context["h7_headers"] = find_h7_headers(self.object)
 
-        context["DOCRAPTOR_TEST_MODE"] = config.DOCRAPTOR_TEST_MODE
+        context["DOCRAPTOR_LIVE_MODE"] = is_docraptor_live_mode_active(
+            config.DOCRAPTOR_LIVE_MODE
+        )
 
         return context
 
@@ -611,7 +615,9 @@ class PrintNofoAsPDFView(GroupAccessObjectMixin, DetailView):
         try:
             response = doc_api.create_doc(
                 {
-                    "test": config.DOCRAPTOR_TEST_MODE,  # test documents are free but watermarked
+                    "test": not is_docraptor_live_mode_active(
+                        config.DOCRAPTOR_LIVE_MODE
+                    ),  # test documents are free but watermarked
                     "document_url": nofo_url,
                     "document_type": "pdf",
                     "javascript": False,

--- a/bloom_nofos/users/managers.py
+++ b/bloom_nofos/users/managers.py
@@ -36,6 +36,9 @@ class BloomUserManager(BaseUserManager):
         extra_fields.setdefault("is_superuser", True)
         extra_fields.setdefault("is_active", True)
         extra_fields.setdefault("group", "bloom")
+        extra_fields.setdefault(
+            "force_password_reset", False
+        )  # Default to False for superusers
 
         if extra_fields.get("group") != "bloom":
             raise ValueError(_("Superuser must have group=Bloomworks."))

--- a/bloom_nofos/users/templates/users/login.html
+++ b/bloom_nofos/users/templates/users/login.html
@@ -20,7 +20,7 @@
   <form method="post" action="{% url 'users:login' %}">
     {% csrf_token %}
 
-    <fieldset>
+    <fieldset class="usa-fieldset">
       
       {% if form.non_field_errors %}
         <legend>

--- a/bloom_nofos/users/templates/users/user_edit_password.html
+++ b/bloom_nofos/users/templates/users/user_edit_password.html
@@ -21,7 +21,7 @@
   <p>Passwords must be at least 8 characters long.</p>
 
   <form method="post" action="">
-    <fieldset>
+    <fieldset class="usa-fieldset">
       
       {% if form.non_field_errors %}
         <legend>


### PR DESCRIPTION
## Summary

This PR makes one major change, which is detailed in #83: Automatically flip back "LIVE" mode into "TEST" mode.

The idea here is that we have a limit on the number of "Live" NOFOs we can print, so we have invented this notion of "LIVE" and "TEST" modes. Usually you should be using "TEST" mode, since you can generate unlimited PDFs that way. When you need the good copy, change it to LIVE.  

However, not everyone changes it back, and since it is a global setting, we want to make sure that it doesn't stay on all day unintentionally.

This PR makes this change: it creates a 5 minute timer that is activated whenever you set the NOFO Builder to "LIVE". After 5 mins, it goes back to TEST mode. The idea is that you turn it Live, get your PDF, and then leave, and don't worry about it turning back.

I've changed the variable name to be clearer about what is actually happening, so let's hold onto our butts. 

