### PR TITLE
Fixes for new DGHP document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Decompose instructions boxes that start with "Instructions for new nofo team"
+
 ### Fixed
 
 ## [1.39.0] - 2023-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- bug: since adding replace_links, replace_chars was not being applied
+
 ## [1.39.0] - 2023-12-04
 
 ### Added

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -1765,7 +1765,10 @@ def decompose_instructions_tables(soup):
     for table in tables:
         cells = table.find_all("td")
         if len(cells) == 1:
-            if table.get_text().lower().startswith(
-                "instructions for nofo writers:"
-            ) or re.match(r".+-specific instructions", table.get_text().lower()):
+            table_text_lowercase = table.get_text().lower()
+            if (
+                table_text_lowercase.startswith("instructions for nofo writers")
+                or table_text_lowercase.startswith("instructions for new nofo team")
+                or re.match(r".+-specific instructions", table_text_lowercase)
+            ):
                 table.decompose()

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -5630,7 +5630,7 @@ class DecomposeInstructionsTablesTest(TestCase):
         html_content = """
         <html>
             <body>
-                <table><tr><td>Instructions for NOFO writers: This table should be removed.</td></tr></table>
+                <table><tr><td><span>Instructions for NOFO writers</span><p>This table should be removed</p></td></tr></table>
                 <table><tr><td>Another table that should remain.</td></tr></table>
             </body>
         </html>
@@ -5640,7 +5640,25 @@ class DecomposeInstructionsTablesTest(TestCase):
         remaining_tables = soup.find_all("table")
         self.assertEqual(len(remaining_tables), 1)
         self.assertNotIn(
-            "Instructions for NOFO writers:", remaining_tables[0].get_text()
+            "Instructions for NOFO writers", remaining_tables[0].get_text()
+        )
+
+    def test_removes_correct_tables_nofo_team(self):
+        """Test that tables with specific instructional text are removed."""
+        html_content = """
+        <html>
+            <body>
+                <table><tr><td><strong class="instruction-box-heading"><span>INSTRUCTIONS FOR NEW NOFO TEAM</span></strong><span>DGHP New NOFO Team: Below are three metadata fields.</span></td></tr></table>
+                <table><tr><td>Another table that should remain.</td></tr></table>
+            </body>
+        </html>
+        """
+        soup = BeautifulSoup(html_content, "html.parser")
+        decompose_instructions_tables(soup)
+        remaining_tables = soup.find_all("table")
+        self.assertEqual(len(remaining_tables), 1)
+        self.assertNotIn(
+            "INSTRUCTIONS FOR NEW NOFO TEAM", remaining_tables[0].get_text()
         )
 
     def test_removes_correct_tables_instructions_1(self):

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -305,8 +305,7 @@ def nofo_import(request, pk=None):
             return redirect(view_path, **kwargs)
 
         # replace problematic characters/links on import
-        cleaned_content = replace_chars(file_content)
-        cleaned_content = replace_links(file_content)
+        cleaned_content = replace_links(replace_chars(file_content))
 
         soup = BeautifulSoup(cleaned_content, "html.parser")  # Parse the cleaned HTML
         soup = add_body_if_no_body(soup)


### PR DESCRIPTION
## Summary

This PR adds 2 things: 1 change and 1 bugfix.

1. Decompose "instructions" boxes for NEW NOFO WRITERS
2. `replace_chars` was not being applied — now it is

#### 1. Decompose "instructions" boxes for NEW NOFO WRITERS

Content Guide documents have often have instructions for writers, explaining how to fill out the following section.

<img width="600" alt="Screenshot 2024-12-11 at 7 27 05 PM" src="https://github.com/user-attachments/assets/138ca6c0-93bc-4115-9710-1be33635b66e" />

Previously, all of these boxes would be titled "Instructions for NOFO writers:", but now we are seeing a variant that goes "Instructions for new NOFO writers". Updated the function to remove these boxes as well.

| before | after  |
|--------|--------|
|  layout is messed up. "Instructions for new NOFO writers" box should not be there.       |   Certified fresh.     |
| <img width="623" alt="Screenshot 2024-12-11 at 7 30 03 PM" src="https://github.com/user-attachments/assets/04c61bbb-7756-4c87-9c09-07a63507767b" /> | <img width="623" alt="Screenshot 2024-12-11 at 7 30 11 PM" src="https://github.com/user-attachments/assets/6a341efa-af00-4a72-9ee8-5a3b67ad2dca" /> |

#### 2. `replace_chars` was not being applied — now it is

So when I added the `replace_links` function (#64), I created a bug in the `nofo_import` route. 

Here's the bug:

```python
# replace problematic characters/links on import
cleaned_content = replace_chars(file_content)
cleaned_content = replace_links(file_content) # bug is here: this function should be taking "cleaned_content"
```

So the `replace_chars` function was being run but not saved, which meant that we were seeing weird stuff coming back in, primarily where we see this is around the application checkboxes.

Small fix to get this working again, although it took a while to find.

| before | after  |
|--------|--------|
| checkboxes are umlaut character  (¨)      |  checkboxes are normal, because `replace_chars` deals with it   |
| <img width="715" alt="Screenshot 2024-12-11 at 7 36 16 PM" src="https://github.com/user-attachments/assets/050e0778-1533-41d4-b04b-8407b224630c" /> | <img width="715" alt="Screenshot 2024-12-11 at 7 36 07 PM" src="https://github.com/user-attachments/assets/e3f61b39-5215-4377-b6dd-1d63072a3dca" /> |


