### PR TITLE
Updates to CMS blue theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Updates to CMS theme:
+  - Fix background and text colour for cover page
+  - "Standard" icons are blue
+  - Tighter line-height for h5s
+  - Smaller, bolder h7s
+
 ### Fixed
 
 ## [1.41.0] - 2023-12-18

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cms-blue.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cms-blue.css
@@ -50,6 +50,12 @@ h2 {
 
 /* Cover page */
 
+.nofo--cover-page--header,
+.nofo--cover-page--footer {
+  background-color: var(--color--cms-blue);
+  color: var(--color--white);
+}
+
 .nofo--cover-page--header--logo--subheading {
   color: var(--color--cms-blue);
 }
@@ -77,20 +83,7 @@ h2 {
 
 /* Cover page: text */
 
-.nofo--cover-page--text .nofo--cover-page--header {
-  background-color: var(--color--cms-blue);
-  color: var(--color--white);
-}
-
-.nofo--cover-page--text .nofo--cover-page--footer {
-  background-color: var(--color--cms-blue);
-}
-
 /* Cover page: medium image */
-
-.nofo--cover-page--medium .nofo--cover-page--header {
-  background-color: var(--color--white);
-}
 
 /* Cover page: hero image */
 
@@ -104,7 +97,7 @@ h2 {
 /* Table of contents */
 
 .toc .toc--section-name .toc--section-name--img svg {
-  color: var(--color--cms-yellow);
+  color: var(--color--cms-blue);
 }
 
 .nofo--icons--border .toc .toc--section-name .toc--section-name--img svg {
@@ -137,7 +130,7 @@ h2 {
 }
 
 .nofo--icons--solid .before-you-begin .section--before-you-begin--icon svg {
-  color: var(--color--cms-yellow);
+  color: var(--color--cms-blue);
 }
 
 section.before-you-begin h2 {

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cms.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cms.css
@@ -61,6 +61,7 @@ h5 {
     Arial, sans-serif;
   color: var(--color--black);
   font-weight: 500;
+  line-height: 1.35;
 }
 
 h6 {
@@ -69,6 +70,12 @@ h6 {
   color: var(--color--black);
   font-weight: 500;
   font-size: 13pt;
+}
+
+/* this functions as an h7 */
+div[role="heading"] {
+  font-size: 12pt;
+  font-weight: 700;
 }
 
 /* Running header */


### PR DESCRIPTION
## Summary 

This PR Introduces various small improvements to the CMS "blue" theme. These are all things @admoorgit noticed when he was reviewing this theme:

  - Fix background and text colour for cover page
  - "Standard" icons are blue
  - Tighter line-height for h5s
  - Smaller, bolder h7s

The list of things to fix are in this doc: https://docs.google.com/document/d/1DlTUjmJL5XO8Y7rBfOMcXavl4gZWtiu0zNR7EkD7Egw/edit?tab=t.0#heading=h.vbol9hk2ixat

### Screenshots

| before: cover page | after: cover page  |
|--------|--------|
|  cover page is messed up     |   cover page is good     |
| ![Screenshot 2024-12-18 at 5 52 37 PM](https://github.com/user-attachments/assets/95d27949-510e-4482-8b86-b1a496beb964) | ![Screenshot 2024-12-18 at 5 52 49 PM](https://github.com/user-attachments/assets/2d907688-6b2d-46be-b543-647c0eb0bf24) |


| before: table of contents | after: table of contents  |
|--------|--------|
|   icons are yellow, hard to see on a white background |      icons are blue, easy to see  |
| ![Screenshot 2024-12-18 at 5 54 47 PM](https://github.com/user-attachments/assets/2c3eba63-fbc9-4bb7-98ba-da80298675d6) | ![Screenshot 2024-12-18 at 5 54 36 PM](https://github.com/user-attachments/assets/7214d1fc-875d-4cb4-8240-7e56a0fdefa0) |

This PR also includes the header updates that @admoorgit asked for, but those are not pictured.