### PR TITLE
Solve H7 bug when importing NOFOs + extend timeout time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - "Standard" icons are blue
   - Tighter line-height for h5s
   - Smaller, bolder h7s
+- TEMP: Double the app's timeout time
+  - TODO: Remove once import bottleneck is improved
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Don't demote h7s, since there is no lower heading level
+
 ## [1.41.0] - 2023-12-18
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN /root/.local/bin/poetry run python bloom_nofos/manage.py collectstatic --noi
 
 EXPOSE $PORT
 
-CMD ["sh", "-c", "/root/.local/bin/poetry run gunicorn --workers 8 --timeout 89 --chdir bloom_nofos --bind 0.0.0.0:$PORT bloom_nofos.wsgi:application"]
+CMD ["sh", "-c", "/root/.local/bin/poetry run gunicorn --workers 8 --timeout 179 --chdir bloom_nofos --bind 0.0.0.0:$PORT bloom_nofos.wsgi:application"]

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -330,7 +330,14 @@ def get_subsections_from_sections(sections, top_heading_level="h1"):
         heading_tags = ["h2"] + heading_tags
 
     def _demote_tag(tag_name):
-        newTags = {"h2": "h3", "h3": "h4", "h4": "h5", "h5": "h6", "h6": "h7"}
+        newTags = {
+            "h2": "h3",
+            "h3": "h4",
+            "h4": "h5",
+            "h5": "h6",
+            "h6": "h7",
+            "div": "h7",
+        }
 
         return newTags[tag_name]
 

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -816,6 +816,39 @@ class HTMLSubsectionTestsH2(TestCase):
         self.assertEqual(section.get("subsections")[3].get("name"), "Subsection h6")
         self.assertEqual(section.get("subsections")[3].get("html_id"), "subsection--h6")
 
+    def test_get_subsections_from_soup_h1_section_headings_demoted(self):
+        soup = BeautifulSoup(
+            '<h1>Section h1</h1><h2>Subsection h2</h2><h3>Subsection h3</h3><h4>Subsection h4</h4><h5>Subsection h5</h5><h6>Subsection h6</h6>><div role="heading" aria-level="7">Subsection h7</div><p>Section 1 body</p>',
+            "html.parser",
+        )
+        sections = get_subsections_from_sections(
+            get_sections_from_soup(soup, top_heading_level="h1"), top_heading_level="h1"
+        )
+        self.assertEqual(len(sections), 1)
+
+        section = sections[0]
+        self.assertEqual(section.get("name"), "Section h1")
+
+        self.assertEqual(len(section.get("subsections")), 6)
+
+        self.assertEqual(section.get("subsections")[0].get("name"), "Subsection h2")
+        self.assertEqual(section.get("subsections")[0].get("tag"), "h3")
+
+        self.assertEqual(section.get("subsections")[1].get("name"), "Subsection h3")
+        self.assertEqual(section.get("subsections")[1].get("tag"), "h4")
+
+        self.assertEqual(section.get("subsections")[2].get("name"), "Subsection h4")
+        self.assertEqual(section.get("subsections")[2].get("tag"), "h5")
+
+        self.assertEqual(section.get("subsections")[3].get("name"), "Subsection h5")
+        self.assertEqual(section.get("subsections")[3].get("tag"), "h6")
+
+        self.assertEqual(section.get("subsections")[4].get("name"), "Subsection h6")
+        self.assertEqual(section.get("subsections")[4].get("tag"), "h7")
+
+        self.assertEqual(section.get("subsections")[5].get("name"), "Subsection h7")
+        self.assertEqual(section.get("subsections")[5].get("tag"), "h7")
+
 
 class HTMLNofoFileTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

This PR does two things:

1. Solves the import problem where NOFOs with h1s and h7s would fail to import
2. Doubles the app timeout time

### 1. Solves the import bug with H1s and H7s

Sometimes, we demote heading levels vs other times we don't.

When someone submits documents that have H1s in it, then we demote them all because there is only 1 H1 allowed in the document, for accessibility reasons.

Historically, this has meant that we have been demoting H6 levels to H7s, which is why we shim H7s.

However, when people submit a document that has H1s _and_ H7s, then it threw an exception and wouldn't import because there's no such thing as an H8.

This commit solves this by keeping the H7s as H7s, it doesn't demote them but it also doesn't cause an error when they show up.

### 2. Doubles the app timeout time

We have had trouble importing long NOFO documents in prod because the app times out.

This is a test to see whether or not we can import documents with a longer timeout time.

This is not the real fix, it is a temporary fix, but we want to benchmark the app.