### PR TITLE
Add classes to Table of Contents based on number of items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add classes to Table of Contents based on number of items
+  - The idea is to shrink the table of contents a bit if lots of items show up
 - Add a new icon for "award" (only for 2 CDC NOFOs for now)
 - Add 2 new images for CDC-RFA-CE-25-0114-b
 - Add cover image for CDC-RFA-CK-25-0125

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -799,6 +799,10 @@ div[role="heading"] {
   margin-top: 8px;
 }
 
+.toc.toc--small ol li {
+  margin-top: 5px;
+}
+
 .toc a {
   display: inline-block;
   position: relative;

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -1,5 +1,5 @@
 {% extends 'base_barebones.html' %}
-{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_classes_to_lists add_classes_to_headings add_captions_to_tables split_char_and_remove get_breadcrumb convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section %}
+{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_classes_to_lists add_classes_to_headings add_classes_to_toc add_captions_to_tables split_char_and_remove get_breadcrumb convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section %}
 
 {% block metadata %}
   {% if nofo.author %}
@@ -173,7 +173,8 @@
     </div>
   </section>
 
-  <section id="section--toc" class="toc">
+  <!-- TABLE OF CONTENTS -->
+  <section id="section--toc" class="toc {{ nofo|add_classes_to_toc }}">
     <h2 id="section--toc--heading">Contents</h2>
     {% spaceless %}
     <ol class="usa-list usa-list--unstyled">
@@ -214,6 +215,7 @@
     {% endspaceless %}
   </section>
 
+  <!-- BEFORE YOU BEGIN PAGE -->
   <section id="section--before-you-begin" class="before-you-begin{% if nofo.sole_source_justification %} before-you-begin--sole-source{% endif %}">
     <div class="section--before-you-begin--icon">
       {% if "thin" in nofo.icon_style %}

--- a/bloom_nofos/nofos/templatetags/add_classes_to_toc.py
+++ b/bloom_nofos/nofos/templatetags/add_classes_to_toc.py
@@ -1,0 +1,35 @@
+from django import template
+from bs4 import BeautifulSoup
+
+register = template.Library()
+
+
+@register.filter
+def add_classes_to_toc(nofo):
+    """
+    Custom filter to calculate the number of ToC items for a given NOFO object.
+
+    Args:
+        nofo (object): The NOFO object containing sections and HTML content.
+
+    Returns:
+        int: Total count of ToC items.
+    """
+    count = 0
+
+    # Count sections
+    sections = nofo.sections.all().order_by("order")
+    count += len(sections)
+
+    for section in sections:
+        if section.has_section_page and "contacts" not in section.name.lower():
+            for subsection in section.subsections.all().order_by("order"):
+                if subsection.tag == "h3":
+                    count += 1
+
+    # before you begin page is not a section so not counted above
+    count += 1
+
+    toc_class = "toc--normal" if count <= 23 else "toc--small"
+
+    return "{} toc--items--{}".format(toc_class, count)


### PR DESCRIPTION
## Summary

This PR adds classes to the ToC section based on how many items are in the table of contents.

The reason for this change is that when the table of contents has too many items, sometimes one item drops onto the next page.

This PR tries to get ahead of that by shrinking the spacing between `<li>` elements if there are too many items in the table of contents.

I did a bunch of testing to arrive where I did, but still don't have a strong sense if this is the right cutoff / CSS to use. We will see in regular use if this works out or needs to be tweaked.

| ToC with 20 items | ToC with 27 items  |
|--------|-------|
|  Has classes: <br>-`toc--normal`<br>-`toc--items--20`       |     Has classes: <br>-`toc--small`<br>-`toc--items--27`   |
|   <img width="1254" alt="Screenshot 2025-01-22 at 4 33 24 PM" src="https://github.com/user-attachments/assets/f8e4e245-8c7e-49f6-bdec-e29a36b1797d" />     |    <img width="1254" alt="Screenshot 2025-01-22 at 4 33 11 PM" src="https://github.com/user-attachments/assets/4aa814fd-d560-4a6f-9e2e-391033ec8bdd" />   |

The cutoff between `toc--normal` and `toc--small` is 23 items. As in, 23 means `normal` and 24 means `small`.


