### PR TITLE
Return sections by "order" for nofo.get_first_subsection()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Versioning since version 1.0.0.
 - Fixes issue where archiving a NOFO would fail due to validation checks requiring at least one section
 - Links starting with "file:///" should be flagged as broken links
 - Hotfix to make viewing content tables easier in edit view
+- Return sections by "order" for nofo.get_first_subsection()
 
 ## [2.1.0] - 2025-01-01
 

--- a/bloom_nofos/nofos/models.py
+++ b/bloom_nofos/nofos/models.py
@@ -310,7 +310,12 @@ class Nofo(models.Model):
         return reverse("nofos:nofo_edit", args=(self.id,))
 
     def get_first_subsection(self):
-        return self.sections.first().subsections.order_by("order").first()
+        return (
+            self.sections.order_by("order")
+            .first()
+            .subsections.order_by("order")
+            .first()
+        )
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
## Summary

This PR contains 1 change, which is (in practice) to show the "Basic information" heading if our sections are out of order.

Not having this ordering logic was causing a subtle bug for us. If the first section _created_ was not Step 1, it would grab the first heading of the first section _created_, not "Step 1", which is what we would obviously prefer.

| before | after |
|--------|-------|
|    No "basic information" heading    |    All good!   |
|    <img width="583" alt="Screenshot 2025-01-13 at 6 20 22 PM" src="https://github.com/user-attachments/assets/032b6353-12f6-4ce9-96e5-b95e47299807" />  |   <img width="583" alt="Screenshot 2025-01-13 at 6 20 40 PM" src="https://github.com/user-attachments/assets/06cca957-48a1-4488-a736-a95281a867e4" />     |

This bug is described further in this issue:
- https://github.com/HHS/simpler-grants-pdf-builder/issues/159