### PR TITLE
Add new subsection "Important: public information" at the end of step 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,18 +21,22 @@ Versioning since version 1.0.0.
 ### Changed
 
 - All page break visuals say "page-break" now, dropped the "-before", "-after"
-- In the nofo section editor, page breaks added to a section now say "page-break"
+- In the nofo section editor, page breaks added to a section now say
+  "page-break"
   - Previously, it was just a dashed line, but nobody knew what that meant
 - Loop through sections to create breadcrumbs
   - Support "Understand Review, Selection, and Award" as a new section name
 - Preserve existing page breaks when a NOFO is reimported
-  - Note that this is a best-guess effort: if subsections are renamed, page breaks can't be preserved
+  - Note that this is a best-guess effort: if subsections are renamed, page
+    breaks can't be preserved
 - DocRaptor IPs can now be updated by superadmin users
 
 ### Fixed
 
-- H7 warning notice at the top of a NOFO now handles h7s in markdown body as well
-- Preserve heading links for h7 headings (other heading levels worked before, but not h7s)
+- H7 warning notice at the top of a NOFO now handles h7s in markdown body as
+  well
+- Preserve heading links for h7 headings (other heading levels worked before,
+  but not h7s)
 - Remove unneeded nested lists "li > ul > li" for BYB page and appendices
 - Page breaks were not possible to add to subsections without a heading
 - page-break-after was briefly not working
@@ -71,11 +75,13 @@ Versioning since version 1.0.0.
 
 - Styling changes to external links page for acommodate more cols
 - Style maps are better at handling lists when importing .docx files
-- Before You Begin page uses 'sole_source_justification' to show alternate version, not a specific NOFO ID
+- Before You Begin page uses 'sole_source_justification' to show alternate
+  version, not a specific NOFO ID
 
 ### Fixed
 
-- Fixes issue where archiving a NOFO would fail due to validation checks requiring at least one section
+- Fixes issue where archiving a NOFO would fail due to validation checks
+  requiring at least one section
 - Links starting with "file:///" should be flagged as broken links
 - Hotfix to make viewing content tables easier in edit view
 - Return sections by "order" for nofo.get_first_subsection()

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2198,3 +2198,49 @@ def decompose_instructions_tables(soup):
                 or re.match(r".+-specific instructions", table_text_lowercase)
             ):
                 table.decompose()
+
+
+###########################################################
+#################### ADD TO HTML FUNCS ####################
+###########################################################
+
+PUBLIC_INFORMATION_SUBSECTION = {
+    "name": "Important: public information",
+    "order": None,  # This will be dynamically set
+    "tag": "h5",
+    "html_id": "",
+    "is_callout_box": True,
+    "body": """
+When filling out your SF-424 form, pay attention to Box 15: Descriptive Title of Applicant's Project.
+
+We share what you put there with [USAspending](https://www.usaspending.gov). This is where the public goes to learn how the federal government spends their money.
+
+Instead of just a title, insert a short description of your project and what it will do.
+""",
+}
+
+
+def add_final_subsection_to_step_3(sections):
+    # The target section names to search for
+    step_3_names = [
+        "Step 3: Prepare Your Application",
+        "Step 3: Write Your Application",
+    ]
+
+    for section in sections:
+        # case insensitive match
+        if section.get("name", "").lower() in [name.lower() for name in step_3_names]:
+            # Get the subsections array
+            subsections = section.get("subsections", [])
+
+            # Calculate the new order
+            last_order = max((sub.get("order", 0) for sub in subsections), default=0)
+
+            new_public_information_subsection = PUBLIC_INFORMATION_SUBSECTION.copy()
+            new_public_information_subsection["order"] = last_order + 1
+            subsections.append(new_public_information_subsection)
+
+            section["subsections"] = subsections
+
+            # Exit after adding new subsection
+            break

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2226,7 +2226,8 @@ def add_final_subsection_to_step_3(sections):
     """
     This function looks for a section named either "Step 3: Prepare Your Application"
     or "Step 3: Write Your Application" (case-insensitive). If found, it adds a
-    new subsection as the last subsection in the section's "subsections" list.
+    new subsection as the last subsection in the section's "subsections" list,
+    but only if a subsection with the same name doesn't already exist.
 
     Args:
         sections (list of dict): A list of section dictionaries, where each section may
@@ -2234,7 +2235,7 @@ def add_final_subsection_to_step_3(sections):
 
     Side Effects:
         - Modifies the `sections` list in-place by adding a new subsection to the
-          matching "Step 3" section.
+          matching "Step 3" section if it doesn't already exist.
 
     Note:
         This function stops searching after finding and modifying the first matching
@@ -2252,6 +2253,11 @@ def add_final_subsection_to_step_3(sections):
         if section.get("name", "").lower() in [name.lower() for name in step_3_names]:
             # Get the subsections array
             subsections = section.get("subsections", [])
+
+            # Check if subsection already exists
+            public_info_name = PUBLIC_INFORMATION_SUBSECTION["name"]
+            if any(sub.get("name") == public_info_name for sub in subsections):
+                break
 
             # Calculate the new order
             last_order = max((sub.get("order", 0) for sub in subsections), default=0)

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2223,6 +2223,24 @@ Instead of just a title, insert a short description of your project and what it 
 
 
 def add_final_subsection_to_step_3(sections):
+    """
+    This function looks for a section named either "Step 3: Prepare Your Application"
+    or "Step 3: Write Your Application" (case-insensitive). If found, it adds a
+    new subsection as the last subsection in the section's "subsections" list.
+
+    Args:
+        sections (list of dict): A list of section dictionaries, where each section may
+            contain a "name" (str) and a "subsections" (list of dict) key.
+
+    Side Effects:
+        - Modifies the `sections` list in-place by adding a new subsection to the
+          matching "Step 3" section.
+
+    Note:
+        This function stops searching after finding and modifying the first matching
+        "Step 3" section.
+    """
+
     # The target section names to search for
     step_3_names = [
         "Step 3: Prepare Your Application",

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2216,6 +2216,8 @@ When filling out your SF-424 form, pay attention to Box 15: Descriptive Title of
 We share what you put there with [USAspending](https://www.usaspending.gov). This is where the public goes to learn how the federal government spends their money.
 
 Instead of just a title, insert a short description of your project and what it will do.
+
+[See instructions and examples](https://www.hhs.gov/sites/default/files/hhs-writing-award-descriptions.pdf).
 """,
 }
 

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -1203,6 +1203,44 @@ class AddFinalSubsectionTests(TestCase):
         final_subsection = sections[-1].get("subsections", [])[-1]
         self.assertEqual(final_subsection.get("name"), "Subsection 3.1")
 
+    def test_NO_add_duplicate_public_information_section(self):
+        """
+        Test that the public information subsection is not added if it already exists in Step 3.
+        """
+        sections = self._get_sections_1_2_3()
+
+        # Manually add the public information subsection to Step 3
+        sections[2]["subsections"].append(
+            {
+                "name": PUBLIC_INFORMATION_SUBSECTION["name"],
+                "order": 2,
+                "tag": "h5",
+                "html_id": "",
+                "body": PUBLIC_INFORMATION_SUBSECTION["body"],
+                "is_callout_box": True,
+            }
+        )
+
+        # Initial state should have 2 subsections in Step 3
+        self.assertEqual(len(sections[2].get("subsections")), 2)
+
+        # Try to add the public information section again
+        add_final_subsection_to_step_3(sections)
+
+        # Verify no additional subsection was added
+        self.assertEqual(len(sections[0].get("subsections")), 1)  # Step 1 unchanged
+        self.assertEqual(len(sections[1].get("subsections")), 1)  # Step 2 unchanged
+        self.assertEqual(len(sections[2].get("subsections")), 2)  # Step 3 unchanged
+
+        # Verify the last subsection is still the public information subsection
+        final_subsection = sections[2].get("subsections", [])[-1]
+        self.assertEqual(
+            final_subsection.get("name"), PUBLIC_INFORMATION_SUBSECTION["name"]
+        )
+        self.assertEqual(
+            final_subsection.get("body"), PUBLIC_INFORMATION_SUBSECTION["body"]
+        )
+
 
 class AddHeadingsTests(TestCase):
     def setUp(self):

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -54,6 +54,7 @@ from .mixins import (
 )
 from .models import THEME_CHOICES, HeadingValidationError, Nofo, Section, Subsection
 from .nofo import (
+    add_final_subsection_to_step_3,
     add_headings_to_nofo,
     add_page_breaks_to_headings,
     create_nofo,
@@ -302,6 +303,8 @@ class BaseNofoImportView(View):
             return HttpResponseBadRequest(f"500 error: {str(e)}")
 
         filename = uploaded_file.name.strip()
+
+        add_final_subsection_to_step_3(sections)
 
         # 5. Hand off to child for nofo creation
         return self.handle_nofo_create(


### PR DESCRIPTION
## Summary

This PR adds a new subsection to the end of step 3 with the following text:

```
Important: public information

When filling out your SF-424 form, pay attention to Box 15: Descriptive Title of Applicant's Project.

We share what you put there with [USAspending](https://www.usaspending.gov/). This is where the public goes to learn how the federal government spends their money.

Instead of just a title, insert a short description of your project and what it will do.
```

This will be added to the end of any section named "Step 3: Prepare Your Application" or Step 3: Write Your Application".

Once this goes in, it will be added to every uploaded NOFO from now on. This is what we want, right, @admoorgit?

### screenshot

| editing view | html view  |
|--------|--------|
|  this new section in the editing view      |  new section in the HTML view      |
| <img width="1562" alt="Screenshot 2024-12-10 at 10 33 20 AM" src="https://github.com/user-attachments/assets/3a77a860-9f37-4dc4-bff9-14b480ea99f4"> | <img width="1482" alt="Screenshot 2024-12-10 at 10 34 03 AM" src="https://github.com/user-attachments/assets/ecd59ffc-2d76-4975-86fa-727a5f33a8a1"> |


Merging this PR closes #88 
