### PR TITLE
Add utility classes for list counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Add cover image for CDC-RFA-IP-25-0007
 - Add cover image for CMS-2V2-25-001
   - Also add inline images
+- Add utility classes for different list counters
 
 ### Changed
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -147,6 +147,22 @@ h2 {
 
 /* Utility classes */
 
+.list-lower-roman {
+  list-style-type: lower-roman;
+}
+
+.list-upper-roman {
+  list-style-type: upper-roman;
+}
+
+.list-lower-alpha {
+  list-style-type: lower-alpha;
+}
+
+.list-upper-alpha {
+  list-style-type: upper-alpha;
+}
+
 .w-100,
 .w-full {
   width: 100%;


### PR DESCRIPTION
# Summary

Sometimes we need different list counters for complex NOFO documents.

This PR adds some classes we can use to change the list counters to be roman numerals (i, ii, iii), uppercase roman numerals (I, II, III), alphabets, (a, b, c), and uppercase alphabets (A, B, C). 

We can't represent these in markdown, but we can convert to HTML and add the classes. 

#### markdown

```markdown
- one 
- two
- three
```

#### big alpha

```html
<ol class="list-upper-alpha">
  <li>one</li>
  <li>two</li>
  <li>three</li>
</ol>
```

#### lower roman

```html
<ol class="list-lower-roman">
  <li>one</li>
  <li>two</li>
  <li>three</li>
</ol>
```
