### PR TITLE
Fix bage break UI & page break bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Can use 'page-break' to add a page-break in markdown body
+
 ### Changed
 
+- All page break visuals say "page-break" now, dropped the "-before", "-after"
+- In the nofo section editor, page breaks added to a section now say "page-break"
+  - Previously, it was just a dashed line, but nobody knew what that meant
+
 ### Fixed
+
+- Fix: page breaks were not possible to add to subsections without a heading
 
 ## [2.3.0] - 2025-01-17
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -563,17 +563,6 @@ details > summary > span:hover {
   border-bottom: 1px dotted #5c5c5c;
 }
 
-.nofo_edit .page-break--hr--container .page-break--hr--text {
-  position: absolute;
-  top: -8px;
-  left: 50%;
-  transform: translate(-50%);
-  background: white;
-  color: #5c5c5c;
-  font-family: monospace;
-  font-size: 12px;
-}
-
 .section_edit .nofo-edit-table--subsection--body h1,
 .nofo_edit .nofo-edit-table--subsection--body h1 {
   font-size: 2.202rem;
@@ -643,7 +632,7 @@ details > summary > span:hover {
 
 .nofo_edit main table.table--section {
   border-collapse: initial;
-  border-spacing: 0 5px;
+  border-spacing: 0 8px;
 }
 
 .nofo_edit main table.table--section th,
@@ -706,6 +695,21 @@ details > summary > span:hover {
 .nofo_edit table th.nofo-edit-table--subsection--name.page-break-before,
 .nofo_edit table th.nofo-edit-table--subsection--name.page-break-before ~ td {
   border-top: 2px dashed #5c5c5c;
+}
+
+.nofo_edit .page-break--hr--container .page-break--hr--text,
+.nofo_edit
+  table
+  th.nofo-edit-table--subsection--name.page-break-before::before {
+  content: "[ ↓ page-break ↓ ]";
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translate(-50%);
+  background: white;
+  color: #5c5c5c;
+  font-family: monospace;
+  font-size: 12px;
 }
 
 .nofo_edit table th.nofo-edit-table--subsection--name.column-break-before,
@@ -780,6 +784,7 @@ main .back-link a::before,
   margin-left: 3px;
 }
 
+.nofo_edit .table--section tr,
 .section_edit .table--section tr {
   position: relative;
 }

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -1113,13 +1113,11 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   }
 
   /* Page break rules */
-  .page-break-before,
   .page-break-before--heading,
   .page-break--hr--container hr.page-break-before.page-break--hr {
     border-top: 2px dashed var(--color--med-grey);
   }
 
-  .page-break-after,
   .page-break-after--heading,
   .page-break--hr--container hr.page-break-after.page-break--hr {
     border-bottom: 2px dashed var(--color--med-grey);
@@ -1223,13 +1221,13 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   }
 
   /* Page break rules */
-  .page-break-before,
+  .page-break-before--container .page-break-before,
   .page-break-before--heading {
     break-before: page !important;
     page-break-before: always !important;
   }
 
-  .page-break-after,
+  .page-break-before--container .page-break-after,
   .page-break-after--heading {
     break-after: page !important;
     page-break-after: always !important;

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -391,6 +391,11 @@
             {% endif %}
           {% else %}
             {% if subsection.name|lower != 'basic information' %}
+              {% spaceless %}
+              {% if 'page-break-before' in subsection.html_class %}
+                {{ '<p>page-break-before</p>'|convert_paragraphs_to_hrs }}
+              {% endif %}
+              {% endspaceless %}
               {% with tag=subsection.tag content=subsection.name id=subsection.html_id class=subsection.html_class %}
                 {% include "includes/heading.html" with tag=tag content=content id=id class=class only %}
               {% endwith %}

--- a/bloom_nofos/nofos/templatetags/convert_paragraphs_to_hrs.py
+++ b/bloom_nofos/nofos/templatetags/convert_paragraphs_to_hrs.py
@@ -14,6 +14,7 @@ def convert_paragraphs_to_hrs(html_string):
         "p",
         string=lambda text: text
         in [
+            "page-break",
             "page-break-before",
             "page-break-after",
             "column-break-before",

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -170,15 +170,11 @@ def convert_paragraph_to_searchable_hr(p):
 
         if p.string == "page-break-before":
             p["class"] = "page-break--hr--container page-break-before--container"
-            hr, span = _create_hr_and_span(
-                "page-break-before", "[ ↑ page-break-before ↑ ]"
-            )
+            hr, span = _create_hr_and_span("page-break-before", "[ ↓ page-break ↓ ]")
 
         if p.string == "page-break-after":
             p["class"] = "page-break--hr--container page-break-after--container"
-            hr, span = _create_hr_and_span(
-                "page-break-after", "[ ↓ page-break-after ↓ ]"
-            )
+            hr, span = _create_hr_and_span("page-break-after", "[ ↓ page-break ↓ ]")
 
         if p.string == "column-break-before":
             p["class"] = "page-break--hr--container column-break-before--container"

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -160,6 +160,7 @@ def convert_paragraph_to_searchable_hr(p):
         )
 
     if p.name == "p" and p.string in [
+        "page-break",
         "page-break-before",
         "page-break-after",
         "column-break-before",
@@ -168,7 +169,7 @@ def convert_paragraph_to_searchable_hr(p):
         # Change the tag name from 'p' to 'div'
         p.name = "div"
 
-        if p.string == "page-break-before":
+        if p.string == "page-break" or p.string == "page-break-before":
             p["class"] = "page-break--hr--container page-break-before--container"
             hr, span = _create_hr_and_span("page-break-before", "[ ↓ page-break ↓ ]")
 

--- a/bloom_nofos/nofos/tests/test_templatetags.py
+++ b/bloom_nofos/nofos/tests/test_templatetags.py
@@ -490,7 +490,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-before</p>"
-        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↑ page-break-before ↑ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -503,6 +503,7 @@ class ModifyHtmlTests(TestCase):
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), original_html)
 
+    # next
     def test_convert_paragraph_to_searchable_hr_without_matching_paragraph_page_break_before(
         self,
     ):
@@ -517,7 +518,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-before</p><p>page-break-before</p>"
-        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↑ page-break-before ↑ ]</span></div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↑ page-break-before ↑ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         for p in soup.find_all("p"):
             convert_paragraph_to_searchable_hr(p)
@@ -527,7 +528,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<div><p>page-break-before</p></div>"
-        expected_html = '<div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↑ page-break-before ↑ ]</span></div></div>'
+        expected_html = '<div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -537,7 +538,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-after</p>"
-        expected_html = '<div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break-after ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -556,7 +557,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-after</p><p>page-break-after</p>"
-        expected_html = '<div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break-after ↓ ]</span></div><div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break-after ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         for p in soup.find_all("p"):
             convert_paragraph_to_searchable_hr(p)
@@ -564,7 +565,7 @@ class ModifyHtmlTests(TestCase):
 
     def test_convert_paragraph_to_searchable_hr_with_nested_tags_page_break_after(self):
         original_html = "<div><p>page-break-after</p></div>"
-        expected_html = '<div><div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break-after ↓ ]</span></div></div>'
+        expected_html = '<div><div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)

--- a/bloom_nofos/nofos/tests/test_templatetags.py
+++ b/bloom_nofos/nofos/tests/test_templatetags.py
@@ -485,6 +485,42 @@ class TestAddClassToTableRows(TestCase):
 
 
 class ModifyHtmlTests(TestCase):
+    # page-break
+    def test_convert_paragraph_to_searchable_hr_with_matching_paragraph_page_break(
+        self,
+    ):
+        original_html = "<p>page-break</p>"
+        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        soup = BeautifulSoup(original_html, "html.parser")
+        convert_paragraph_to_searchable_hr(soup.p)
+        self.assertEqual(str(soup), expected_html)
+
+    def test_convert_paragraph_to_searchable_hr_without_matching_paragraph_page_break(
+        self,
+    ):
+        original_html = "<p>Some other content</p>"
+        soup = BeautifulSoup(original_html, "html.parser")
+        convert_paragraph_to_searchable_hr(soup.p)
+        self.assertEqual(str(soup), original_html)
+
+    def test_convert_paragraph_to_searchable_hr_without_matching_paragraph_page_break(
+        self,
+    ):
+        original_html = "<p> page-break </p>"  # fails because of the extra whitespace
+        soup = BeautifulSoup(original_html, "html.parser")
+        convert_paragraph_to_searchable_hr(soup.p)
+        self.assertEqual(str(soup), original_html)
+
+    def test_convert_paragraph_to_searchable_hr_with_multiple_matching_paragraphs_page_break(
+        self,
+    ):
+        original_html = "<p>page-break</p><p>page-break</p>"
+        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        soup = BeautifulSoup(original_html, "html.parser")
+        for p in soup.find_all("p"):
+            convert_paragraph_to_searchable_hr(p)
+        self.assertEqual(str(soup), expected_html)
+
     # page-break-before
     def test_convert_paragraph_to_searchable_hr_with_matching_paragraph_page_break_before(
         self,
@@ -495,15 +531,15 @@ class ModifyHtmlTests(TestCase):
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
 
-    def test_convert_paragraph_to_searchable_hr_without_matching_paragraph_page_break_before(
+    def test_convert_paragraph_to_searchable_hr_with_nested_tags_page_break(
         self,
     ):
-        original_html = "<p>Some other content</p>"
+        original_html = "<div><p>page-break</p></div>"
+        expected_html = '<div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
-        self.assertEqual(str(soup), original_html)
+        self.assertEqual(str(soup), expected_html)
 
-    # next
     def test_convert_paragraph_to_searchable_hr_without_matching_paragraph_page_break_before(
         self,
     ):


### PR DESCRIPTION
## Summary 

This is an omnibus PR that solves all the `page-break` issues:

1. Allows `page-break` as a page-break string
2. Removes `-before` and `-after` strings from UI
3. Adds the `[ ↓ page-break ↓ ]` label to the edit page and the HTML view for subsection breaks
4. Solves the bug where page breaks don't get applied if there are no headings

All of these changes are backwards compatible, so nothing will change for existing NOFOs.

### Screenshot comparisons

On the "edit" view

| before | after |
|--------|-------|
|  - (orange) top border is not labelled</br> - (green) 'page-break' is not recognized as a page break        |    - (orange) top border IS labelled now</br> - (green) 'page-break' IS recognized as a page break now       |
|    <img width="985" alt="Screenshot 2025-01-20 at 11 32 36 AM" src="https://github.com/user-attachments/assets/fcedc0bd-b747-4f34-a50e-50bf4d47099c" />    |   <img width="985" alt="Screenshot 2025-01-20 at 11 31 58 AM" src="https://github.com/user-attachments/assets/d0df28e4-9161-445a-bfaf-00bfb59cc255" />   |


On the "HTML" view

| before | after |
|--------|-------|
|  - (orange) top border for heading is not labelled</br> - (green) 'page-break' is not recognized as a page break        |    - (orange) top border for heading IS labelled now</br> - (green) 'page-break' IS recognized as a page break now       |
|   <img width="643" alt="Screenshot 2025-01-20 at 11 33 02 AM" src="https://github.com/user-attachments/assets/e3954f11-6de0-42f3-b3be-a3d9e7becbf7" />     |  <img width="643" alt="Screenshot 2025-01-20 at 11 33 24 AM" src="https://github.com/user-attachments/assets/ebff0a09-3280-4cdb-8068-55c220ce70db" />     |

