### PR TITLE
Batch create Sections and Subsections in _build_nofo function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 
 - All tables in appendices are full-width
+- Speed up "create_nofo" function
+  - Batch create sections and subsections in "\_build_nofo"
 
 ### Fixed
 

--- a/bloom_nofos/nofos/models.py
+++ b/bloom_nofos/nofos/models.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils import timezone
 from martor.models import MartorField
 
-from .utils import create_subsection_html_id
+from .utils import add_html_id_to_subsection
 
 COACH_CHOICES = [
     ("aarti", "Aarti"),
@@ -414,9 +414,7 @@ class Subsection(models.Model):
             raise ValidationError("Tag is required when 'name' is present.")
 
     def save(self, *args, **kwargs):
-        if self.name and not self.html_id:
-            counter = self.pk or self.order
-            self.html_id = create_subsection_html_id(counter, self)
+        add_html_id_to_subsection(self)
 
         self.full_clean()  # Call the clean method for validation
         super().save(*args, **kwargs)

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -18,7 +18,7 @@ from slugify import slugify
 
 from .models import Nofo, Section, Subsection
 from .nofo_markdown import md
-from .utils import clean_string, create_subsection_html_id
+from .utils import add_html_id_to_subsection, clean_string, create_subsection_html_id
 
 DEFAULT_NOFO_OPPORTUNITY_NUMBER = "NOFO #999"
 # Use Firefox user agent
@@ -199,6 +199,10 @@ def _build_nofo(nofo, sections):
                 body=md_body,  # body can be empty
                 section=model_section,
             )
+
+            # Ensure `subsection.html_id` is assigned if not already set
+            add_html_id_to_subsection(model_subsection)
+
             model_subsection.save()
 
     return nofo

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -62,6 +62,17 @@ def create_subsection_html_id(counter, subsection):
     return "{}--{}--{}".format(counter, slugify(section_name), slugify(subsection.name))
 
 
+def add_html_id_to_subsection(subsection):
+    """
+    Assigns an `html_id` to a Subsection if not already set.
+    The `html_id` is based on the subsection's order or primary key (if present).
+    """
+    if subsection.name and not subsection.html_id:
+        # Use the primary key if available; otherwise, fall back to the order field
+        counter = subsection.pk or subsection.order
+        subsection.html_id = create_subsection_html_id(counter, subsection)
+
+
 def get_icon_path_choices(theme):
     if theme == "portrait-acf-white":
         return [


### PR DESCRIPTION
## Summary

This PR speeds up NOFO importing (again) by using batch processing inside of the `_build_nofo` function, which we use when creating a NOFO.

### Details

On Friday December 20th, we received the largest NOFO we had ever seen, and trying to import it actually would result in an app timeout on the server. 

So we started profiling the various functions we run in `import_nofo`, and discovered that we had a couple of noticeable bottlenecks:

1. `add_headings_to_nofo`: took `102 seconds` out of `129  sections` 
2. `create_nofo`: took `20 seconds` out of `129 seconds`

In PR #134, we refactored `add_headings_to_nofo` in 2 ways:

1. Move regex compilation out of the for loop: this accounted for the bulk of our time savings
2. Use batch updates to update all Sections and Subsections at once instead of calling `save()` on individual Sections/Subsections

That was a huge improvement, check out the data for a generic CMS NOFO.

|                             | before | after |
|-----------------------------|--------|-------|
| total import time           |   21.829363 seconds     |   8.694077 seconds (~60% reduction)    |
| `add_headings_to_nofo ` runtime |  14.137533 seconds      |   0.953009 seconds (~94% reduction)    |

This PR uses the second strategy, batch creation, to refactor the `_build_nofo` function (used by create_nofo). We haven't seen such a dramatic speedup in absolute terms, but it's definitely a change worth making.

Here're the new numbers:

|                             | before | after |
|-----------------------------|--------|-------|
| total import time           |   8.694077 seconds     |   3.691065 seconds (~58% reduction)    |
| `create_nofo` runtime |  5.670648 seconds      |   0.78112 seconds (~86% reduction)    |

After the improvements to `add_headings_to_nofo`, `create_nofo` was the next slowest function, and one that is entirely within our codebase. This change speeds up importing significantly. 

### A note on the `save()` function

One thing to note here is that because our Subsection's `save()` function would previously run some logic to add `html_id` to subsections automatically, we now do this manually inside of `_build_nofo` because the `.save()` function for individual subsections was not getting called.

Doesn't seem to make a difference in my testing, importing a bunch of NOFOs, I still see the same number of broken links in both (so we are not severing links in the original word doc by doing this change) and all the tests pass as before, so I think we are good to ship this.

### Note 2: on CRUD events

Since we were updating the `updated` timestamp previously when calling `save`, and now we don't call `save`, our audit event trail is much less noisy. 

We don't care about this: this is a good thing.
