### PR TITLE
New ul bullets + wide tables in appendices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- Add list style for quint nested lis
+
 ### Changed
+
+- All tables in appendices are full-width
 
 ### Fixed
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -539,12 +539,25 @@ ol ol ol {
 
 ul ul ul ul {
   list-style-type: none;
-  padding-left: 20px;
 }
 
 ul ul ul ul > li:before {
   content: "⁃";
-  margin-right: 5px;
+  margin-left: -14px;
+  margin-right: 8px;
+}
+
+ul ul ul ul ul {
+  list-style-type: disc;
+}
+
+ul ul ul ul ul > li:before {
+  content: none;
+  margin-right: 0;
+}
+
+ul ul ul ul ul ul {
+  list-style-type: circle;
 }
 
 img.usa-icon--check_box_outline_blank {

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -310,9 +310,11 @@ body.portrait
   .section--content
   table
   + table:not(.table--criterion) {
-  width: calc(
-    216mm - 40mm
-  ); /* large tables in section 4 should be full-width */
+  width: calc(216mm - 40mm); /* tables in section 4 should be full-width */
+}
+
+section.section--appendix > .section--content > table {
+  width: calc(216mm - 40mm); /* tables in the appendix should be full-width */
 }
 
 table tr td.usa-icon__td--sublist {

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -267,7 +267,7 @@
   </section>
 
   {% for section in nofo.sections.all|dictsort:"order" %}
-    <section id="section--{{ section.html_id }}" class="section section--{{ forloop.counter }} section--{{ section.html_id }}">
+    <section id="section--{{ section.html_id }}" class="section section--{{ forloop.counter }} {% if forloop.counter > 7 %}section--appendix {% endif %}section--{{ section.html_id }}">
       <!-- SECTION TITLE PAGE -->
       {% if section.has_section_page %}
         <div class="title-page section--title-page">


### PR DESCRIPTION
## Summary

This PR makes 2 changes:

1. Adds new bullet styling for uls nested 5 and 6 times
  1.1. Also fixes the 4th level nested bullets that use dashes
2. Makes all tables in appendices full-width 

### 1. Bullets for 4th, 5th, 6th levels 

| before | after |
|--------|-------|
|  orange: 4th level "dash" (-) bullets are nested incorrectly, pushing the first line in <br> purple:  5th and 6th level bullets are both using dashes (-)       |  orange: 4th level "dash" (-) bullets are nested correctly, so the entire block of text in `li` has the same left alignment  <br> purple: added black circles for 5th level bullets and outline circles for 6th level bullets     |
|   <img width="633" alt="Screenshot 2024-12-30 at 11 24 18 AM" src="https://github.com/user-attachments/assets/d56f6922-825f-4569-a30a-cf0733d39810" />     |    <img width="633" alt="Screenshot 2024-12-30 at 11 24 10 AM" src="https://github.com/user-attachments/assets/5b7153e0-3be4-40a0-8331-8b1baf221415" />   |

### 2. All tables in all appendices now are full width

Since our "large/small" table rules look at a variety of things (no. columns, no. words), we were getting some stacked tables that looked sawtoothed in the appendices. This PR just makes every table in any appendix full width.

| before | after |
|--------|-------|
|  smaller middle table has shorter width      |  all tables same width     |
|    <img width="726" alt="Screenshot 2024-12-30 at 11 26 14 AM" src="https://github.com/user-attachments/assets/23cf433f-2dd8-4da9-b9f7-b44014d956af" />    |    <img width="726" alt="Screenshot 2024-12-30 at 11 25 48 AM" src="https://github.com/user-attachments/assets/d4be7ef5-8781-4c0f-9190-d1b10b9593a6" />   |

