### PR TITLE
Add loading gif to re-import screen + improve button loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 
 - Decompose instructions boxes that start with "Instructions for new nofo team"
+- Made the import button more dynamic
 
 ### Fixed
 
+- Loading gif also used on re-import page
 - bug: since adding replace_links, replace_chars was not being applied
 
 ## [1.39.0] - 2023-12-04

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -293,6 +293,14 @@ details > summary > span:hover {
   padding: 8px 0;
 }
 
+.nofo_import .submit-button {
+  width: 132px;
+}
+
+.nofo_import .submit-button.submit-button--loading {
+  text-align: left;
+}
+
 /* Edit page */
 
 /* header widget for NOFO */

--- a/bloom_nofos/bloom_nofos/templates/includes/loading_horse.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/loading_horse.html
@@ -12,10 +12,21 @@
     const loadingGif = form.querySelector(".loading-horse--container");
 
     form.addEventListener("submit", function () {
-      // Disable the button and change its text
+      // Disable the button, change its text, add classname
       button.disabled = true;
-      button.textContent = "Importing…";
+      button.textContent = "Importing";
+      button.classList.add("submit-button--loading");
+      button.setAttribute("aria-label", "Importing…");
 
+      let dotCount = 0; // Tracks the number of dots (0 to 3)
+
+      // Start an interval to cycle through the dots
+      intervalId = setInterval(() => {
+        dotCount = (dotCount + 1) % 4; // Cycle between 0, 1, 2, 3
+        button.textContent = `Importing${".".repeat(dotCount)}`;
+      }, 330);
+
+      // show the horse gif
       setTimeout(() => {
         loadingGif.classList.add("visible");
       }, 50);

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -5,6 +5,8 @@
   Re-import “{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}”
 {% endblock %}
 
+{% block body_class %}nofo_import nofo_import--reimport{% endblock %}
+
 {% block content %}
   <div class="usa-alert usa-alert--warning margin-bottom-3">
     <div class="usa-alert__body">
@@ -25,7 +27,7 @@
     {% endwith %}
   {% endwith %}
 
-  <form id="nofo-import--form" method="post" enctype="multipart/form-data">
+  <form id="nofo-import--form" class="form-import--loading" method="post" enctype="multipart/form-data">
     {% csrf_token %}
     {% with id="nofo-import" label="Select NOFO file" hint="Accepts .docx or .html files." value=title %}
       {% for message in messages %}
@@ -37,6 +39,8 @@
       {% endfor %}
     {% endwith %}
 
-    <button class="usa-button margin-top-3" type="submit">Re-import</button>
+    {% include "includes/loading_horse.html" %}
+
+    <button class="usa-button margin-top-3 submit-button" type="submit">Re-import</button>
   </form>
 {% endblock %}


### PR DESCRIPTION
## Summary 

This is a small PR which is focused on the loading state when you are importing a NOFO.

1. Add the loading state to the re-import page
2. Make the button loading state more dynamic

#### 1. Add the loading state to the re-import page

This was pointed out to me earlier today as a bug. Since #71, when you are importing a NOFO, you see a little galloping horse, but on the _re-import_ page, nothing happens. 

This is now fixed.

#### 2. Make the button loading state more dynamic

Finally, the completion of my vision for the loading button on the import page. We now cycle through dots to indicate that it is working very hard on importing your NOFO.

This is a loading interaction for the ages. 

![Image](https://github.com/user-attachments/assets/c0e01a72-c269-4e0e-9351-c44d1b73e9ea)
