### PR TITLE
Remove unneeded nested ULs inside of the ToC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Fix: Remove unneeded nested lists "li > ul > li" for BYB page and appendices
 - Fix: page breaks were not possible to add to subsections without a heading
 
 ## [2.3.0] - 2025-01-17

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -787,6 +787,10 @@ div[role="heading"] {
   margin-bottom: 10px;
 }
 
+.toc > ol > li:last-of-type {
+  padding-bottom: 0;
+}
+
 .toc > ol > li:not(:last-of-type) {
   border-bottom: 1px solid var(--color--light-grey);
 }
@@ -810,6 +814,7 @@ div[role="heading"] {
   text-decoration: underline;
 }
 
+.toc .toc--section-name.toc--no-icon a,
 .toc .toc--subsection-name a {
   font-size: 11pt;
 }
@@ -838,8 +843,7 @@ div[role="heading"] {
 }
 
 .toc ol li.toc--no-icon {
-  margin-top: -10px;
-  padding-left: 30px;
+  padding-left: 40px;
 }
 
 /* Before you begin page */

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -179,11 +179,7 @@
     <ol class="usa-list usa-list--unstyled">
 
       <li class="toc--section-name toc--no-icon toc--before-you-begin">
-        <div class="toc--section-name--wrapper">
-          <ol class="usa-list usa-list--unstyled">
-            <li class="toc--subsection-name"><a href="#section--before-you-begin">Before you begin</a></li>
-          </ol>
-        </div>
+        <a href="#section--before-you-begin">Before you begin</a>
       </li>
 
       {% for section in nofo.sections.all|dictsort:"order" %}
@@ -210,11 +206,7 @@
           </li>
         {% else %}
           <li class="toc--section-name toc--no-icon toc--{{ section.html_id }}">
-            <div class="toc--section-name--wrapper">
-              <ol class="usa-list usa-list--unstyled">
-                <li class="toc--subsection-name"><a href="#section--{{ section.html_id }}">{{ section.name }}</a></li>
-              </ol>
-            </div>
+            <a href="#section--{{ section.html_id }}">{{ section.name }}</a>
           </li>
         {% endif%}
       {% endfor %}


### PR DESCRIPTION
## Summary 

This PR fixes an a11y issue where we had too many nested LIs for table of contents elements that didn't need them (#105).

We can see there is less nesting inside of the accessibility tags:

| before | after |
|--------|-------|
|  BYB link looks like: `TOC > TOCI > TOC > TOCI > Link`      |  BYB link now looks like: `TOC > TOCI > Link`     |
|   <img width="1036" alt="Screenshot 2025-01-20 at 4 12 25 PM" src="https://github.com/user-attachments/assets/6514e789-9ca0-42a7-9e10-8895425f725a" />  |  <img width="1036" alt="Screenshot 2025-01-20 at 4 12 34 PM" src="https://github.com/user-attachments/assets/ed57a78c-0ef9-4f61-a03f-6c3ee4ce1205" />     |

It was the same with appendices/glossaries/endnotes as well, but now that is resolved.

### More details

When we have a section with a section page, we typically do this inside of the table of contents:

```
- UL: ToC
  - LI: Step 1: Review the Opportunity
    - UL: (container for h3s)
      - LI: Basic Information
      - LI: Eligibility
      - LI: Program Description
      - LI: Award Information
```

So that's how it should be, but it was pointed out to us that we were using this same structure for _all_ links, even when they didn't have a section page.

So, for the Before you begin page, it looked like this:

```
- UL: ToC
  - LI: (empty)
    - UL: (container for 1 element)
      - LI: Before you begin
```

In that case, we don't need the extra LI > UL, we can just include it at the first level of heirarchy.

```
- UL: ToC
  - LI: Before you begin
```

This makes sense semantically too, since most of these are section pages in their own right.

The reason we were doing this is because it was a shortcut to make all the links visually look the same, but it was semantically confusing.