### PR TITLE
Copy metadata for subsections on re-import of nofo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning since version 1.0.0.
   - Previously, it was just a dashed line, but nobody knew what that meant
 - Loop through sections to create breadcrumbs
   - Support "Understand Review, Selection, and Award" as a new section name
+- Preserve existing page breaks when a NOFO is reimported
+  - Note that this is a best-guess effort: if subsections are renamed, page breaks can't be preserved
 
 ### Fixed
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -18,8 +18,7 @@ div.section--title-page {
 /* Assign page breaks */
 
 div.title-page,
-section,
-.callout-box.page-break-before {
+section {
   page-break-before: always;
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -18,7 +18,8 @@ div.section--title-page {
 /* Assign page breaks */
 
 div.title-page,
-section {
+section,
+.callout-box.page-break-before {
   page-break-before: always;
 }
 
@@ -1231,7 +1232,8 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
 
   /* Page break rules */
   .page-break--hr--container .page-break-before,
-  .page-break-before--heading {
+  .page-break-before--heading,
+  .callout-box.page-break-before {
     break-before: page !important;
     page-break-before: always !important;
   }

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -12,10 +12,10 @@
     <div class="usa-alert__body">
       <h4 class="usa-alert__heading">Warning</h4>
       <p class="usa-alert__text">
-        Re-importing a NOFO overwrites all existing content (but not its theme or assigned coach).
+        Re-importing a NOFO overwrites most existing content (but not its theme or assigned coach).  Callout box and HTML class settings are preserved.
       </p>
       <p class="usa-alert__text">
-        If you continue, you will lose all manual edits made since creating the NOFO.
+        If you continue, you will lose all manual edits made since creating the NOFO except for the settings preserved above.
       </p>
     </div>
   </div>

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -2,7 +2,7 @@
 {% load nofo_name %}
 
 {% block title %}
-  Re-import “{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}”
+  Re-import "{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}"
 {% endblock %}
 
 {% block body_class %}nofo_import nofo_import--reimport{% endblock %}
@@ -21,14 +21,28 @@
   </div>
 
   {% with nofo|nofo_name as nofo_name_str %}
-    {% with "Edit  “"|add:nofo_name_str|add:"”" as back_text %}
+    {% with "Edit "|add:nofo_name_str as back_text %}
       {% url 'nofos:nofo_edit' nofo.id as back_href %}
-      {% include "includes/page_heading.html" with title="Re-import “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
+      {% include "includes/page_heading.html" with title="Re-import "|add:nofo_name_str back_text=back_text back_href=back_href only %}
     {% endwith %}
   {% endwith %}
 
   <form id="nofo-import--form" class="form-import--loading" method="post" enctype="multipart/form-data">
     {% csrf_token %}
+    <div class="usa-form-group">
+      <div class="usa-checkbox">
+        <input
+          class="usa-checkbox__input"
+          id="preserve_page_breaks"
+          type="checkbox"
+          name="preserve_page_breaks"
+          checked
+        >
+        <label class="usa-checkbox__label" for="preserve_page_breaks">
+          Keep page breaks from current NOFO
+        </label>
+      </div>
+    </div>
     {% with id="nofo-import" label="Select NOFO file" hint="Accepts .docx or .html files." value=title %}
       {% for message in messages %}
         {% if "error" in message.tags %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -2,7 +2,7 @@
 {% load nofo_name %}
 
 {% block title %}
-  Re-import "{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}"
+  Re-import “{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}”
 {% endblock %}
 
 {% block body_class %}nofo_import nofo_import--reimport{% endblock %}
@@ -12,7 +12,7 @@
     <div class="usa-alert__body">
       <h4 class="usa-alert__heading">Warning</h4>
       <p class="usa-alert__text">
-        Re-importing a NOFO overwrites most existing content (but not its theme or assigned coach).  Callout box and HTML class settings are preserved.
+        Re-importing a NOFO overwrites most existing content (but not its theme, assigned coach, or optionally page breaks).
       </p>
       <p class="usa-alert__text">
         If you continue, you will lose all manual edits made since creating the NOFO except for the settings preserved above.
@@ -21,9 +21,9 @@
   </div>
 
   {% with nofo|nofo_name as nofo_name_str %}
-    {% with "Edit "|add:nofo_name_str as back_text %}
+    {% with "Edit “"|add:nofo_name_str|add:"“" as back_text %}
       {% url 'nofos:nofo_edit' nofo.id as back_href %}
-      {% include "includes/page_heading.html" with title="Re-import "|add:nofo_name_str back_text=back_text back_href=back_href only %}
+      {% include "includes/page_heading.html" with title="Re-import “"|add:nofo_name_str|add:"“" back_text=back_text back_href=back_href only %}
     {% endwith %}
   {% endwith %}
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -29,6 +29,19 @@
 
   <form id="nofo-import--form" class="form-import--loading" method="post" enctype="multipart/form-data">
     {% csrf_token %}
+
+    {% with id="nofo-import" label="Select NOFO file" hint="Accepts .docx or .html files." value=title %}
+      {% for message in messages %}
+        {% if "error" in message.tags %}
+          {% include "includes/file_input.html" with id=id label=label hint=hint error=message only %}
+        {% endif %}
+      {% empty %}
+        {% include "includes/file_input.html" with id=id label=label hint=hint only %}
+      {% endfor %}
+    {% endwith %}
+
+    {% include "includes/loading_horse.html" %}
+
     <div class="usa-form-group">
       <div class="usa-checkbox">
         <input
@@ -43,17 +56,6 @@
         </label>
       </div>
     </div>
-    {% with id="nofo-import" label="Select NOFO file" hint="Accepts .docx or .html files." value=title %}
-      {% for message in messages %}
-        {% if "error" in message.tags %}
-          {% include "includes/file_input.html" with id=id label=label hint=hint error=message only %}
-        {% endif %}
-      {% empty %}
-        {% include "includes/file_input.html" with id=id label=label hint=hint only %}
-      {% endfor %}
-    {% endwith %}
-
-    {% include "includes/loading_horse.html" %}
 
     <button class="usa-button margin-top-3 submit-button" type="submit">Re-import</button>
   </form>

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -21,9 +21,9 @@
   </div>
 
   {% with nofo|nofo_name as nofo_name_str %}
-    {% with "Edit “"|add:nofo_name_str|add:"“" as back_text %}
+    {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
       {% url 'nofos:nofo_edit' nofo.id as back_href %}
-      {% include "includes/page_heading.html" with title="Re-import “"|add:nofo_name_str|add:"“" back_text=back_text back_href=back_href only %}
+      {% include "includes/page_heading.html" with title="Re-import “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
     {% endwith %}
   {% endwith %}
 

--- a/bloom_nofos/nofos/tests/test_reimport.py
+++ b/bloom_nofos/nofos/tests/test_reimport.py
@@ -1,0 +1,189 @@
+from django.test import TestCase, Client
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.contrib.messages import get_messages
+from nofos.models import Nofo, Section, Subsection
+from users.models import BloomUser
+from django.urls import reverse
+
+
+class NofoReimportTests(TestCase):
+    def setUp(self):
+        # Create test user with required group
+        self.user = BloomUser.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            force_password_reset=False,
+            group="bloom",
+        )
+        self.client = Client()
+        self.client.login(email="test@example.com", password="testpass123")
+
+        # Create test NOFO with required fields
+        self.nofo = Nofo.objects.create(
+            title="Test NOFO",
+            short_name="test-nofo",
+            opdiv="ACF",
+            group="bloom",
+        )
+
+        # Create test section
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Test Section 1",
+            order=1,
+        )
+
+        # Create test subsections with different page break classes
+        self.subsections = []
+        subsection_data = [
+            ("Subsection 1", "page-break-before"),
+            ("Subsection 2", "page-break-after"),
+            ("Subsection 3", "page-break"),
+            ("Subsection 4", "no-page-break"),
+        ]
+
+        for i, (name, html_class) in enumerate(subsection_data):
+            subsection = Subsection.objects.create(
+                section=self.section,
+                name=name,
+                order=i + 1,
+                html_class=html_class,
+                tag="h2",
+                body=f"Content for {name}",
+            )
+            self.subsections.append(subsection)
+
+    def create_test_file(self):
+        """Create a test HTML file for reimporting."""
+        html_content = """
+        <html>
+        <head>
+            <title>Test NOFO</title>
+        </head>
+        <body>
+            <p>Opdiv: ACF</p>
+            <h1>Test Section 1</h1>
+            <h2>Subsection 1</h2>
+            <p>Content for Subsection 1</p>
+            <h2>Subsection 2</h2>
+            <p>Content for Subsection 2</p>
+            <h2>Subsection 3</h2>
+            <p>Content for Subsection 3</p>
+            <h2>Subsection 4</h2>
+            <p>Content for Subsection 4</p>
+        </body>
+        </html>
+        """
+        return SimpleUploadedFile(
+            "test.html", html_content.encode("utf-8"), content_type="text/html"
+        )
+
+    def test_reimport_preserves_page_breaks_when_checked(self):
+        """Test that page breaks are preserved when the checkbox is checked."""
+        # Create a test file with HTML content
+        test_file = self.create_test_file()
+
+        # Make the POST request to reimport
+        response = self.client.post(
+            reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
+            {
+                "nofo-import": test_file,
+                "preserve_page_breaks": "on",
+                "csrfmiddlewaretoken": "dummy",
+            },
+            follow=True,
+        )
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+
+        # Get the updated NOFO and its sections/subsections
+        updated_nofo = Nofo.objects.get(id=self.nofo.id)
+        updated_sections = updated_nofo.sections.all()
+
+        # Verify page breaks were preserved
+        found_page_break = False
+        for section in updated_sections:
+            for subsection in section.subsections.all():
+                if "page-break" in subsection.html_class:
+                    found_page_break = True
+                    break
+            if found_page_break:
+                break
+
+        self.assertTrue(
+            found_page_break,
+            "Expected to find at least one subsection with page-break class",
+        )
+
+    def test_reimport_does_not_preserve_page_breaks_when_unchecked(self):
+        """Test that page breaks are not preserved when the checkbox is unchecked."""
+        # Verify initial state has page breaks
+        initial_has_page_break = False
+        for section in self.nofo.sections.all():
+            for subsection in section.subsections.all():
+                if "page-break" in subsection.html_class:
+                    initial_has_page_break = True
+                    break
+            if initial_has_page_break:
+                break
+
+        self.assertTrue(
+            initial_has_page_break,
+            "Test setup should include at least one subsection with page-break class",
+        )
+
+        # Create a test file with HTML content
+        test_file = self.create_test_file()
+
+        # Make the POST request to reimport
+        response = self.client.post(
+            reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
+            {
+                "nofo-import": test_file,
+                "preserve_page_breaks": "off",
+                "csrfmiddlewaretoken": "dummy",
+            },
+            follow=True,
+        )
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+
+        # Get the updated NOFO and its sections/subsections
+        updated_nofo = Nofo.objects.get(id=self.nofo.id)
+        updated_sections = updated_nofo.sections.all()
+
+        # Verify no page breaks were preserved
+        for section in updated_sections:
+            for subsection in section.subsections.all():
+                self.assertNotIn("page-break", subsection.html_class)
+
+    def test_reimport_success_behavior(self):
+        """Test success message and redirect behavior for reimport."""
+        # Create a test file with HTML content
+        test_file = self.create_test_file()
+
+        # Make the POST request to reimport
+        response = self.client.post(
+            reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
+            {
+                "nofo-import": test_file,
+                "preserve_page_breaks": "on",
+                "csrfmiddlewaretoken": "dummy",
+            },
+            follow=True,
+        )
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.redirect_chain), 1)
+        self.assertEqual(
+            response.redirect_chain[0][0],
+            reverse("nofos:nofo_edit", kwargs={"pk": self.nofo.id}),
+        )
+
+        # Check success message
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Re-imported NOFO from file: test.html")

--- a/bloom_nofos/nofos/tests/test_reimport.py
+++ b/bloom_nofos/nofos/tests/test_reimport.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 
 class NofoReimportTests(TestCase):
     def setUp(self):
-        # Create test user with required group
         self.user = BloomUser.objects.create_user(
             email="test@example.com",
             password="testpass123",
@@ -18,7 +17,6 @@ class NofoReimportTests(TestCase):
         self.client = Client()
         self.client.login(email="test@example.com", password="testpass123")
 
-        # Create test NOFO with required fields
         self.nofo = Nofo.objects.create(
             title="Test NOFO",
             short_name="test-nofo",
@@ -26,51 +24,57 @@ class NofoReimportTests(TestCase):
             group="bloom",
         )
 
-        # Create test section
         self.section = Section.objects.create(
             nofo=self.nofo,
             name="Test Section 1",
             order=1,
         )
 
-        # Create test subsections with different page break classes
+        # Create test subsections with initial content and classes
         self.subsections = []
         subsection_data = [
-            ("Subsection 1", "page-break-before"),
-            ("Subsection 2", "page-break-after"),
-            ("Subsection 3", "page-break"),
-            ("Subsection 4", "no-page-break"),
+            {
+                "name": "Eligibility Information",
+                "html_class": "",
+                "body": "Original eligibility content",
+            },
+            {
+                "name": "Program Requirements",
+                "html_class": "custom-class",
+                "body": "Original program requirements",
+            },
+            {
+                "name": "Award Information",
+                "html_class": "",
+                "body": "Original award information",
+            },
         ]
 
-        for i, (name, html_class) in enumerate(subsection_data):
+        for i, data in enumerate(subsection_data):
             subsection = Subsection.objects.create(
                 section=self.section,
-                name=name,
+                name=data["name"],
                 order=i + 1,
-                html_class=html_class,
+                html_class=data["html_class"],
                 tag="h2",
-                body=f"Content for {name}",
+                body=data["body"],
             )
             self.subsections.append(subsection)
 
-    def create_test_file(self):
-        """Create a test HTML file for reimporting."""
+    def create_test_file(self, with_page_breaks=False):
+        """Create a test HTML file for reimporting with optional page breaks in content."""
         html_content = """
         <html>
-        <head>
-            <title>Test NOFO</title>
-        </head>
+        <head><title>Test NOFO</title></head>
         <body>
             <p>Opdiv: ACF</p>
             <h1>Test Section 1</h1>
-            <h2>Subsection 1</h2>
-            <p>Content for Subsection 1</p>
-            <h2>Subsection 2</h2>
-            <p>Content for Subsection 2</p>
-            <h2>Subsection 3</h2>
-            <p>Content for Subsection 3</p>
-            <h2>Subsection 4</h2>
-            <p>Content for Subsection 4</p>
+            <h2>Eligibility Information</h2>
+            <p>Updated eligibility content with new requirements</p>
+            <h2 class="custom-class">Program Requirements</h2>
+            <p>Updated program requirements with new guidelines</p>
+            <h2>Award Information</h2>
+            <p>Updated award information with new amounts</p>
         </body>
         </html>
         """
@@ -79,11 +83,21 @@ class NofoReimportTests(TestCase):
         )
 
     def test_reimport_preserves_page_breaks_when_checked(self):
-        """Test that page breaks are preserved when the checkbox is checked."""
-        # Create a test file with HTML content
+        """Test that page breaks are preserved when checkbox is checked while content is updated."""
+        # Add page breaks to simulate manual addition
+        self.subsections[0].html_class = "page-break-before"
+        self.subsections[0].save()
+        self.subsections[1].html_class = "custom-class page-break-before"
+        self.subsections[1].save()
+
         test_file = self.create_test_file()
 
-        # Make the POST request to reimport
+        # Verify initial state
+        self.assertEqual(self.subsections[0].body, "Original eligibility content")
+        self.assertTrue("page-break-before" in self.subsections[0].html_class)
+        self.assertTrue("page-break-before" in self.subsections[1].html_class)
+        self.assertTrue("custom-class" in self.subsections[1].html_class)
+
         response = self.client.post(
             reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
             {
@@ -94,77 +108,69 @@ class NofoReimportTests(TestCase):
             follow=True,
         )
 
-        # Check response
         self.assertEqual(response.status_code, 200)
 
-        # Get the updated NOFO and its sections/subsections
+        # Verify content was updated but page breaks were preserved
         updated_nofo = Nofo.objects.get(id=self.nofo.id)
-        updated_sections = updated_nofo.sections.all()
-
-        # Verify page breaks were preserved
-        found_page_break = False
-        for section in updated_sections:
-            for subsection in section.subsections.all():
-                if "page-break" in subsection.html_class:
-                    found_page_break = True
-                    break
-            if found_page_break:
-                break
-
-        self.assertTrue(
-            found_page_break,
-            "Expected to find at least one subsection with page-break class",
+        updated_subsections = (
+            updated_nofo.sections.first().subsections.all().order_by("order")
         )
+
+        self.assertEqual(
+            updated_subsections[0].body.strip(),
+            "Updated eligibility content with new requirements",
+        )
+        self.assertTrue("page-break-before" in updated_subsections[0].html_class)
+        self.assertTrue("page-break-before" in updated_subsections[1].html_class)
+        self.assertTrue("custom-class" in updated_subsections[1].html_class)
 
     def test_reimport_does_not_preserve_page_breaks_when_unchecked(self):
-        """Test that page breaks are not preserved when the checkbox is unchecked."""
-        # Verify initial state has page breaks
-        initial_has_page_break = False
-        for section in self.nofo.sections.all():
-            for subsection in section.subsections.all():
-                if "page-break" in subsection.html_class:
-                    initial_has_page_break = True
-                    break
-            if initial_has_page_break:
-                break
+        """Test that page breaks are removed when checkbox is unchecked while other classes are preserved."""
+        # Add page breaks to simulate manual addition
+        self.subsections[0].html_class = "page-break-before"
+        self.subsections[0].save()
+        self.subsections[1].html_class = "custom-class page-break-before"
+        self.subsections[1].save()
 
-        self.assertTrue(
-            initial_has_page_break,
-            "Test setup should include at least one subsection with page-break class",
-        )
-
-        # Create a test file with HTML content
         test_file = self.create_test_file()
 
-        # Make the POST request to reimport
+        # Verify initial state
+        self.assertEqual(self.subsections[0].body, "Original eligibility content")
+        self.assertTrue("page-break-before" in self.subsections[0].html_class)
+        self.assertTrue("page-break-before" in self.subsections[1].html_class)
+        self.assertTrue("custom-class" in self.subsections[1].html_class)
+
         response = self.client.post(
             reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
             {
                 "nofo-import": test_file,
-                "preserve_page_breaks": "off",
                 "csrfmiddlewaretoken": "dummy",
             },
             follow=True,
         )
 
-        # Check response
         self.assertEqual(response.status_code, 200)
 
-        # Get the updated NOFO and its sections/subsections
         updated_nofo = Nofo.objects.get(id=self.nofo.id)
-        updated_sections = updated_nofo.sections.all()
+        updated_subsections = (
+            updated_nofo.sections.first().subsections.all().order_by("order")
+        )
 
-        # Verify no page breaks were preserved
-        for section in updated_sections:
-            for subsection in section.subsections.all():
-                self.assertNotIn("page-break", subsection.html_class)
+        self.assertEqual(
+            updated_subsections[0].body.strip(),
+            "Updated eligibility content with new requirements",
+        )
+        self.assertFalse("page-break-before" in updated_subsections[0].html_class)
+        self.assertFalse("page-break-before" in updated_subsections[1].html_class)
+        self.assertTrue(
+            "custom-class" in updated_subsections[1].html_class,
+            "custom-class should be present because it's in the imported HTML",
+        )
 
     def test_reimport_success_behavior(self):
         """Test success message and redirect behavior for reimport."""
-        # Create a test file with HTML content
         test_file = self.create_test_file()
 
-        # Make the POST request to reimport
         response = self.client.post(
             reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
             {
@@ -175,7 +181,6 @@ class NofoReimportTests(TestCase):
             follow=True,
         )
 
-        # Check response
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.redirect_chain), 1)
         self.assertEqual(
@@ -183,7 +188,6 @@ class NofoReimportTests(TestCase):
             reverse("nofos:nofo_edit", kwargs={"pk": self.nofo.id}),
         )
 
-        # Check success message
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
         self.assertEqual(str(messages[0]), "Re-imported NOFO from file: test.html")

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -320,21 +320,16 @@ def nofo_import(request, pk=None):
             try:
                 nofo.filename = filename
 
-                # Always preserve metadata, but filter page breaks if checkbox is unchecked
-                preserved_metadata = preserve_subsection_metadata(nofo, sections)
+                # Preserve page breaks if checkbox is checked
+                preserved_page_breaks = {}
+                if request.POST.get("preserve_page_breaks") == "on":
+                    preserved_page_breaks = preserve_subsection_metadata(nofo, sections)
+
                 nofo = overwrite_nofo(nofo, sections)
 
-                # If preserve_page_breaks is not checked, remove page break classes from preserved metadata
-                if request.POST.get("preserve_page_breaks") != "on":
-                    for key in preserved_metadata:
-                        if "html_class" in preserved_metadata[key]:
-                            classes = preserved_metadata[key]["html_class"].split()
-                            classes = [
-                                c for c in classes if not c.startswith("page-break")
-                            ]
-                            preserved_metadata[key]["html_class"] = " ".join(classes)
-
-                nofo = restore_subsection_metadata(nofo, preserved_metadata)
+                # Restore page breaks if any were preserved
+                if preserved_page_breaks:
+                    nofo = restore_subsection_metadata(nofo, preserved_page_breaks)
 
                 add_headings_to_nofo(nofo)
                 add_page_breaks_to_headings(nofo)

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -324,7 +324,7 @@ def nofo_import(request, pk=None):
                     preserved_metadata,
                     (callout_count, callout_items),
                     (html_class_count, html_class_items),
-                ) = preserve_subsection_metadata(nofo)
+                ) = preserve_subsection_metadata(nofo, sections)
 
                 nofo = overwrite_nofo(nofo, sections)
                 nofo = restore_subsection_metadata(nofo, preserved_metadata)
@@ -333,13 +333,6 @@ def nofo_import(request, pk=None):
                 add_page_breaks_to_headings(nofo)
                 suggest_all_nofo_fields(nofo, soup)
                 nofo.save()
-
-                # Unpack the preserved counts and items
-                (
-                    preserved_metadata,
-                    (callout_count, callout_items),
-                    (html_class_count, html_class_items),
-                ) = preserve_subsection_metadata(nofo)
 
                 # Build success message starting with the basic info
                 success_msg = (

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -320,12 +320,20 @@ def nofo_import(request, pk=None):
             try:
                 nofo.filename = filename
 
-                preserved_metadata = {}
-                # Only preserve metadata if checkbox is checked
-                if request.POST.get("preserve_page_breaks", "on") == "on":
-                    preserved_metadata = preserve_subsection_metadata(nofo, sections)
-
+                # Always preserve metadata, but filter page breaks if checkbox is unchecked
+                preserved_metadata = preserve_subsection_metadata(nofo, sections)
                 nofo = overwrite_nofo(nofo, sections)
+
+                # If preserve_page_breaks is not checked, remove page break classes from preserved metadata
+                if request.POST.get("preserve_page_breaks") != "on":
+                    for key in preserved_metadata:
+                        if "html_class" in preserved_metadata[key]:
+                            classes = preserved_metadata[key]["html_class"].split()
+                            classes = [
+                                c for c in classes if not c.startswith("page-break")
+                            ]
+                            preserved_metadata[key]["html_class"] = " ".join(classes)
+
                 nofo = restore_subsection_metadata(nofo, preserved_metadata)
 
                 add_headings_to_nofo(nofo)


### PR DESCRIPTION
This code allows us to save metadata for subsections on reimport, and apply them to the new import.  It tracks those changes and tells the user what changes were preserved as part of the success message on reimport.

QA Steps:
- Import a nofo
- make a subsection a callout field
- change a subsections html class
- reimport the same nofo
- verify that the success message reflects the changes you made
- verify that the changes are actually still what you set them to be

Note: There is currently behavior for page breaks that is showing them as changed, whether they were in the original document or not.  I'm not sure if this is actually an issue or not, to verify this, upload a nofo, and then reupload the same nofo.  The success message will tell you the page breaks are preserved, even if they were originally there.

Screenshot: 
<img width="1335" alt="image" src="https://github.com/user-attachments/assets/2c84a55e-58b3-4956-8961-9c2358d076e6" />

<img width="912" alt="image" src="https://github.com/user-attachments/assets/5300a7f3-1b67-4b10-b051-a9fb4357eec1" />

