### PR TITLE
acf heading style updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Change ACF heading styles
+  - h1s: 36 pt, 700
+  - h4s: 600
+  - h7s: 11.5pt, 600, #264a64
 - Change how sublist headings are identified in application checklist
   - headings with links must also not have a checkbox
   - cells with "Narratives" are headings now

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -145,6 +145,15 @@ h2 {
     format("woff2");
 }
 
+/* Add source sans pro */
+@font-face {
+  font-family: "Source Sans Pro Web";
+  font-style: normal;
+  font-weight: 600;
+  font-display: fallback;
+  src: url(/static/fonts/source-sans-pro/sourcesanspro-semibold-webfont.woff2) format("woff2");
+}
+
 /* Utility classes */
 
 .w-100,

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acf.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acf.css
@@ -53,10 +53,8 @@ h3 {
 }
 
 h4 {
-  color: var(--color--cdc-blue);
   font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial,
     sans-serif;
-  font-size: 20pt;
   font-weight: 600;
 }
 
@@ -74,8 +72,8 @@ h6 {
 
 /* this functions as an h7 */
 div[role="heading"] {
-  font-size: 11.5pt !important;
-  font-weight: 600 !important;
+  font-size: 11.5pt;
+  font-weight: 600;
   color: var(--color--acf-blue);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acf.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acf.css
@@ -38,6 +38,8 @@
 h1 {
   font-family: "Merriweather Web", Georgia, Cambria, Times New Roman, Times,
     serif;
+  font-size: 36pt;
+  font-weight: 700;
 }
 
 h2 {
@@ -51,9 +53,11 @@ h3 {
 }
 
 h4 {
+  color: var(--color--cdc-blue);
   font-family: Source Sans Pro Web, Helvetica Neue, Helvetica, Roboto, Arial,
     sans-serif;
-  color: var(--color--cdc-blue);
+  font-size: 20pt;
+  font-weight: 600;
 }
 
 h5 {
@@ -70,8 +74,9 @@ h6 {
 
 /* this functions as an h7 */
 div[role="heading"] {
-  font-size: 12.5pt;
-  font-weight: 600;
+  font-size: 11.5pt !important;
+  font-weight: 600 !important;
+  color: var(--color--acf-blue);
 }
 
 /* Cover page */


### PR DESCRIPTION
issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/130

Modifies headers to match new spec. h1, h4, and h7 are modified for the ACF theme

BEFORE:
<img width="967" alt="Screen Shot 2024-12-31 at 3 21 44 PM" src="https://github.com/user-attachments/assets/f6c04150-34fa-4e74-b919-b823dc528637" />
<img width="676" alt="Screen Shot 2024-12-31 at 4 01 41 PM" src="https://github.com/user-attachments/assets/53ec9ebb-dc59-4acb-9909-7ced09588e75" />



AFTER:
<img width="996" alt="Screen Shot 2024-12-31 at 3 58 41 PM" src="https://github.com/user-attachments/assets/6f6e335f-9a23-4b74-be4d-9590d3990594" />

<img width="945" alt="Screen Shot 2024-12-31 at 3 45 00 PM" src="https://github.com/user-attachments/assets/88adc06d-32c8-4569-a09a-7975de078095" />
<img width="676" alt="Screen Shot 2024-12-31 at 4 01 41 PM" src="https://github.com/user-attachments/assets/6076c505-0340-493e-975d-09f29db486e6" />
