### PR TITLE
Dynamic breadcrumbs in top nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning since version 1.0.0.
 - All page break visuals say "page-break" now, dropped the "-before", "-after"
 - In the nofo section editor, page breaks added to a section now say "page-break"
   - Previously, it was just a dashed line, but nobody knew what that meant
+- Loop through sections to create breadcrumbs
+  - Support "Understand Review, Selection, and Award" as a new section name
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,10 @@
 - Add Login.gov
 - Password reset flow on command line
 - Password reset flow exists
-- Refac: short section names for breadcrumbs means we can loop
 
 # DONE
 
+- Loop the sections to create breadcrumbs
 - .docx imports
   - Investigate images
 - Autodeploy from Github Actions

--- a/bloom_nofos/bloom_nofos/templates/includes/_icon_macro.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/_icon_macro.html
@@ -6,6 +6,8 @@
   {% include icon_path|add:"3-write.svg" %}
 {% elif "learn about review" in section_name %}
   {% include icon_path|add:"4-learn.svg" %}
+{% elif "understand review" in section_name %}
+  {% include icon_path|add:"4-learn.svg" %}
 {% elif "submit" in section_name %}
   {% include icon_path|add:"5-submit.svg" %}
 {% elif "learn what happens" in section_name %}

--- a/bloom_nofos/bloom_nofos/templates/includes/_icon_macro.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/_icon_macro.html
@@ -1,12 +1,10 @@
-{% if "review the opportunity" in section_name %}
+{% if "review the opportunity" in section_name or  "review the funding opportunity" in section_name %}
   {% include icon_path|add:"1-review.svg" %}
 {% elif "ready" in section_name %}
   {% include icon_path|add:"2-get-ready.svg" %}
 {% elif "write your" in section_name or "prepare your application" in section_name %}
   {% include icon_path|add:"3-write.svg" %}
-{% elif "learn about review" in section_name %}
-  {% include icon_path|add:"4-learn.svg" %}
-{% elif "understand review" in section_name %}
+{% elif "learn about review" in section_name or "understand review" in section_name %}
   {% include icon_path|add:"4-learn.svg" %}
 {% elif "submit" in section_name %}
   {% include icon_path|add:"5-submit.svg" %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -1,5 +1,5 @@
 {% extends 'base_barebones.html' %}
-{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_classes_to_lists add_classes_to_headings add_captions_to_tables split_char_and_remove convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section %}
+{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_classes_to_lists add_classes_to_headings add_captions_to_tables split_char_and_remove get_breadcrumb convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section %}
 
 {% block metadata %}
   {% if nofo.author %}
@@ -280,14 +280,12 @@
             <p>Jump to a step</p>
             <ol>
               {% spaceless %}
-              {% with nofo.sections.all|dictsort:"order" as nav_sections %}
-                <li><a href="#section--{{ nav_sections.0.html_id }}" {% if nav_sections.0.html_id == section.html_id %}aria-current="step"{% endif %}>Review</a></li>
-                <li><a href="#section--{{ nav_sections.1.html_id }}" {% if nav_sections.1.html_id == section.html_id %}aria-current="step"{% endif %}>Get Ready</a></li>
-                <li><a href="#section--{{ nav_sections.2.html_id }}" {% if nav_sections.2.html_id == section.html_id %}aria-current="step"{% endif %}>{% if 'Write' in nav_sections.2.name %}Write{% else %}Prepare{% endif %}</a></li>
-                <li><a href="#section--{{ nav_sections.3.html_id }}" {% if nav_sections.3.html_id == section.html_id %}aria-current="step"{% endif %}>Learn</a></li>
-                <li><a href="#section--{{ nav_sections.4.html_id }}" {% if nav_sections.4.html_id == section.html_id %}aria-current="step"{% endif %}>Submit</a></li>
-                <li><a href="#section--{{ nav_sections.5.html_id }}" {% if nav_sections.5.html_id == section.html_id %}aria-current="step"{% endif %}>Award</a></li>
-                <li><a href="#section--{{ nav_sections.6.html_id }}" {% if nav_sections.6.html_id == section.html_id %}aria-current="step"{% endif %}>Contacts</a></li>
+              {% with nofo.sections.all|dictsort:"order"|filter_breadcrumb_sections as breadcrumb_sections %}
+                {% for breadcrumb in breadcrumb_sections %}
+                  <li>
+                    <a href="#section--{{ breadcrumb.html_id }}" {% if breadcrumb.html_id == section.html_id %}aria-current="step"{% endif %}>{{ breadcrumb.name|get_breadcrumb }}</a>
+                  </li>
+                {% endfor %}
               {% endwith %}
               {% endspaceless %}
             </ol>
@@ -326,19 +324,17 @@
       <!-- RUNNING HEADER -->
       <!-- after first section title page -->
       <div class="header-nav header-nav--running-header">
-        {% spaceless %}
         <ol>
-          {% with nofo.sections.all|dictsort:"order" as nav_sections %}
-              <li><a href="#section--{{ nav_sections.0.html_id }}" {% if nav_sections.0.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">Review</a></li>
-              <li><a href="#section--{{ nav_sections.1.html_id }}" {% if nav_sections.1.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">Get Ready</a></li>
-              <li><a href="#section--{{ nav_sections.2.html_id }}" {% if nav_sections.2.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">{% if 'Write' in nav_sections.2.name %}Write{% else %}Prepare{% endif %}</a></li>
-              <li><a href="#section--{{ nav_sections.3.html_id }}" {% if nav_sections.3.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">Learn</a></li>
-              <li><a href="#section--{{ nav_sections.4.html_id }}" {% if nav_sections.4.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">Submit</a></li>
-              <li><a href="#section--{{ nav_sections.5.html_id }}" {% if nav_sections.5.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">Award</a></li>
-              <li><a href="#section--{{ nav_sections.6.html_id }}" {% if nav_sections.6.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">Contacts</a></li>
+            {% spaceless %}
+            {% with nofo.sections.all|dictsort:"order"|filter_breadcrumb_sections as breadcrumb_sections %}
+              {% for breadcrumb in breadcrumb_sections %}
+                <li>
+                  <a href="#section--{{ breadcrumb.html_id }}" {% if breadcrumb.html_id == section.html_id %}aria-current="step"{% endif %} aria-hidden="true" tabindex="-1" aria-label="" title="">{{ breadcrumb.name|get_breadcrumb }}</a>
+                </li>
+              {% endfor %}
             {% endwith %}
+            {% endspaceless %}
         </ol>
-        {% endspaceless %}
       </div>
 
       <!-- SECTION CONTENT -->

--- a/bloom_nofos/nofos/templatetags/get_breadcrumb.py
+++ b/bloom_nofos/nofos/templatetags/get_breadcrumb.py
@@ -1,0 +1,19 @@
+from django import template
+
+from .utils import (
+    filter_breadcrumb_sections as _filter_breadcrumb_sections,
+    get_breadcrumb_text,
+)
+
+
+register = template.Library()
+
+
+@register.filter
+def filter_breadcrumb_sections(sections):
+    return _filter_breadcrumb_sections(sections)
+
+
+@register.filter
+def get_breadcrumb(section_name):
+    return get_breadcrumb_text(section_name)

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -209,6 +209,37 @@ def find_elements_with_character(element, container, character="~"):
             find_elements_with_character(child, container, character)
 
 
+def filter_breadcrumb_sections(sections):
+    return [
+        section
+        for section in sections
+        if section.name.lower().startswith(("step", "contacts", "learn"))
+    ]
+
+
+def get_breadcrumb_text(section_name):
+    # Map section names to their breadcrumb link text
+    name_map = {
+        "review the opportunity": "Review",
+        "ready": "Get Ready",
+        "write your application": "Write",
+        "understand review": "Understand",
+        "prepare your application": "Prepare",
+        "learn about review": "Learn",
+        "submit": "Submit",
+        "learn what happens": "Award",
+        "contacts": "Contacts",
+    }
+
+    # Find a match in name_map
+    for key, value in name_map.items():
+        if key in section_name.lower():
+            return value
+
+    # Default case
+    return "⚠️ TODO ⚠️"
+
+
 def get_parent_td(element):
     """
     Gets the parent <td> element for a given element, which may include itself.

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -210,6 +210,10 @@ def find_elements_with_character(element, container, character="~"):
 
 
 def filter_breadcrumb_sections(sections):
+    """
+    Filters a list of section objects to include only those whose names
+    start with specific keywords: "step", "contacts", or "learn" (case-insensitive).
+    """
     return [
         section
         for section in sections
@@ -218,9 +222,20 @@ def filter_breadcrumb_sections(sections):
 
 
 def get_breadcrumb_text(section_name):
-    # Map section names to their breadcrumb link text
-    name_map = {
+    """
+    Maps a section name to its corresponding breadcrumb link text.
+
+    This function uses a predefined mapping to convert longer section names
+    into concise breadcrumb link text. If no match is found, it returns a default
+    placeholder ("⚠️ TODO ⚠️").
+
+    Notes:
+        - The mapping is case-insensitive.
+        - Partial matches are used, so "Get Ready to Apply" will match "ready".
+    """
+    breadcrumb_text_map = {
         "review the opportunity": "Review",
+        "review the funding opportunity": "Review",
         "ready": "Get Ready",
         "write your application": "Write",
         "understand review": "Understand",
@@ -232,7 +247,7 @@ def get_breadcrumb_text(section_name):
     }
 
     # Find a match in name_map
-    for key, value in name_map.items():
+    for key, value in breadcrumb_text_map.items():
         if key in section_name.lower():
             return value
 


### PR DESCRIPTION
## Summary

This PR makes a 2 changes:

1. Dynamically generate the top breadcrumb nav
2. Add the little lightbulb symbol icon for "Understand Review, Selection, and Award"

| before | after |
|--------|-------|
|   - hardcoded breadcrumbs, don't correspond with this NOFO (`3. Prepare` is wrong)<br/> - 🔍  Magnifying glass is the wrong icon   |  - dynamic breadcrumbs based on this NOFO (`3. Understand` is right)</br> - 💡 Lightbulb is the right icon     |
|     <img width="894" alt="Screenshot 2025-01-20 at 2 31 04 PM" src="https://github.com/user-attachments/assets/863f3cde-f118-41c4-be0a-5841ba834639" />   |    <img width="894" alt="Screenshot 2025-01-20 at 2 31 23 PM" src="https://github.com/user-attachments/assets/f7d1e05c-c68a-4918-bf2f-a895c9dde411" />   |

(2) is very simple, but I can expand a bit more on (1).

### 1. Dynamically generate the top breadcrumb nav

Since almost the beginning of the NOFO builder, the section breadcrumbs have been hardcoded because we have had the same content guide which has meant all our NOFOs have the same sections with the same names in the same order. However, there are potentially new content guides coming which have (a) differently named sections and (b) different numbers of sections.

I hadn't created any kind of 'loop through sections to create breadcrumbs' logic previously because the section names _are not the same_ as the breadcrumb labels.

For the section section: `Step 1: Review the Opportunity`
The breadcrumb label is: `1. Review`

Looping through the sections doesn't actually give us that label. 

However, I actually already solved something similar when deciding which icons should appear on which section pages, inside of [`_icon_macro.html`](https://github.com/HHS/simpler-grants-pdf-builder/blob/main/bloom_nofos/bloom_nofos/templates/includes/_icon_macro.html). Basically, I created a switch statement which returns the right icon if it sees the right word or phrase inside of a section name. 

So we do the same thing again to generate the breadcrumbs. Easy.
