### PR TITLE
Show H7 headings in "edit" and "preview" modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Changed
 
 - Change heading sizes in edit mode
+- Remove "Fix in Word and reimport." note in warning message
 - Change ACF heading styles
   - h1s: 36 pt, 700
   - h4s: 600

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
+- Add heading styles for H7s in edit and preview modes
 - Add cover image for HRSA-25-007
 - Add list style for quint nested lis
 
 ### Changed
 
+- Change heading sizes in edit mode
 - Change ACF heading styles
   - h1s: 36 pt, 700
   - h4s: 600

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -574,6 +574,44 @@ details > summary > span:hover {
   font-size: 12px;
 }
 
+.section_edit .nofo-edit-table--subsection--body h1,
+.nofo_edit .nofo-edit-table--subsection--body h1 {
+  font-size: 2.202rem;
+}
+
+.section_edit .nofo-edit-table--subsection--body h2,
+.nofo_edit .nofo-edit-table--subsection--body h2 {
+  font-size: 2.002rem;
+}
+
+.section_edit .nofo-edit-table--subsection--body h3,
+.nofo_edit .nofo-edit-table--subsection--body h3 {
+  font-size: 1.802rem;
+}
+
+.section_edit .nofo-edit-table--subsection--body h4,
+.nofo_edit .nofo-edit-table--subsection--body h4 {
+  font-size: 1.602rem;
+}
+
+.section_edit .nofo-edit-table--subsection--body h5,
+.nofo_edit .nofo-edit-table--subsection--body h5 {
+  font-size: 1.424rem;
+}
+
+.section_edit .nofo-edit-table--subsection--body h6,
+.nofo_edit .nofo-edit-table--subsection--body h6 {
+  font-size: 1.225rem;
+}
+
+.section_edit .nofo-edit-table--subsection--body div[role="heading"],
+.nofo_edit .nofo-edit-table--subsection--body div[role="heading"] {
+  font-size: 1.105rem;
+  font-weight: 700;
+  margin-block-start: 1.25em;
+  margin-block-end: 1.25em;
+}
+
 .section_edit .nofo-edit-table--subsection--body,
 .nofo_edit .nofo-edit-table--subsection--body {
   word-break: break-word;
@@ -835,6 +873,13 @@ main .back-link a::before,
 .subsection_create .main-martor .resizable .resizable-b {
   width: 100%;
   cursor: row-resize;
+}
+
+.subsection_edit div.martor-preview div[role="heading"] {
+  color: #777;
+  font-size: 12.5px;
+  font-weight: 600;
+  font-variant: small-caps;
 }
 
 details.usa-accordion .usa-accordion__button {

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -411,7 +411,7 @@ Edit “{{ nofo|nofo_name }}”
             id="{{ subsection.html_id }}">
             <span class="floating">
               {% if subsection.name %}
-                <span {% if subsection|has_heading_error:heading_errors %}class="usa-tooltip" data-position="bottom" title="{{ subsection|get_heading_error:heading_errors|split_char_and_remove:":" }}. Fix in Word and reimport."{% endif %}>
+                <span {% if subsection|has_heading_error:heading_errors %}class="usa-tooltip" data-position="bottom" title="{{ subsection|get_heading_error:heading_errors|split_char_and_remove:":" }}."{% endif %}>
                   {{ subsection.name }}
                 </span>
               {% else %}


### PR DESCRIPTION
## Summary

This PR makes 3 changes:

1. Add h7 styles to the "edit" mode and "preview" pane in the markdown editor
2. Update body-text header styling in the NOFO content for the edit page
3. Remove the "Fix in Word and reimport" in heading error messages

### 1. Add h7 styles to the "edit" mode and "preview" pane 

Since our H7 styles are shimmed, they don't show up as regular HTML elements would. These means we need to add custom styling if we want to see them show up in the edit mode. 

Here is how it looks now in the "Edit" screen:

| before | after |
|--------|-------|
|  h6 is too small. <br> h7 has no styling.       |    h6 is proportional. <br> h7 is styled like a heading.  |
|      <img width="802" alt="Screenshot 2025-01-06 at 3 30 43 PM" src="https://github.com/user-attachments/assets/89e1630a-ca22-4094-b819-7f5fa1e88d49" /> |    <img width="802" alt="Screenshot 2025-01-06 at 3 30 21 PM" src="https://github.com/user-attachments/assets/7d6c669c-5a36-4382-8f14-cf96f454ffbf" />    |


And here is how it looks on the "Preview" pane of the markdown editor:

| before | after |
|--------|-------|
|  h7 looks like body text      |   h7 has styling that differentiates if from body text     |
|  <img width="990" alt="Screenshot 2025-01-06 at 3 27 51 PM" src="https://github.com/user-attachments/assets/8105da93-b137-438d-912d-2002d182be6f" />      |    <img width="990" alt="Screenshot 2025-01-06 at 3 27 13 PM" src="https://github.com/user-attachments/assets/94a2d8c2-a1c6-489a-8f3f-23468e0991cc" />   |

Note that the heading levels in the preview pane are not the same as on the "edit" page because there is some opinionated styling (using lots of `!important`s) being applied to that preview content, and I figured I would just leave it intact rather than trying to override everything.

### 3. Remove the "Fix in Word and reimport" 

When we wrote that message, it wasn't yet possible to change a heading level using the NOFO Builder. Since then, you can do it and people are doing it. So no need for the "Reimport" message at this point, since you don't need to do that.

| before | after |
|--------|-------|
|   <img width="416" alt="Screenshot 2025-01-06 at 4 32 26 PM" src="https://github.com/user-attachments/assets/a7c39ab1-a7e9-4801-bc9a-705b0ef04356" />     |    <img width="248" alt="Screenshot 2025-01-06 at 4 39 27 PM" src="https://github.com/user-attachments/assets/7ee79985-2c3d-420b-b2e8-2aa17284d51e" />   |

