### PR TITLE
Standardize colour for small ToC links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning since version 1.0.0.
 - Remove unneeded nested lists "li > ul > li" for BYB page and appendices
 - Page breaks were not possible to add to subsections without a heading
 - page-break-after was briefly not working
+- Small ToC links are all the same colour
 
 ## [2.3.0] - 2025-01-17
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -817,6 +817,7 @@ div[role="heading"] {
 .toc .toc--section-name.toc--no-icon a,
 .toc .toc--subsection-name a {
   font-size: 11pt;
+  color: var(--color--black);
 }
 
 .toc .toc--section-name .toc--section-name--a {

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
@@ -53,10 +53,6 @@ h5 {
   color: var(--color--light-black);
 }
 
-.toc ol li a {
-  color: var(--color--black);
-}
-
 .toc .toc--section-name .toc--section-name--img svg {
   color: var(--color--light-black);
 }

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acl-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acl-white.css
@@ -45,10 +45,6 @@ h3 {
   color: var(--color--acl-blue);
 }
 
-.toc ol li a {
-  color: var(--color--black);
-}
-
 .toc .toc--section-name .toc--section-name--img svg {
   color: var(--color--acl-blue);
 }

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-aspr.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-aspr.css
@@ -108,10 +108,6 @@ section.nofo--cover-page.nofo--cover-page--hero {
   color: var(--color--aspr-blue);
 }
 
-.toc ol ol li a {
-  color: var(--color--black);
-}
-
 /* Before you begin page */
 
 .before-you-begin h2 {

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc.css
@@ -137,10 +137,6 @@ section.nofo--cover-page.nofo--cover-page--hero {
   color: var(--color--cdc-blue);
 }
 
-.toc ol ol li a {
-  color: var(--color--black);
-}
-
 /* Before you begin page */
 
 .before-you-begin h2 {

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cms.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cms.css
@@ -109,10 +109,6 @@ div[role="heading"] {
 
 /* Table of contents */
 
-.toc .toc--subsection-name a {
-  color: var(--color--black);
-}
-
 /* Before you begin page */
 
 /* Section title page */

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-blue.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-blue.css
@@ -68,10 +68,6 @@ h4 {
   color: var(--color--hrsa-blue);
 }
 
-.toc ol li a {
-  color: var(--color--black);
-}
-
 .toc .toc--section-name .toc--section-name--img[class*="white-icon"] {
   background: var(--color--hrsa-blue);
 }

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
@@ -48,10 +48,6 @@ h4 {
 
 /* Table of contents */
 
-.toc ol li a {
-  color: var(--color--black);
-}
-
 .toc .toc--section-name .toc--section-name--img svg {
   color: var(--color--hrsa-blue);
 }

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs.css
@@ -90,6 +90,7 @@ div[role="heading"] {
   color: var(--color--ihs-blue);
 }
 
+.toc .toc--section-name.toc--no-icon a,
 .toc .toc--subsection-name a {
   color: var(--color--ihs-black);
 }


### PR DESCRIPTION
## Summary

This is a small PR with only 1 change.

- Standardize colour for small ToC links

Our CSS was a bit different, which led to some links being blue and others being black in a few themes.

Sorted this out by standardizing the CSS for this.

Here's a screenshot: you can see in the "before" that the "Before you begin" and the Appendices are all in blue instead of black like the other subsections.

| before | after |
|--------|-------|
|  "before" and appendices are blue      |  all small links are the same colour     |
|   <img width="585" alt="Screenshot 2025-01-21 at 12 24 09 PM" src="https://github.com/user-attachments/assets/13d667b9-4961-4fdb-bbad-1ebda40ac4ae" />     |   <img width="585" alt="Screenshot 2025-01-21 at 12 23 42 PM" src="https://github.com/user-attachments/assets/3b9e633c-90db-4494-9784-6200f1006607" />    |

