### PR TITLE
logic and tests for returning nofos with ordered sections

### DIFF
--- a/bloom_nofos/nofos/api/api.py
+++ b/bloom_nofos/nofos/api/api.py
@@ -58,6 +58,19 @@ def get_nofo(request, nofo_id: int):
     """Export a NOFO by ID"""
     try:
         nofo = Nofo.objects.get(id=nofo_id, archived__isnull=True)
-        return 200, nofo
+
+        # Use a dictionary representation of the NOFO to sort
+        nofo_dict = NofoSchema.from_orm(nofo).dict()
+
+        # Sort sections
+        nofo_dict["sections"] = sorted(nofo_dict["sections"], key=lambda x: x["order"])
+
+        # Sort subsections
+        for section in nofo_dict["sections"]:
+            section["subsections"] = sorted(
+                section["subsections"], key=lambda x: x["order"]
+            )
+
+        return 200, nofo_dict
     except Nofo.DoesNotExist:
         return 404, {"message": "NOFO not found"}


### PR DESCRIPTION
Issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/159

This specifically addresses the second task in the above ticket.  This change makes it so that the api response has its sections and subsections are correctly ordered by their "order" property

Includes unit test

QA Steps:
- create a nofo
- add sections
- manually swap some sections around so that a they are in a different order than their creation order
- use the http://localhost:8000/api/nofos/{id} endpoint to retrieve that nofo
- verify that they are correctly ordered by order, not creation date