### PR TITLE
Change how sublist headings are identified in application checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Change how sublist headings are identified in application checklist
+  - headings with links must also not have a checkbox
+  - cells with "Narratives" are headings now
 - All tables in appendices are full-width
 - Speed up "create_nofo" function
   - Batch create sections and subsections in "\_build_nofo"

--- a/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
+++ b/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
@@ -48,13 +48,17 @@ def has_checkbox(td):
 
 
 def is_list_heading(td):
-    if td.find("a"):
+    if td.find("a") and not has_checkbox(td):
         return True
 
     if td.find("strong") and ":" in td.get_text():
         return True
 
-    if td.text.lower() == "other required forms" or td.text.lower() == "attachments":
+    if (
+        td.text.lower() == "other required forms"
+        or td.text.lower() == "attachments"
+        or td.text.lower() == "narratives"
+    ):
         return True
 
     return False


### PR DESCRIPTION
## Summary

This PR includes 1 change that accommodate a new set of tables we are seeing that use a sublist heading for the top 3 items.

The change in this PR is to add a sublist to the first few items in the application checklist table that starts with Narratives.

Specifically:
  - headings with links must also not have a checkbox
  - cells with "Narratives" are headings now

Tested with 12 other application checklists and it seems this is an acceptable change.

### Screenshot

| before | after |
|--------|-------|
|  "Narratives" not identified as a heading. <br> Following rows can't be grouped together because they are links.      |   "Narratives" IS identified as a heading. <br> Following rows CAN be grouped together because they have checkboxes.    |
|   <img width="717" alt="Screenshot 2025-01-02 at 3 01 45 PM" src="https://github.com/user-attachments/assets/6c1712fe-eb1f-49b3-8c3e-ac5114cc8db5" />     |  <img width="717" alt="Screenshot 2025-01-02 at 2 59 44 PM" src="https://github.com/user-attachments/assets/d7b6fbe3-c8b9-45a7-8698-5be078821d83" />     |

