### PR TITLE
Speed up NOFO importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Add cover image for CMS-2V2-25-001
   - Also add inline images
 - Add utility classes for different list counters
-- TEMP: add benchmarking numbers so that we can test speed of imports
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - Smaller, bolder h7s
 - TEMP: Double the app's timeout time
   - TODO: Remove once import bottleneck is improved
+- Precompile regex patterns for heading ID substitution in "add_headings_to_nofo" function
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Add cover image for CMS-2V2-25-001
   - Also add inline images
 - Add utility classes for different list counters
+- TEMP: add benchmarking numbers so that we can test speed of imports
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.42.0] - 2023-12-24
+
+### Added
+
 - Add cover image for CDC-RFA-IP-25-0007
 - Add cover image for CMS-2V2-25-001
   - Also add inline images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - "Standard" icons are blue
   - Tighter line-height for h5s
   - Smaller, bolder h7s
-- TEMP: Double the app's timeout time
-  - TODO: Remove once import bottleneck is improved
 - Speed up "add_headings_to_nofo" function
   - Precompile regex patterns for heading ID substitution
   - Batch update sections and subsections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
   - Smaller, bolder h7s
 - TEMP: Double the app's timeout time
   - TODO: Remove once import bottleneck is improved
-- Precompile regex patterns for heading ID substitution in "add_headings_to_nofo" function
+- Speed up "add_headings_to_nofo" function
+  - Precompile regex patterns for heading ID substitution
+  - Batch update sections and subsections
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN /root/.local/bin/poetry run python bloom_nofos/manage.py collectstatic --noi
 
 EXPOSE $PORT
 
-CMD ["sh", "-c", "/root/.local/bin/poetry run gunicorn --workers 8 --timeout 179 --chdir bloom_nofos --bind 0.0.0.0:$PORT bloom_nofos.wsgi:application"]
+CMD ["sh", "-c", "/root/.local/bin/poetry run gunicorn --workers 8 --timeout 89 --chdir bloom_nofos --bind 0.0.0.0:$PORT bloom_nofos.wsgi:application"]

--- a/bloom_nofos/bloom_nofos/urls.py
+++ b/bloom_nofos/bloom_nofos/urls.py
@@ -20,6 +20,7 @@ from django.http import HttpResponse
 from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
 from nofos.api.api import api
+
 from . import views
 
 handler404 = views.page_not_found

--- a/bloom_nofos/nofos/api/api.py
+++ b/bloom_nofos/nofos/api/api.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from ninja import NinjaAPI, Schema
+from ninja import NinjaAPI
 from ninja.security import HttpBearer
 from nofos.models import Nofo
-from nofos.views import _build_nofo
+from nofos.nofo import _build_nofo
 
 from .schemas import ErrorSchema, NofoSchema, SuccessSchema
 

--- a/bloom_nofos/nofos/api/api.py
+++ b/bloom_nofos/nofos/api/api.py
@@ -1,10 +1,11 @@
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from ninja import NinjaAPI, Schema
 from ninja.security import HttpBearer
-from django.core.exceptions import ValidationError
-from .schemas import NofoSchema, ErrorSchema, SuccessSchema
 from nofos.models import Nofo
 from nofos.views import _build_nofo
-from django.conf import settings
+
+from .schemas import ErrorSchema, NofoSchema, SuccessSchema
 
 
 class BearerAuth(HttpBearer):

--- a/bloom_nofos/nofos/api/schemas.py
+++ b/bloom_nofos/nofos/api/schemas.py
@@ -1,5 +1,6 @@
-from ninja import ModelSchema, Schema
 from typing import List, Optional
+
+from ninja import ModelSchema, Schema
 from nofos.models import Nofo, Section, Subsection
 
 

--- a/bloom_nofos/nofos/api/tests.py
+++ b/bloom_nofos/nofos/api/tests.py
@@ -1,8 +1,9 @@
-from django.test import TestCase, override_settings
-from django.conf import settings
-from nofos.models import Nofo, Section, Subsection
 import json
 import os
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+from nofos.models import Nofo, Section, Subsection
 
 
 @override_settings(API_TOKEN="test-token-for-ci")

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -96,7 +96,6 @@ from .nofo import (
 )
 from .utils import create_nofo_audit_event, create_subsection_html_id, style_map_manager
 
-
 ###########################################################
 ###################### NOFO VIEWS ########################
 ###########################################################

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1,5 +1,4 @@
 import io
-import json
 
 import docraptor
 import mammoth
@@ -11,10 +10,9 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.db.models import F
-from django.forms.models import model_to_dict
-from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse_lazy
 from django.utils import dateformat, timezone
 from django.views.generic import (
     CreateView,
@@ -23,7 +21,6 @@ from django.views.generic import (
     FormView,
     ListView,
     UpdateView,
-    View,
 )
 
 from bloom_nofos.utils import cast_to_boolean, is_docraptor_live_mode_active
@@ -57,7 +54,6 @@ from .mixins import (
 )
 from .models import THEME_CHOICES, Nofo, Section, Subsection
 from .nofo import (
-    _build_nofo,
     add_body_if_no_body,
     add_em_to_de_minimis,
     add_endnotes_header_if_exists,
@@ -232,9 +228,6 @@ class NofosArchiveView(GroupAccessObjectMixin, UpdateView):
 
 
 def nofo_import(request, pk=None):
-    start_time = time.time()  # Initialize the timer
-    start_time_original = start_time
-
     view_path = "nofos:nofo_import"
     kwargs = {}
     if pk:

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1,6 +1,5 @@
 import io
 import json
-import time
 
 import docraptor
 import mammoth
@@ -96,15 +95,6 @@ from .nofo import (
     unwrap_nested_lists,
 )
 from .utils import create_nofo_audit_event, create_subsection_html_id, style_map_manager
-
-
-def benchmark(start_time, description):
-    """
-    Prints the elapsed time since start_time with a description.
-    """
-    elapsed_time = time.time() - start_time
-    print(f"{description} took {elapsed_time:.6f} seconds")
-    return time.time()  # Return the new start time for the next benchmark
 
 
 ###########################################################
@@ -254,10 +244,7 @@ def nofo_import(request, pk=None):
         kwargs = {"pk": nofo.id}
 
     if request.method == "POST":
-        start_time = benchmark(start_time, "256")
-
         uploaded_file = request.FILES.get("nofo-import", None)
-        start_time = benchmark(start_time, "259")
 
         if not uploaded_file:
             messages.add_message(request, messages.ERROR, "Oops! No fos uploaded")
@@ -276,14 +263,10 @@ def nofo_import(request, pk=None):
             uploaded_file.content_type
             == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         ):
-            start_time = benchmark(start_time, "278")
-
             try:
                 doc_to_html_result = mammoth.convert_to_html(
                     uploaded_file, style_map=style_map_manager.get_style_map()
                 )
-                start_time = benchmark(start_time, "284")
-
             except Exception as e:
                 return HttpResponseBadRequest(
                     "Error importing .docx file: {}".format(e)
@@ -325,17 +308,10 @@ def nofo_import(request, pk=None):
             )
             return redirect(view_path, **kwargs)
 
-        start_time = benchmark(start_time, "327")
-
         # replace problematic characters/links on import
         cleaned_content = replace_links(replace_chars(file_content))
-        start_time = benchmark(start_time, "331")
-
         soup = BeautifulSoup(cleaned_content, "html.parser")  # Parse the cleaned HTML
-        start_time = benchmark(start_time, "334")
-
         soup = add_body_if_no_body(soup)
-        start_time = benchmark(start_time, "337")
 
         # # Specify the output file path
         # output_file_path = "debug_output.html"
@@ -348,45 +324,26 @@ def nofo_import(request, pk=None):
         top_heading_level = "h1" if soup.find("h1") else "h2"
 
         # mutate the HTML
-        start_time = benchmark(start_time, "350")
         decompose_instructions_tables(soup)
-        start_time = benchmark(start_time, "352")
         join_nested_lists(soup)
-        start_time = benchmark(start_time, "354")
         add_strongs_to_soup(soup)
-        start_time = benchmark(start_time, "356")
         preserve_bookmark_links(soup)
-        start_time = benchmark(start_time, "358")
         preserve_heading_links(soup)
-        start_time = benchmark(start_time, "360")
         preserve_table_heading_links(soup)
-        start_time = benchmark(start_time, "362")
         clean_heading_tags(soup)
-        start_time = benchmark(start_time, "364")
         clean_table_cells(soup)
-        start_time = benchmark(start_time, "366")
         unwrap_empty_elements(soup)
-        start_time = benchmark(start_time, "368")
         decompose_empty_tags(soup)
-        start_time = benchmark(start_time, "370")
         combine_consecutive_links(soup)
-        start_time = benchmark(start_time, "372")
         remove_google_tracking_info_from_links(soup)
-        start_time = benchmark(start_time, "374")
         replace_src_for_inline_images(soup)
-        start_time = benchmark(start_time, "376")
         add_endnotes_header_if_exists(soup, top_heading_level)
-        start_time = benchmark(start_time, "378")
         unwrap_nested_lists(soup)
-        start_time = benchmark(start_time, "380")
         preserve_bookmark_targets(soup)
-        start_time = benchmark(start_time, "382")
         soup = add_em_to_de_minimis(soup)
-        start_time = benchmark(start_time, "384")
 
         # format all the data as dicts
         sections = get_sections_from_soup(soup, top_heading_level)
-        start_time = benchmark(start_time, "388")
         if not len(sections):
             messages.add_message(
                 request,
@@ -396,7 +353,6 @@ def nofo_import(request, pk=None):
             return redirect(view_path, **kwargs)
 
         sections = get_subsections_from_sections(sections, top_heading_level)
-        start_time = benchmark(start_time, "398")
         filename = uploaded_file.name.strip()
 
         if pk:
@@ -436,13 +392,9 @@ def nofo_import(request, pk=None):
             nofo_title = suggest_nofo_title(soup)  # guess the NOFO name
 
             try:
-                start_time = benchmark(start_time, "439")
                 nofo = create_nofo(nofo_title, sections)
-                start_time = benchmark(start_time, "441")
                 add_headings_to_nofo(nofo)
-                start_time = benchmark(start_time, "443")
                 add_page_breaks_to_headings(nofo)
-                start_time = benchmark(start_time, "445")
                 nofo.filename = filename
             except ValidationError as e:
                 # Check if this is an html_id length error
@@ -482,17 +434,13 @@ def nofo_import(request, pk=None):
                 return HttpResponseBadRequest("Error creating NOFO: {}".format(e))
 
             nofo.group = request.user.group  # set group separately with request.user
-            start_time = benchmark(start_time, "485")
             suggest_all_nofo_fields(nofo, soup)
             nofo.save()
-            start_time = benchmark(start_time, "488")
 
             # Create audit event for importing a nofo
             create_nofo_audit_event(
                 event_type="nofo_import", nofo=nofo, user=request.user
             )
-            start_time = benchmark(start_time, "494")
-            benchmark(start_time_original, "completed NOFO import")
 
             return redirect("nofos:nofo_import_title", pk=nofo.id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bloom-nofos"
-version = "1.41.0"
+version = "1.42.0"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
As we have continued to add steps to the NOFO import step, we've ended up increasing the total time needed to import a NOFO.

After running some profiling of the entire import step, we discovered the largest contributor to the import slowdown is the `add_headings_to_nofo` function, which was acocunting for over 60% of the import time for a typical NOFO.

Using a CMS NOFO as an example, we were seeing this online:

- Total import time: 21.829363 seconds 
- `add_headings_to_nofo` runtime: 14.137533 seconds

So if we can make this function more efficient, we can dramatically improve our NOFO import times.