### PR TITLE
Add link to HTML from the subsection itself

### DIFF
--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -735,16 +735,6 @@ details > summary > span:hover {
   display: none;
 }
 
-.nofo_edit main .nofo-edit-table--subsection--body table tr.table--first-row th,
-.nofo_edit
-  main
-  .nofo-edit-table--subsection--body
-  table
-  tr.table--first-row
-  td {
-  width: 15%;
-}
-
 /* Section edit page */
 
 .section_edit .edit_section--other_sections {
@@ -890,6 +880,22 @@ main .back-link a::before,
   font-size: 12.5px;
   font-weight: 600;
   font-variant: small-caps;
+}
+
+.subsection_edit div.martor-preview table thead th > p,
+.subsection_edit div.martor-preview table tbody tr:first-of-type th p {
+  font-weight: 400;
+}
+
+.subsection_edit div.martor-preview table thead th p:first-child,
+.subsection_edit
+  div.martor-preview
+  table
+  tbody
+  tr:first-of-type
+  th
+  p:first-child {
+  font-weight: 600;
 }
 
 /* NOFO external links page */

--- a/bloom_nofos/bloom_nofos/templates/base.html
+++ b/bloom_nofos/bloom_nofos/templates/base.html
@@ -31,9 +31,14 @@
       </div>
       <nav aria-label="Primary navigation" class="usa-nav">
         <ul class="usa-nav__primary usa-accordion">
+          {% if user.is_superuser and nofo and subsection %}
+            <li class="usa-nav__primary-item">
+              <a href="{% url 'admin:nofos_subsection_change' subsection.id %}">Subsection admin link</a>
+            </li>
+          {% endif %}
           {% if user.is_superuser and nofo %}
             <li class="usa-nav__primary-item">
-              <a href="{{ nofo.get_admin_url }}">Edit NOFO in Admin</a>
+              <a href="{{ nofo.get_admin_url }}">NOFO admin link</a>
             </li>
           {% endif %}
           {% if user.is_authenticated %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -56,6 +56,11 @@
       </div>
       <nav aria-label="Primary navigation" class="usa-nav">
         <ul class="usa-nav__primary usa-accordion">
+          {% if user.is_superuser and nofo %}
+            <li class="usa-nav__primary-item">
+              <a href="{{ nofo.get_admin_url }}">NOFO admin link</a>
+            </li>
+          {% endif %}
           <li class="usa-nav__primary-item usa-nav__primary-item__right-padding">
             <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-nav-link">Edit this NOFO</a>
           </li>

--- a/bloom_nofos/nofos/templates/nofos/subsection_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_edit.html
@@ -22,10 +22,10 @@
     <div class="subsection_edit--header">
       <h1 class="font-heading-xl margin-y-0">Subsection: {% if subsection.name %}{{ subsection.name }}{% else %}(#{{ subsection.order }}){% endif %}</h1>
       {% if subsection.callout_box %}<h2 class="font-heading-lg margin-y-1 text-base"><span aria-hidden="true">📦</span> Callout box</h2>{% endif %}
-      {% if request.user.is_superuser %}
-        <div class="subsection_edit--header--view font-sans-md">
-          <a href="{% url 'admin:nofos_subsection_change' subsection.id %}">Edit in Admin</a>
-        </div>
+      {% if subsection.name %}
+      <div class="subsection_edit--header--view font-sans-md">
+        <a href="{% url 'nofos:nofo_view' nofo.id %}{{ "#"|add:subsection.html_id  }}" target="_blank">View HTML for subsection</a>
+      </div>
       {% endif %}
     </div>
   {% endwith %}


### PR DESCRIPTION
## Summary

This is a small PR that adds some links to make the editing and reviewing process easier. 

- Add 'admin' links to the header in the edit pages
- Add 'Edit' link to the subsection edit page
- Fix a CSS problem with table headings in the markdown preview

 Here's the biggest change as a screenshot.

| before | after |
|--------|-------|
|  Move "Admin" link to header      |   Add "View HTML" link in subsection    |
|     <img width="1566" alt="Screenshot 2025-01-17 at 5 44 00 PM" src="https://github.com/user-attachments/assets/a89c97a4-1e04-4cfa-bdf6-8ff0085cfb36" />   |    <img width="1566" alt="Screenshot 2025-01-17 at 5 43 27 PM" src="https://github.com/user-attachments/assets/f3efc1f4-8876-4db4-b713-c1b2cbf238a4" />   |

