### PR TITLE
[WIP] NOFO re-import text diff UI concept

### DIFF
--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -875,3 +875,27 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 .usa-error-message {
   font-size: 1rem;
 }
+
+/* comparison form */
+
+.comparison-form {
+  max-width: 100%;
+}
+
+.comparison-form ul {
+  list-style: none;
+}
+
+.comparison-form summary {
+  margin-bottom: 10px;
+}
+
+.comparison-form .comparison-form--subsection-list li label {
+  display: flex;
+  align-items: baseline;
+  gap: 1em;
+}
+
+.comparison-form .diff {
+  margin: 10px 0;
+}

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -1,0 +1,97 @@
+{% extends 'base.html' %}
+{% load nofo_name %}
+
+{% block title %}
+  Compare “{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}”
+{% endblock %}
+
+{% block body_class %}nofo_import nofo_import--compare{% endblock %}
+
+{% block content %}
+
+  {% with nofo|nofo_name as nofo_name_str %}
+    {% with "Edit  “"|add:nofo_name_str|add:"”" as back_text %}
+      {% url 'nofos:nofo_edit' nofo.id as back_href %}
+      {% include "includes/page_heading.html" with title="Compare “"|add:nofo_name_str|add:"” to a new document" back_text=back_text back_href=back_href only %}
+    {% endwith %}
+  {% endwith %}
+
+  <p>Upload a NOFO file to compare with to “{{nofo|nofo_name}}”</p>
+  <form id="nofo-import--form" class="form-import--loading" method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {% with id="nofo-import" label="Select NOFO file" hint="Accepts .docx or .html files." value=title %}
+      {% for message in messages %}
+        {% if "error" in message.tags %}
+          {% include "includes/file_input.html" with id=id label=label hint=hint error=message only %}
+        {% endif %}
+      {% empty %}
+        {% include "includes/file_input.html" with id=id label=label hint=hint only %}
+      {% endfor %}
+    {% endwith %}
+
+    {% include "includes/loading_horse.html" %}
+
+    <button class="usa-button margin-top-3 submit-button" type="submit">Compare NOFOs</button>
+  </form>
+
+  {% if nofo_comparison %}
+    <form id="comparison-form" class="usa-form margin-top-4 comparison-form">
+      <h2>Accept or Reject Changes</h2>
+
+      <p>
+        There are <strong>{{ num_changed_subsections }}</strong> subsection{{ num_changed_subsections|pluralize }} with changes in {{ num_changed_sections }} section{{ num_changed_sections|pluralize }}.
+      </p>
+
+      <ul>
+        {% for section in nofo_comparison %}
+          <li>
+            <h3>Section: {{ section.name }}</h3>
+            <ul class="comparison-form--subsection-list">
+              {% for subsection in section.subsections %}
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="subsections"
+                      value="{{ subsection.name }}"
+                      class="subsection-checkbox"
+                    />
+                    <details>
+                      <summary>{{ subsection.name }}</summary>
+                      <div class="diff">{{ subsection.diff_body|safe }}</div>
+                    </details>
+                  </label>
+                </li>
+              {% endfor %}
+            </ul>
+          </li>
+        {% endfor %}
+      </ul>
+
+      <div class="button-group margin-bottom-2">
+        <button type="button" class="usa-button usa-button--outline" id="select-all">Select All</button>
+        <button type="button" class="usa-button usa-button--outline" id="deselect-all">Deselect All</button>
+      </div>
+
+      <button type="submit" class="usa-button margin-top-3">Submit Changes</button>
+    </form>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const selectAllButton = document.getElementById("select-all");
+        const deselectAllButton = document.getElementById("deselect-all");
+        const checkboxes = document.querySelectorAll(".subsection-checkbox");
+    
+        selectAllButton.addEventListener("click", function (event) {
+          event.preventDefault();
+          checkboxes.forEach((checkbox) => (checkbox.checked = true));
+        });
+    
+        deselectAllButton.addEventListener("click", function (event) {
+          event.preventDefault();
+          checkboxes.forEach((checkbox) => (checkbox.checked = false));
+        });
+      });
+    </script>
+  {% endif %}
+{% endblock %}

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("import", views.nofo_import, name="nofo_import"),
     path("<int:pk>/delete", views.NofosArchiveView.as_view(), name="nofo_archive"),
     path("<int:pk>/import", views.nofo_import, name="nofo_import_overwrite"),
+    path("<int:pk>/compare", views.nofo_compare, name="nofo_compare"),
     path(
         "<int:pk>/import/title",
         views.NofoImportTitleView.as_view(),


### PR DESCRIPTION
## Summary

⚠️  DO NOT MERGE THIS PR. IT IS A CONCEPT ONLY ⚠️ 

This is related to #125.

### What is it?

The idea here is to demo a UI concept for re-importing a NOFO with changes from the current NOFO.

The objective here is to provide a simple way for people to y/n changes that have happened since their last import. The idea would be that you can see all the changed subsections and either select "yes, import the new content" (check the box) or "no, keep my content" (uncheck the box). 

Only the titles of edited subsections would be shown and then people would be able to click into each one to see the specific change. 

Changes can happen in 2 ways: 

1. You have manually edited a subsection using the NOFO Builder
2. The content in the Word Doc has changed

Regardless, the text diff will show additions and deletions, it doesn't differentiate where the change comes from.

Added some buttons at the bottom for people who will either say "just import and take everything", or "do not overwrite anything" (metadata and classnames* etc will still get imported).

### How to test this

1. Make a "save as" version of an existing NOFO word doc you have.
2. Add some changes to the new doc
3. Import the first Word doc to create a new NOFO
4. Go to the "edit" page for your new NOFO
5. Manually navigate to `/nofos/(id)/compare`
6. Import your "save as" version of the NOFO
7. Be amazed

### gif

![Screen Recording 2025-01-03 at 5 03 32 PM](https://github.com/user-attachments/assets/bf4430ba-039a-4e7a-b182-44eff8b29083)

### TODOs

There are some major problems with this code as it stands:

1. It doesn't import anything
2. It creates a new NOFO every time you run it
3. It is extremely moist (not even trying to be DRY)
4. It doesn't handle new subsections or removed subsections
5. Lots of problems

But anyway, it's a start. Let's discuss further next week. Adam is on board.