### PR TITLE
Refactor nofo_import: Move 'process the HTML' steps into their own function

### DIFF
--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -88,6 +88,45 @@ def parse_uploaded_file_as_html_string(uploaded_file):
         raise ValidationError("Please import a .docx or HTML file.")
 
 
+def process_nofo_html(soup, top_heading_level):
+    """
+    Takes a soup object, cleans it up and mutates it, and returns a modified soup object.
+    """
+    soup = add_body_if_no_body(soup)
+
+    # When DEBUG is True, write out the soup to a local debug file
+    if settings.DEBUG:
+        # Build a path to your _temp folder in fixtures (create if needed)
+        debug_dir = os.path.join(settings.BASE_DIR, "nofos", "fixtures", "_temp")
+        # create dir if not exists
+        os.makedirs(debug_dir, exist_ok=True)
+
+        output_file_path = os.path.join(debug_dir, "debug_output.html")
+        with open(output_file_path, "w", encoding="utf-8") as file:
+            file.write(str(soup))
+
+    decompose_instructions_tables(soup)
+    join_nested_lists(soup)
+    add_strongs_to_soup(soup)
+    preserve_bookmark_links(soup)
+    preserve_heading_links(soup)
+    preserve_table_heading_links(soup)
+    clean_heading_tags(soup)
+    clean_table_cells(soup)
+    unwrap_empty_elements(soup)
+    decompose_empty_tags(soup)
+    combine_consecutive_links(soup)
+    remove_google_tracking_info_from_links(soup)
+    replace_src_for_inline_images(soup)
+    add_endnotes_header_if_exists(soup, top_heading_level)
+    unwrap_nested_lists(soup)
+    preserve_bookmark_targets(soup)
+
+    soup = add_em_to_de_minimis(soup)
+
+    return soup, top_heading_level
+
+
 ###########################################################
 #################### UTILITY FUNCS ####################
 ###########################################################

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -83,6 +83,7 @@ from .nofo import (
     preserve_bookmark_targets,
     preserve_heading_links,
     preserve_table_heading_links,
+    process_nofo_html,
     remove_google_tracking_info_from_links,
     replace_chars,
     replace_links,
@@ -263,37 +264,12 @@ def nofo_import(request, pk=None):
 
         # replace problematic characters/links on import
         cleaned_content = replace_links(replace_chars(file_content))
-        soup = BeautifulSoup(cleaned_content, "html.parser")  # Parse the cleaned HTML
-        soup = add_body_if_no_body(soup)
-
-        # # Specify the output file path
-        # output_file_path = "debug_output.html"
-
-        # # Write the HTML content to the file
-        # with open(output_file_path, "w", encoding="utf-8") as file:
-        #     file.write(str(soup))
-
-        # if there are no h1s, then h2s are the new top
+        # Create a 'soup' object from our HTML string
+        soup = BeautifulSoup(cleaned_content, "html.parser")
+        # if there are no h1s, then h2s are the top heading level
         top_heading_level = "h1" if soup.find("h1") else "h2"
 
-        # mutate the HTML
-        decompose_instructions_tables(soup)
-        join_nested_lists(soup)
-        add_strongs_to_soup(soup)
-        preserve_bookmark_links(soup)
-        preserve_heading_links(soup)
-        preserve_table_heading_links(soup)
-        clean_heading_tags(soup)
-        clean_table_cells(soup)
-        unwrap_empty_elements(soup)
-        decompose_empty_tags(soup)
-        combine_consecutive_links(soup)
-        remove_google_tracking_info_from_links(soup)
-        replace_src_for_inline_images(soup)
-        add_endnotes_header_if_exists(soup, top_heading_level)
-        unwrap_nested_lists(soup)
-        preserve_bookmark_targets(soup)
-        soup = add_em_to_de_minimis(soup)
+        process_nofo_html(soup, top_heading_level)
 
         # format all the data as dicts
         sections = get_sections_from_soup(soup, top_heading_level)


### PR DESCRIPTION
## Summary

This is a refactoring PR that doesn't change any logic or functionality but hopefully makes the codebase more composable (particularly soon).

There's not too much to point to here: basically, there is a big block of code that contains various small-ish-in-scope functions that process the initial NOFO on import. I have a similar function for the `suggest_*` funcs that used to be also all over NOFO import: https://github.com/HHS/simpler-grants-pdf-builder/blob/main/bloom_nofos/nofos/nofo.py#L1153

So this is the same thing really. The methods inside are all tested individually, so I haven't added tests for this aggregate function.

The other thing I want to call out is that I created a debug HTML output file whenever we are running in DEBUG mode. I turn this on and off selectively as it is helpful from identifying stuff that doesn't import correctly, but keeping commented-out code in the codebase and just uncommenting it manually sucks. So let's just formalize this and make it dependent on the `DEBUG` setting like we do in other parts of the code.

`nofo_import` was 154 lines long before, after this PR it is 129 lines long.