### PR TITLE
Move utility classes so that they will show up in the edit view

### DIFF
--- a/bloom_nofos/bloom_nofos/static/shared.css
+++ b/bloom_nofos/bloom_nofos/static/shared.css
@@ -24,6 +24,8 @@
   --color--staging-coral: #f08080;
 }
 
+/* Utility classes */
+
 .bg-group--bloom {
   background-color: var(--color--bloom-green);
 }
@@ -58,6 +60,22 @@
 
 .bg-group--staging {
   background-color: var(--color--staging-coral);
+}
+
+.list-lower-roman {
+  list-style-type: lower-roman;
+}
+
+.list-upper-roman {
+  list-style-type: upper-roman;
+}
+
+.list-lower-alpha {
+  list-style-type: lower-alpha;
+}
+
+.list-upper-alpha {
+  list-style-type: upper-alpha;
 }
 
 .usa-table--font-size-1 {

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -147,22 +147,6 @@ h2 {
 
 /* Utility classes */
 
-.list-lower-roman {
-  list-style-type: lower-roman;
-}
-
-.list-upper-roman {
-  list-style-type: upper-roman;
-}
-
-.list-lower-alpha {
-  list-style-type: lower-alpha;
-}
-
-.list-upper-alpha {
-  list-style-type: upper-alpha;
-}
-
 .w-100,
 .w-full {
   width: 100%;


### PR DESCRIPTION
## Summary

This PR is a follow-up from #132.

The last PR would add the list styling to the HTML view, but not to the edit view. 

This one brings that styling to the edit view as well.