### PR TITLE
Fix links in callout boxes + All links are blue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Fix for links after colons in callout boxes
+  - Visually, they would look like "Key:Link", now they look like "Key: Link"
+
 ## [1.42.0] - 2023-12-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - All tables in appendices are full-width
 - Speed up "create_nofo" function
   - Batch create sections and subsections in "\_build_nofo"
+- All links are blue now, not black
+- White background in svg circle in HRSA light
 
 ### Fixed
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
@@ -143,10 +143,6 @@ h5 {
   color: var(--color--black);
 }
 
-.callout-box--contents a {
-  color: var(--color--black);
-}
-
 .callout-box--icon {
   background-color: var(--color-white);
   border: 2px solid var(--color--light-black);

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dop.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dop.css
@@ -217,10 +217,6 @@ h4 {
   color: var(--color--black);
 }
 
-.callout-box--contents a {
-  color: var(--color--black);
-}
-
 .callout-box--icon {
   background-color: var(--color--dop-blue);
   color: var(--color--white);

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
@@ -127,6 +127,10 @@ h4 {
   color: var(--color--black);
 }
 
+.callout-box--icon .callout-box--contents svg {
+  fill: var(--color--white);
+}
+
 table th {
   color: var(--color--white);
   background-color: var(--color--hrsa-blue);

--- a/bloom_nofos/nofos/templatetags/callout_box_contents.py
+++ b/bloom_nofos/nofos/templatetags/callout_box_contents.py
@@ -4,35 +4,10 @@ from bs4 import BeautifulSoup
 from django import template
 from django.utils.safestring import mark_safe
 
+from .utils import wrap_text_before_colon_in_strong
+
+
 register = template.Library()
-
-
-def wrap_text_before_colon_in_strong(p, soup):
-    # Initialize a flag to track when the colon is found
-    found_colon = False
-    # Create a strong tag
-    strong_tag = soup.new_tag("strong")
-    span_tag = soup.new_tag("span")
-
-    # Iterate over contents, moving elements before the colon to the strong tag
-    for content in p.contents[:]:
-        if found_colon:
-            span_tag.append(content.extract())
-        else:
-            if isinstance(content, str) and ":" in content:
-                before_colon, after_colon = content.split(":", 1)
-                strong_tag.append(before_colon + ":")
-                # Replace the original content with what's after the colon
-                span_tag.append(after_colon)
-                found_colon = True  # Mark colon as found
-            else:
-                # Move content to strong tag if colon not yet found
-                strong_tag.append(content.extract())
-
-    # Insert the strong tag at the beginning of the paragraph
-    p.clear()
-    p.append(strong_tag)
-    p.append(span_tag)
 
 
 @register.filter()

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -344,3 +344,37 @@ def match_numbered_sublist(text):
 
     # Check if the text matches any of the sublist numbering patterns
     return re.match(pattern, text)
+
+
+def wrap_text_before_colon_in_strong(p, soup):
+    if not ":" in p.get_text():
+        return p
+
+    # Initialize a flag to track when the colon is found
+    found_colon = False
+    # Create a strong tag
+    strong_tag = soup.new_tag("strong")
+    span_tag = soup.new_tag("span")
+
+    # Iterate over contents, moving elements before the colon to the strong tag
+    for content in p.contents[:]:
+        if found_colon:
+            span_tag.append(content.extract())
+        else:
+            if isinstance(content, str) and ":" in content:
+                before_colon, after_colon = content.split(":", 1)
+                strong_tag.append(before_colon + ":")
+                # Replace the original content with what's after the colon
+                span_tag.append(after_colon)
+                found_colon = True  # Mark colon as found
+            else:
+                # Move content to strong tag if colon not yet found
+                strong_tag.append(content.extract())
+
+    # insert an extra space after the colon in the strong tag
+    strong_tag.append(" ")
+
+    # Insert the strong tag at the beginning of the paragraph
+    p.clear()
+    p.append(strong_tag)
+    p.append(span_tag)

--- a/bloom_nofos/nofos/tests/test_templatetags.py
+++ b/bloom_nofos/nofos/tests/test_templatetags.py
@@ -21,6 +21,7 @@ from nofos.templatetags.utils import (
     is_floating_callout_box,
     is_footnote_ref,
     match_numbered_sublist,
+    wrap_text_before_colon_in_strong,
 )
 
 
@@ -956,3 +957,73 @@ class MatchNumberedSublistTest(TestCase):
 
     def test_empty_string(self):
         self.assertFalse(match_numbered_sublist(""))
+
+
+class WrapTextBeforeColonInStrongTests(TestCase):
+    def test_simple_paragraph(self):
+        """Test a basic paragraph with text before and after the colon."""
+        html = "<p>Label: Value</p>"
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        expected_html = "<p><strong>Label: </strong><span> Value</span></p>"
+        self.assertEqual(str(paragraph), expected_html)
+
+    def test_paragraph_with_link(self):
+        """Test a paragraph with a link after the colon."""
+        html = '<p>Link: <a href="https://example.com">Example</a></p>'
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        expected_html = '<p><strong>Link: </strong><span> <a href="https://example.com">Example</a></span></p>'
+        self.assertEqual(str(paragraph), expected_html)
+
+    def test_no_colon(self):
+        """Test a paragraph with no colon."""
+        html = "<p>No colon here</p>"
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        # In practice, we only call this func if there is a colon in the text string.
+        expected_html = "<p>No colon here</p>"
+        self.assertEqual(str(paragraph), expected_html)
+
+    def test_multiple_colons(self):
+        """Test a paragraph with multiple colons."""
+        html = "<p>First: Second: Third</p>"
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        # Only the first colon should be handled
+        expected_html = "<p><strong>First: </strong><span> Second: Third</span></p>"
+        self.assertEqual(str(paragraph), expected_html)
+
+    def test_nested_elements(self):
+        """Test a paragraph with nested elements before and after the colon."""
+        html = '<p><span>Nested</span>: <ul><li><a href="https://example.com">Example</a></li></ul></p>'
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        expected_html = '<p><strong><span>Nested</span>: </strong><span> <ul><li><a href="https://example.com">Example</a></li></ul></span></p>'
+        self.assertEqual(str(paragraph), expected_html)
+
+    def test_only_colon(self):
+        """Test a paragraph with just a colon."""
+        html = "<p>:</p>"
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        expected_html = "<p><strong>: </strong><span></span></p>"
+        self.assertEqual(str(paragraph), expected_html)


### PR DESCRIPTION
## Summary

There are 3 (small) changes in this PR:

- Fixes links in callout boxes that touch the colon (solves issue #148)
- Standardizes our links as blue (Solves issue #147)
- Adds Jana as a designer (may remove this from the PR depending on whether #138 will go in afterwards)

### 1. Fixes links in callout boxes that touch the colon

This was to do with how HTML handles whitespace. When we had text only, the HTML looked like this:

```html
<p><strong>Stat authority:</strong><span> Here it is</span></p>
```

In that case, the space in the `span` element is preserved when rendered.

However, when the text after the colon started with a link, we would get this:

```html
<p><strong>Stat authority:</strong><span> <a href="https://google.com">Here it is</a></span></p>
```

This space disappears, and if we were to add a space to the link itself, we would see the underline continue up to the colon. Not what we want. 

The solution was to insert a space into the `strong` tag after the colon, so now we have this:

```html
<p><strong>Stat authority: </strong><span> <a href="https://google.com">Here it is</a></span></p>
```

And that seems to work just fine.

| before | after |
|--------|-------|
|    <img width="299" alt="Screenshot 2025-01-08 at 10 11 47 AM" src="https://github.com/user-attachments/assets/f46b71a6-718f-48f7-b1f7-ae8c1f587f5c" />    |   <img width="299" alt="Screenshot 2025-01-08 at 10 11 18 AM" src="https://github.com/user-attachments/assets/b22f23b6-8d06-412e-b658-8b973f28d8cd" />    |

### 2. Standardizes our links as blue 

Links should always be blue, we have decided. 

| before | after |
|--------|-------|
|   <img width="299" alt="Screenshot 2025-01-08 at 10 14 18 AM" src="https://github.com/user-attachments/assets/813ad4b4-bae2-4ef4-91b9-21e365cabbed" />     |   <img width="299" alt="Screenshot 2025-01-08 at 10 14 45 AM" src="https://github.com/user-attachments/assets/995f3fa1-d7bc-4c72-bbb4-5955798ab812" />    |

Also, added a white circle to this HRSA callout box because it looks better.

| before | after |
|--------|-------|
|    <img width="299" alt="Screenshot 2025-01-08 at 10 15 19 AM" src="https://github.com/user-attachments/assets/fb78eefa-7b07-4d11-a166-1064f2db1bb2" />    |    <img width="299" alt="Screenshot 2025-01-08 at 10 15 48 AM" src="https://github.com/user-attachments/assets/79e18704-f8ce-4527-9bf6-57304260be5b" />   |


