### PR TITLE
Remove nonessential page-break container classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
-- Fix: Remove unneeded nested lists "li > ul > li" for BYB page and appendices
-- Fix: page breaks were not possible to add to subsections without a heading
+- Remove unneeded nested lists "li > ul > li" for BYB page and appendices
+- Page breaks were not possible to add to subsections without a heading
+- page-break-after was briefly not working
 
 ## [2.3.0] - 2025-01-17
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -1225,13 +1225,13 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   }
 
   /* Page break rules */
-  .page-break-before--container .page-break-before,
+  .page-break--hr--container .page-break-before,
   .page-break-before--heading {
     break-before: page !important;
     page-break-before: always !important;
   }
 
-  .page-break-before--container .page-break-after,
+  .page-break--hr--container .page-break-after,
   .page-break-after--heading {
     break-after: page !important;
     page-break-after: always !important;

--- a/bloom_nofos/nofos/templatetags/utils/__init__.py
+++ b/bloom_nofos/nofos/templatetags/utils/__init__.py
@@ -170,21 +170,21 @@ def convert_paragraph_to_searchable_hr(p):
         p.name = "div"
 
         if p.string == "page-break" or p.string == "page-break-before":
-            p["class"] = "page-break--hr--container page-break-before--container"
+            p["class"] = "page-break--hr--container"
             hr, span = _create_hr_and_span("page-break-before", "[ ↓ page-break ↓ ]")
 
         if p.string == "page-break-after":
-            p["class"] = "page-break--hr--container page-break-after--container"
+            p["class"] = "page-break--hr--container"
             hr, span = _create_hr_and_span("page-break-after", "[ ↓ page-break ↓ ]")
 
         if p.string == "column-break-before":
-            p["class"] = "page-break--hr--container column-break-before--container"
+            p["class"] = "page-break--hr--container"
             hr, span = _create_hr_and_span(
                 "column-break-before", "[ ← column-break-before ← ]"
             )
 
         if p.string == "column-break-after":
-            p["class"] = "page-break--hr--container column-break-after--container"
+            p["class"] = "page-break--hr--container"
             hr, span = _create_hr_and_span(
                 "column-break-after", "[ → column-break-after → ]"
             )

--- a/bloom_nofos/nofos/tests/test_templatetags.py
+++ b/bloom_nofos/nofos/tests/test_templatetags.py
@@ -497,7 +497,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break</p>"
-        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -522,7 +522,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break</p><p>page-break</p>"
-        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         for p in soup.find_all("p"):
             convert_paragraph_to_searchable_hr(p)
@@ -533,7 +533,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-before</p>"
-        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -542,7 +542,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<div><p>page-break</p></div>"
-        expected_html = '<div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
+        expected_html = '<div><div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -561,7 +561,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-before</p><p>page-break-before</p>"
-        expected_html = '<div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         for p in soup.find_all("p"):
             convert_paragraph_to_searchable_hr(p)
@@ -571,7 +571,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<div><p>page-break-before</p></div>"
-        expected_html = '<div><div class="page-break--hr--container page-break-before--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
+        expected_html = '<div><div class="page-break--hr--container"><hr class="page-break-before page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -581,7 +581,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-after</p>"
-        expected_html = '<div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -600,7 +600,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>page-break-after</p><p>page-break-after</p>"
-        expected_html = '<div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div><div class="page-break--hr--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         for p in soup.find_all("p"):
             convert_paragraph_to_searchable_hr(p)
@@ -608,7 +608,7 @@ class ModifyHtmlTests(TestCase):
 
     def test_convert_paragraph_to_searchable_hr_with_nested_tags_page_break_after(self):
         original_html = "<div><p>page-break-after</p></div>"
-        expected_html = '<div><div class="page-break--hr--container page-break-after--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
+        expected_html = '<div><div class="page-break--hr--container"><hr class="page-break-after page-break--hr"/><span class="page-break--hr--text">[ ↓ page-break ↓ ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -618,7 +618,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>column-break-before</p>"
-        expected_html = '<div class="page-break--hr--container column-break-before--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -637,7 +637,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>column-break-before</p><p>column-break-before</p>"
-        expected_html = '<div class="page-break--hr--container column-break-before--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div><div class="page-break--hr--container column-break-before--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div><div class="page-break--hr--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         for p in soup.find_all("p"):
             convert_paragraph_to_searchable_hr(p)
@@ -647,7 +647,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<div><p>column-break-before</p></div>"
-        expected_html = '<div><div class="page-break--hr--container column-break-before--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div></div>'
+        expected_html = '<div><div class="page-break--hr--container"><hr class="column-break-before page-break--hr"/><span class="page-break--hr--text">[ ← column-break-before ← ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -657,7 +657,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>column-break-after</p>"
-        expected_html = '<div class="page-break--hr--container column-break-after--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
@@ -676,7 +676,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<p>column-break-after</p><p>column-break-after</p>"
-        expected_html = '<div class="page-break--hr--container column-break-after--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div><div class="page-break--hr--container column-break-after--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div>'
+        expected_html = '<div class="page-break--hr--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div><div class="page-break--hr--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         for p in soup.find_all("p"):
             convert_paragraph_to_searchable_hr(p)
@@ -686,7 +686,7 @@ class ModifyHtmlTests(TestCase):
         self,
     ):
         original_html = "<div><p>column-break-after</p></div>"
-        expected_html = '<div><div class="page-break--hr--container column-break-after--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div></div>'
+        expected_html = '<div><div class="page-break--hr--container"><hr class="column-break-after page-break--hr"/><span class="page-break--hr--text">[ → column-break-after → ]</span></div></div>'
         soup = BeautifulSoup(original_html, "html.parser")
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)


### PR DESCRIPTION
## Summary

This PR removes some classes to do with page breaks that weren't getting used.

I used to have these classnames:

- `page-break-before--container`
- `page-break-after--container`
- `column-break-before--container`
- `column-break-after--container`

But they weren't getting used, so we don't need them.