### PR TITLE
Refactor nofo_import: Create "NofosImportNewView" and "NofosImportOverwriteView"

### DIFF
--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -127,6 +127,18 @@ def process_nofo_html(soup, top_heading_level):
     return soup
 
 
+def build_nofo_sections_and_subsections(soup, top_heading_level):
+    """
+    Builds sections and subsections as python dicts, ready to be used to create a new NOFO.
+    Raises ValidationError if no sections found.
+    """
+    sections = get_sections_from_soup(soup, top_heading_level)
+    if not len(sections):
+        raise ValidationError("That file does not contain a NOFO.")
+    sections = get_subsections_from_sections(sections, top_heading_level)
+    return sections
+
+
 ###########################################################
 #################### UTILITY FUNCS ####################
 ###########################################################

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -127,18 +127,6 @@ def process_nofo_html(soup, top_heading_level):
     return soup
 
 
-def build_nofo_sections_and_subsections(soup, top_heading_level):
-    """
-    Builds sections and subsections as python dicts, ready to be used to create a new NOFO.
-    Raises ValidationError if no sections found.
-    """
-    sections = get_sections_from_soup(soup, top_heading_level)
-    if not len(sections):
-        raise ValidationError("That file does not contain a NOFO.")
-    sections = get_subsections_from_sections(sections, top_heading_level)
-    return sections
-
-
 ###########################################################
 #################### UTILITY FUNCS ####################
 ###########################################################

--- a/bloom_nofos/nofos/tests/test_reimport.py
+++ b/bloom_nofos/nofos/tests/test_reimport.py
@@ -1,9 +1,9 @@
-from django.test import TransactionTestCase, Client
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.messages import get_messages
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import Client, TransactionTestCase
+from django.urls import reverse
 from nofos.models import Nofo, Section, Subsection
 from users.models import BloomUser
-from django.urls import reverse
 
 
 class NofoReimportTests(TransactionTestCase):

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -5,9 +5,13 @@ from . import views
 app_name = "nofos"
 urlpatterns = [
     path("", views.NofosListView.as_view(), name="nofo_index"),
-    path("import", views.nofo_import_new, name="nofo_import"),
+    path("import", views.NofosImportNewView.as_view(), name="nofo_import"),
     path("<int:pk>/delete", views.NofosArchiveView.as_view(), name="nofo_archive"),
-    path("<int:pk>/import", views.nofo_import_overwrite, name="nofo_import_overwrite"),
+    path(
+        "<int:pk>/import",
+        views.NofosImportOverwriteView.as_view(),
+        name="nofo_import_overwrite",
+    ),
     path(
         "<int:pk>/import/title",
         views.NofoImportTitleView.as_view(),

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -5,9 +5,9 @@ from . import views
 app_name = "nofos"
 urlpatterns = [
     path("", views.NofosListView.as_view(), name="nofo_index"),
-    path("import", views.nofo_import, name="nofo_import"),
+    path("import", views.nofo_import_new, name="nofo_import"),
     path("<int:pk>/delete", views.NofosArchiveView.as_view(), name="nofo_archive"),
-    path("<int:pk>/import", views.nofo_import, name="nofo_import_overwrite"),
+    path("<int:pk>/import", views.nofo_import_overwrite, name="nofo_import_overwrite"),
     path(
         "<int:pk>/import/title",
         views.NofoImportTitleView.as_view(),


### PR DESCRIPTION
## Summary

This PR breaks up our `nofo_import` function into 2 class-based views: 

1. NofosImportNewView: for importing a new NOFO
2. NofosImportOverwriteView: for overwriting an existing NOFO

Logic and functionality are unchanged from before, this is strictly a refactor so that sets us up for some of the 'reimport' stories we have in the pipeline (#125, #156, #170).

The diff is not very helpful in this PR. I would suggest just reading through the final `views.py` to understand what's happening.

It is the final PR in the "Refactor nofo_import" series, which included these other ones:
- #191 
- #192 

## Details

For a long time, we were using a function-based view called `nofo_import` which handled both importing a new NOFO and overwriting an existing NOFO. This made sense because there is a bunch of shared logic here: 

- uploading the file
- converting the doc string to HTML
- cleaning up the HTML
- creating sections and subsections

Once we had these sections and subsections, we would create the `Nofo` object. Initially, this was almost identical between the 'new' and 'reimport' routes, but over time they have begun to diverge.

The 2 previous PRs were about making `nofo_import` simpler by encapsulating shared functionality in functions that now live in `nofo.py`. However, [when you split `nofo_import` into 2 functions](https://github.com/HHS/simpler-grants-pdf-builder/pull/197/commits/66b46a0bda846171666077a74ff5d702098d4e65), this still led to a lot of copy+paste code: essentially, the first 25 lines of `nofo_import_new` and `nofo_import_overwrite` was 100% copy+paste, only the second half (the logic around creating a NOFO) was different. 

The solution I landed on was _inheritance_: something I learned in first-year CS. Instead of copying a bunch of code between 2 functions, we can inherit the same import/processing steps and then have each class separately implement the "create NOFO" logic. 

Much cleaner than before, and it also makes our `views.py` file more consistent as a large majority of our other views are class-based views.