### PR TITLE
Heading length error messaging

### DIFF
--- a/bloom_nofos/bloom_nofos/templates/400.html
+++ b/bloom_nofos/bloom_nofos/templates/400.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 
 {% block title %}
-	{% if status %}{{ status }}{% else %}400{% endif %} bruv, oops — Bad request
+	{% if status %}{{ status }}{% else %}400{% endif %} - Bad Request
 {% endblock %}
 
 
 {% block content %}
-	<h1 class="font-heading-xl margin-y-0">{% if status %}{{ status }}{% else %}400{% endif %} bruv, oops</h1>
+	<h1 class="font-heading-xl margin-y-0">{% if status %}{{ status }}{% else %}400{% endif %} Error</h1>
 	{% if error_message %}
 		<p><strong>{{ error_message }}</strong></p>
 	{% elif error_message_html %}

--- a/bloom_nofos/bloom_nofos/templates/404.html
+++ b/bloom_nofos/bloom_nofos/templates/404.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 
 {% block title %}
-	404 dawg, sorry — Page not found
+	404 - Page Not Found
 {% endblock %}
 
 
 {% block content %}
-	<h1 class="font-heading-xl margin-y-0">404 dawg, sorry</h1>
-	<p>No fos here or anything else.</p>
-	<p>Maybe go look at:</p>
+	<h1 class="font-heading-xl margin-y-0">404 Error - Page Not Found</h1>
+	<p>The page you are looking for could not be found. Please check the URL and try again.</p>
+	<p>You may want to visit:</p>
 	<ul class="usa-list">
 		<li><a href="{% url 'index' %}">homepage</a></li>
 		<li><a href="{% url 'nofos:nofo_index' %}">all nofos</a></li>

--- a/bloom_nofos/bloom_nofos/templates/500.html
+++ b/bloom_nofos/bloom_nofos/templates/500.html
@@ -1,15 +1,15 @@
 {% extends 'base.html' %}
 
 {% block title %}
-	500 fam, yikes — Server error
+	500 - Server Error
 {% endblock %}
 
 
 {% block content %}
-	<h1 class="font-heading-xl margin-y-0">500 error, yikes</h1>
-  <p>Well dang, buckaroo, you’ve stumbled upon a brand new kinda trouble!</p>
-  <p>If you’re in a fix and want to report it, <a href="https://airtable.com/appdaa5AqUwI8jdOo/pagpyAKIEOyLofFCw/form" target="_blank">fill out a support ticket</a> and we’ll be in touch about it pronto.</p>
-	<p>Why not mosey on back to:</p>
+	<h1 class="font-heading-xl margin-y-0">500 Error - Server Error</h1>
+	<p>Sorry, something went wrong on our end. Our team has been notified of this issue.</p>
+	<p>If you'd like to report this error, please <a href="https://airtable.com/appdaa5AqUwI8jdOo/pagpyAKIEOyLofFCw/form" target="_blank">submit a support ticket</a> and we'll investigate the issue.</p>
+	<p>You may want to visit:</p>
 	<ul class="usa-list">
 		<li><a href="{% url 'index' %}">homepage</a></li>
 		<li><a href="{% url 'nofos:nofo_index' %}">all nofos</a></li>

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import parse_qs, urlparse
 
 import cssutils
+from django.forms import ValidationError
 import markdown
 import requests
 from bs4 import BeautifulSoup, NavigableString, Tag
@@ -189,7 +190,11 @@ def create_nofo(title, sections):
     nofo = Nofo(title=title)
     nofo.number = "NOFO #999"
     nofo.save()
-    return _build_nofo(nofo, sections)
+    try:
+        return _build_nofo(nofo, sections)
+    except ValidationError as e:
+        e.nofo = nofo
+        raise e
 
 
 def overwrite_nofo(nofo, sections):

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -394,6 +394,25 @@ def nofo_import(request, pk=None):
                 add_headings_to_nofo(nofo)
                 add_page_breaks_to_headings(nofo)
                 nofo.filename = filename
+            except ValidationError as e:
+                # Check if this is an html_id length error
+                if "html_id" in e.message_dict and any(
+                    "characters" in msg for msg in e.message_dict["html_id"]
+                ):
+                    return render(
+                        request,
+                        "400.html",
+                        status=422,
+                        context={
+                            "error_message_html": (
+                                "<p>This document contains a heading that is too long.</p>"
+                                "<p>This usually means that a paragraph has been incorrectly styled as a heading. "
+                                "Please check your document's heading styles and try again.</p>"
+                            ),
+                            "status": 422,
+                        },
+                    )
+                return HttpResponseBadRequest("Error creating NOFO: {}".format(e))
             except Exception as e:
                 return HttpResponseBadRequest("Error creating NOFO: {}".format(e))
 

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -405,6 +405,11 @@ def nofo_import(request, pk=None):
                         .order_by("-order")
                         .first()
                     )
+
+                    # Set the NOFO's group to match the user's group
+                    e.nofo.group = request.user.group
+                    e.nofo.save()
+
                     #  TODO: dynamically pull in heading character limit from models.py _or_ error message
                     return render(
                         request,
@@ -415,7 +420,8 @@ def nofo_import(request, pk=None):
                                 f'<p>Your document ("<a href="/nofos/{e.nofo.id}/edit">{e.nofo.short_name or e.nofo.title}</a>") '
                                 "contains a heading that is too long. Headings have a character limit of 511 characters.</p>"
                                 "<p>This usually means that a paragraph has been incorrectly styled as a heading. "
-                                f'The last valid heading was "{last_subsection.name if last_subsection else "none"}", '
+                                f'The last valid heading was "{last_subsection.name if last_subsection else "none"}" '
+                                f'in "{last_subsection.section.name if last_subsection else "none"}", '
                                 "so the incorrectly tagged paragraph is most likely after this heading.</p>"
                             ),
                             "status": 422,

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -399,16 +399,24 @@ def nofo_import(request, pk=None):
                 if "html_id" in e.message_dict and any(
                     "characters" in msg for msg in e.message_dict["html_id"]
                 ):
+                    # Get the last successfully created subsection
+                    last_subsection = (
+                        Subsection.objects.filter(section__nofo=e.nofo)
+                        .order_by("-order")
+                        .first()
+                    )
+                    #  TODO: dynamically pull in heading character limit from models.py _or_ error message
                     return render(
                         request,
                         "400.html",
                         status=422,
                         context={
                             "error_message_html": (
-                                "<p>This document contains a heading that is too long.</p>"
+                                f'<p>Your document ("<a href="/nofos/{e.nofo.id}/edit">{e.nofo.short_name or e.nofo.title}</a>") '
+                                "contains a heading that is too long. Headings have a character limit of 511 characters.</p>"
                                 "<p>This usually means that a paragraph has been incorrectly styled as a heading. "
-                                "Please check your document's heading styles and try again.</p>"
-                                "<p>Headings have a character limit of 511 characters</p>"
+                                f'The last valid heading was "{last_subsection.name if last_subsection else "none"}", '
+                                "so the incorrectly tagged paragraph is most likely after this heading.</p>"
                             ),
                             "status": 422,
                         },

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -408,6 +408,7 @@ def nofo_import(request, pk=None):
                                 "<p>This document contains a heading that is too long.</p>"
                                 "<p>This usually means that a paragraph has been incorrectly styled as a heading. "
                                 "Please check your document's heading styles and try again.</p>"
+                                "<p>Headings have a character limit of 511 characters</p>"
                             ),
                             "status": 422,
                         },


### PR DESCRIPTION
Original issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/25

This adds more specific error messaging for cases where validation errors are thrown for long headings. New text:


Screenshots: 
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/24f07f24-600b-427f-98bc-8efd02586a1c" />




QA Steps:
1. Navigate to `http://localhost:8000/nofos/import`
2. Import a NOFO that has a heading that exceedes the character limit of 511
3. Verify that error message message renders as expected with a status code of 422 
