### PR TITLE
Add "Are you sure?" confirmation page when re-importing a NOFO with a different ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning since version 1.0.0.
 - Add cover image for CDC-RFA-CK-25-0125 and CDC-RFA-JG-25-0178
 - Add inline images for CDC-RFA-CE-25-0114
 - Can use 'page-break' to add a page-break in markdown body
+- Add confirmation page for re-importing a NOFO if the IDs don't match up
 
 ### Changed
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_confirm_delete.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_confirm_delete.html
@@ -29,15 +29,14 @@
 
   <form id="nofo-delete--form" method="post">
     {% csrf_token %}
-    <p>Are you absolutely sure you want to delete “{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}”?</p>
-    {{ form }}
+    <p>Are you absolutely sure you want to delete “{{ nofo|nofo_name }}”?</p>
 
     <ul class="usa-button-group margin-top-3">
       <li class="usa-button-group__item">
         <button class="usa-button usa-button--secondary" type="submit">Yes, delete it</button>
       </li>
       <li class="usa-button-group__item">
-        <a href="{% url 'nofos:nofo_view' nofo.id %}" class="usa-button usa-button--outline">Never mind, I don’t want to delete this NOFO</a>
+        <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button usa-button--outline">Never mind, I don’t want to delete this NOFO</a>
       </li>
     </ul>
   </form>

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_confirm_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_confirm_overwrite.html
@@ -1,0 +1,64 @@
+{% extends 'base.html' %}
+{% load nofo_name %}
+
+{% block title %}
+  Confirm re-import for “{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}”
+{% endblock %}
+
+{% block body_class %}nofo_import nofo_import--confirm-reimport{% endblock %}
+
+{% block content %}
+  <div class="usa-alert usa-alert--warning margin-bottom-3">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">Warning</h4>
+      <p class="usa-alert__text">
+        Re-importing a NOFO overwrites most existing content.
+      </p>
+      <p class="usa-alert__text">
+        If you continue, you will lose all manual edits made since creating the NOFO, other than page breaks.
+      </p>
+    </div>
+  </div>
+
+  {% with nofo|nofo_name as nofo_name_str %}
+  {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
+    {% url 'nofos:nofo_edit' nofo.id as back_href %}
+    {% include "includes/page_heading.html" with title="Confirm re-import for “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
+  {% endwith %}
+  {% endwith %}
+
+  <p>
+    The document you uploaded has a <strong>different opportunity number</strong> than the current NOFO.
+  </p>
+
+  <table class="usa-table">
+    <tbody>
+      <tr>
+        <th scope="row">Opportunity number in current NOFO (“{{ nofo|nofo_name }}”)</th>
+        <td>
+          <strong>{{ nofo.number }}</strong>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">Opportunity number in uploaded file (<code>{{ filename }}</code>)</th>
+        <td>
+          <strong>{{ new_opportunity_number }}</strong>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <form id="nofo_import--confirm-reimport--form" method="post">
+    {% csrf_token %}
+    <p>Are you absolutely sure you want to overwrite “{{ nofo|nofo_name }}” with the contents of <code>{{ filename }}</code>?</p>
+
+    <ul class="usa-button-group margin-top-3">
+      <li class="usa-button-group__item">
+        <button class="usa-button usa-button--secondary" type="submit">Yes, overwrite it</button>
+      </li>
+      <li class="usa-button-group__item">
+        <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button usa-button--outline">Never mind, I don’t want to overwrite this NOFO</a>
+      </li>
+    </ul>
+  </form>
+{% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -12,10 +12,10 @@
     <div class="usa-alert__body">
       <h4 class="usa-alert__heading">Warning</h4>
       <p class="usa-alert__text">
-        Re-importing a NOFO overwrites most existing content (but not its theme, assigned coach, or optionally page breaks).
+        Re-importing a NOFO overwrites most existing content.
       </p>
       <p class="usa-alert__text">
-        If you continue, you will lose all manual edits made since creating the NOFO except for the settings preserved above.
+        If you continue, you will lose all manual edits made since creating the NOFO, other than page breaks.
       </p>
     </div>
   </div>

--- a/bloom_nofos/nofos/tests/test_models.py
+++ b/bloom_nofos/nofos/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 
 from django.conf import settings
@@ -242,9 +243,11 @@ class NofoArchiveTest(TestCase):
         # Set NOFO to published using update() to bypass validation
         Nofo.objects.filter(pk=self.nofo.pk).update(status="published")
 
-        response = self.client.post(
-            reverse("nofos:nofo_archive", kwargs={"pk": self.nofo.pk})
-        )
+        # Suppress "WARNING:django.request:Bad Request: /nofos/1/delete" in Django test logs
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(
+                reverse("nofos:nofo_archive", kwargs={"pk": self.nofo.pk})
+            )
 
         self.assertEqual(response.status_code, 400)
 

--- a/bloom_nofos/nofos/tests/test_reimport.py
+++ b/bloom_nofos/nofos/tests/test_reimport.py
@@ -1,6 +1,7 @@
+from bs4 import BeautifulSoup
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, TransactionTestCase
+from django.test import Client, TestCase, TransactionTestCase
 from django.urls import reverse
 from nofos.models import Nofo, Section, Subsection
 from users.models import BloomUser
@@ -20,6 +21,7 @@ class NofoReimportTests(TransactionTestCase):
         self.nofo = Nofo.objects.create(
             title="Test NOFO",
             short_name="test-nofo",
+            number="NOFO-ACF-001",
             opdiv="ACF",
             group="bloom",
         )
@@ -69,9 +71,10 @@ class NofoReimportTests(TransactionTestCase):
         """Create a test HTML file for reimporting with optional page breaks in content."""
         html_content = """
         <html>
-        <head><title>Test NOFO</title></head>
         <body>
+            <p>Opportunity name: Test NOFO</p>
             <p>Opdiv: ACF</p>
+            <p>Opportunity number: NOFO-ACF-001</p>
             <h1>Test Section 1</h1>
             <h2 data-order="10">Eligibility Information</h2>
             <p>Updated eligibility content with new requirements</p>
@@ -190,3 +193,150 @@ class NofoReimportTests(TransactionTestCase):
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
         self.assertEqual(str(messages[0]), "Re-imported NOFO from file: test.html")
+
+
+class NofosImportOverwriteViewTests(TestCase):
+    def setUp(self):
+        """
+        Create a test client and a sample NOFO object.
+        """
+        self.user = BloomUser.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            force_password_reset=False,
+            group="bloom",
+        )
+        self.client = Client()
+        self.client.login(email="test@example.com", password="testpass123")
+
+        # Create an existing NOFO with a known ID
+        self.nofo = Nofo.objects.create(
+            title="Test NOFO",
+            short_name="test-nofo",
+            number="NOFO-ACF-001",
+            opdiv="ACF",
+            group="bloom",
+        )
+
+        self.import_url = reverse(
+            "nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.pk}
+        )
+
+    def create_test_html_file(self, opportunity_number="NOFO-ACF-001"):
+        """Create a test HTML file for reimporting with a given opportunity number."""
+        html_content = f"""
+        <html>
+        <head><title>Test NOFO</title></head>
+        <body>
+            <p>Opportunity name: Test NOFO</p>
+            <p>Opdiv: ACF</p>
+            <p>Opportunity number: {opportunity_number}</p>
+            <h1>Test Section 1</h1>
+            <h2 data-order="10">Eligibility Information</h2>
+            <p>Updated eligibility content with new requirements</p>
+            <h2 class="custom-class" data-order="20">Program Requirements</h2>
+            <p>Updated program requirements with new guidelines</p>
+            <h2 data-order="30">Award Information</h2>
+            <p>Updated award information with new amounts</p>
+        </body>
+        </html>
+        """
+        return SimpleUploadedFile(
+            "test.html", html_content.encode("utf-8"), content_type="text/html"
+        )
+
+    def test_import_overwrite_view_get(self):
+        """
+        Test that the GET request for the NOFO import overwrite view returns a 200 status
+        and contains an <h1> tag.
+        """
+        response = self.client.get(self.import_url)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Check that the page contains an <h1> tag (assuming the page renders correctly)
+        soup = BeautifulSoup(response.content, "html.parser")
+        h1_tag = soup.find("h1")
+        self.assertEqual(h1_tag.text, "Re-import “{}”".format(self.nofo.short_name))
+
+    def test_import_overwrite_view_post(self):
+        """
+        Test that POSTing an HTML file with a the same NOFO ID works as expected
+        """
+        # Create a test HTML file with the same NOFO id
+        test_file = self.create_test_html_file(opportunity_number=self.nofo.number)
+
+        response = self.client.post(
+            self.import_url,
+            {
+                "nofo-import": test_file,
+                "preserve_page_breaks": "on",
+                "csrfmiddlewaretoken": "dummy",
+            },
+            follow=False,  # don't follow redirect yet
+        )
+
+        # confirm it redirects back to the NOFO edit page
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url, reverse("nofos:nofo_edit", kwargs={"pk": self.nofo.pk})
+        )
+
+        # follow the response
+        response_followed = self.client.get(response.url)
+        soup = BeautifulSoup(response_followed.content, "html.parser")
+        # h1 is short_name of nofo
+        self.assertEqual(soup.find("h1").text, self.nofo.short_name)
+        # h4 heading is the success message
+        self.assertEqual(
+            soup.find("h4", class_="usa-alert__heading").text, "NOFO saved successfully"
+        )
+        # p inside alert box tells us what NOFO was imported
+        self.assertEqual(
+            soup.find("p", class_="usa-alert__text").text.strip(),
+            "Re-imported NOFO from file: test.html",
+        )
+
+    def test_import_overwrite_view_post_redirects_to_confirm(self):
+        """
+        Test that POSTing an HTML file with a different NOFO ID redirects to the nofo edit page
+        """
+        # Create a test HTML file with the same NOFO id
+        test_file = self.create_test_html_file(opportunity_number="NOFO-ACF-002")
+
+        response = self.client.post(
+            self.import_url,
+            {
+                "nofo-import": test_file,
+                "preserve_page_breaks": "on",
+                "csrfmiddlewaretoken": "dummy",
+            },
+            follow=False,  # don't follow redirect yet
+        )
+
+        # confirm it redirects to to the NOFO edit page
+        # confirm it redirects to the confirm-import page
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse("nofos:nofo_import_confirm_overwrite", kwargs={"pk": self.nofo.pk}),
+        )
+
+        # follow the response
+        response_followed = self.client.get(response.url)
+        soup = BeautifulSoup(response_followed.content, "html.parser")
+
+        # Find the <h1> element
+        h1_tag = soup.find("h1")
+        p_after_h1 = h1_tag.find_next_sibling("p")
+
+        # h1 asks to confirm intent to overwrite
+        self.assertEqual(
+            h1_tag.text,
+            "Confirm re-import for “{}”".format(self.nofo.short_name),
+        )
+        # p following the h1 warns you that IDs are different
+        self.assertEqual(
+            p_after_h1.text.strip(),
+            "The document you uploaded has a different opportunity number than the current NOFO.",
+        )

--- a/bloom_nofos/nofos/tests/test_reimport.py
+++ b/bloom_nofos/nofos/tests/test_reimport.py
@@ -7,6 +7,30 @@ from nofos.models import Nofo, Section, Subsection
 from users.models import BloomUser
 
 
+def create_test_html_file(opportunity_number="NOFO-ACF-001"):
+    """Create a test HTML file for reimporting with a given opportunity number."""
+    html_content = f"""
+    <html>
+    <head><title>Test NOFO</title></head>
+    <body>
+        <p>Opportunity name: Test NOFO</p>
+        <p>Opdiv: ACF</p>
+        <p>Opportunity number: {opportunity_number}</p>
+        <h1>Test Section 1</h1>
+        <h2 data-order="10">Eligibility Information</h2>
+        <p>Updated eligibility content with new requirements</p>
+        <h2 class="custom-class" data-order="20">Program Requirements</h2>
+        <p>Updated program requirements with new guidelines</p>
+        <h2 data-order="30">Award Information</h2>
+        <p>Updated award information with new amounts</p>
+    </body>
+    </html>
+    """
+    return SimpleUploadedFile(
+        "test.html", html_content.encode("utf-8"), content_type="text/html"
+    )
+
+
 class NofoReimportTests(TransactionTestCase):
     def setUp(self):
         self.user = BloomUser.objects.create_user(
@@ -67,28 +91,6 @@ class NofoReimportTests(TransactionTestCase):
             )
             self.subsections.append(subsection)
 
-    def create_test_file(self, with_page_breaks=False):
-        """Create a test HTML file for reimporting with optional page breaks in content."""
-        html_content = """
-        <html>
-        <body>
-            <p>Opportunity name: Test NOFO</p>
-            <p>Opdiv: ACF</p>
-            <p>Opportunity number: NOFO-ACF-001</p>
-            <h1>Test Section 1</h1>
-            <h2 data-order="10">Eligibility Information</h2>
-            <p>Updated eligibility content with new requirements</p>
-            <h2 class="custom-class" data-order="20">Program Requirements</h2>
-            <p>Updated program requirements with new guidelines</p>
-            <h2 data-order="30">Award Information</h2>
-            <p>Updated award information with new amounts</p>
-        </body>
-        </html>
-        """
-        return SimpleUploadedFile(
-            "test.html", html_content.encode("utf-8"), content_type="text/html"
-        )
-
     def test_reimport_preserves_page_breaks_when_checked(self):
         """Test that page breaks are preserved when checkbox is checked while content is updated."""
         # Add page breaks to simulate manual addition
@@ -97,7 +99,7 @@ class NofoReimportTests(TransactionTestCase):
         self.subsections[1].html_class = "custom-class page-break-before"
         self.subsections[1].save()
 
-        test_file = self.create_test_file()
+        test_file = create_test_html_file()
 
         # Verify initial state
         self.assertEqual(self.subsections[0].body, "Original eligibility content")
@@ -138,7 +140,7 @@ class NofoReimportTests(TransactionTestCase):
         self.subsections[1].html_class = "custom-class page-break-before"
         self.subsections[1].save()
 
-        test_file = self.create_test_file()
+        test_file = create_test_html_file()
 
         # Verify initial state
         self.assertEqual(self.subsections[0].body, "Original eligibility content")
@@ -171,7 +173,7 @@ class NofoReimportTests(TransactionTestCase):
 
     def test_reimport_success_behavior(self):
         """Test success message and redirect behavior for reimport."""
-        test_file = self.create_test_file()
+        test_file = create_test_html_file()
 
         response = self.client.post(
             reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
@@ -222,29 +224,6 @@ class NofosImportOverwriteViewTests(TestCase):
             "nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.pk}
         )
 
-    def create_test_html_file(self, opportunity_number="NOFO-ACF-001"):
-        """Create a test HTML file for reimporting with a given opportunity number."""
-        html_content = f"""
-        <html>
-        <head><title>Test NOFO</title></head>
-        <body>
-            <p>Opportunity name: Test NOFO</p>
-            <p>Opdiv: ACF</p>
-            <p>Opportunity number: {opportunity_number}</p>
-            <h1>Test Section 1</h1>
-            <h2 data-order="10">Eligibility Information</h2>
-            <p>Updated eligibility content with new requirements</p>
-            <h2 class="custom-class" data-order="20">Program Requirements</h2>
-            <p>Updated program requirements with new guidelines</p>
-            <h2 data-order="30">Award Information</h2>
-            <p>Updated award information with new amounts</p>
-        </body>
-        </html>
-        """
-        return SimpleUploadedFile(
-            "test.html", html_content.encode("utf-8"), content_type="text/html"
-        )
-
     def test_import_overwrite_view_get(self):
         """
         Test that the GET request for the NOFO import overwrite view returns a 200 status
@@ -264,7 +243,7 @@ class NofosImportOverwriteViewTests(TestCase):
         Test that POSTing an HTML file with a the same NOFO ID works as expected
         """
         # Create a test HTML file with the same NOFO id
-        test_file = self.create_test_html_file(opportunity_number=self.nofo.number)
+        test_file = create_test_html_file(opportunity_number=self.nofo.number)
 
         response = self.client.post(
             self.import_url,
@@ -302,7 +281,7 @@ class NofosImportOverwriteViewTests(TestCase):
         Test that POSTing an HTML file with a different NOFO ID redirects to the nofo edit page
         """
         # Create a test HTML file with the same NOFO id
-        test_file = self.create_test_html_file(opportunity_number="NOFO-ACF-002")
+        test_file = create_test_html_file(opportunity_number="NOFO-ACF-002")
 
         response = self.client.post(
             self.import_url,

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -13,6 +13,11 @@ urlpatterns = [
         name="nofo_import_overwrite",
     ),
     path(
+        "<int:pk>/confirm-import/",
+        views.NofosConfirmReimportView.as_view(),
+        name="nofo_import_confirm_overwrite",
+    ),
+    path(
         "<int:pk>/import/title",
         views.NofoImportTitleView.as_view(),
         name="nofo_import_title",

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -273,10 +273,9 @@ class BaseNofoImportView(View):
             soup = process_nofo_html(soup, top_heading_level)
 
             # 4. Build sections and subsections as python dicts
-            sections = get_sections_from_soup(soup, top_heading_level)
-            if not len(sections):
-                raise ValidationError("That file does not contain a NOFO.")
-            sections = get_subsections_from_sections(sections, top_heading_level)
+            sections = self.get_sections_and_subsections_from_soup(
+                soup, top_heading_level
+            )
 
         except ValidationError as e:
             # Render a distinct error page for mammoth style map warnings
@@ -304,6 +303,17 @@ class BaseNofoImportView(View):
         return self.handle_nofo_create(
             request, soup, sections, filename, *args, **kwargs
         )
+
+    @staticmethod
+    def get_sections_and_subsections_from_soup(soup, top_heading_level):
+        """
+        Parse a soup object to extract sections and subsections.
+        Raise ValidationError if no sections are found.
+        """
+        sections = get_sections_from_soup(soup, top_heading_level)
+        if not len(sections):
+            raise ValidationError("That file does not contain a NOFO.")
+        return get_subsections_from_sections(sections, top_heading_level)
 
     def handle_nofo_create(self, request, soup, sections, filename, *args, **kwargs):
         """

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -392,6 +392,14 @@ class NofosImportOverwriteView(BaseNofoImportView):
                 "In review/Published NOFOs can’t be re-imported."
             )
 
+        # Step 3: Proceed with reimport
+        return self.reimport_nofo(request, nofo, soup, sections, filename)
+
+    @staticmethod
+    def reimport_nofo(request, nofo, soup, sections, filename):
+        """
+        Handles the actual reimport logic, allowing external calls without requiring an instance.
+        """
         try:
             if_preserve_page_breaks = request.POST.get("preserve_page_breaks") == "on"
             page_breaks = {}
@@ -400,7 +408,7 @@ class NofosImportOverwriteView(BaseNofoImportView):
 
             nofo = overwrite_nofo(nofo, sections)
 
-            # restore breaks if needed
+            # restore page breaks
             if if_preserve_page_breaks and page_breaks:
                 nofo = restore_subsection_metadata(nofo, page_breaks)
 


### PR DESCRIPTION
## Summary

This PR does 1 major thing and 1 minor thing:

1. Add a confirmation page when re-importing a NOFO with a different ID
2. Suppress the "DELETE" warning in our test suite

### 1. Add a confirmation page when re-importing a NOFO

This is based on a post-mortem we had a couple of weeks ago. Basically, someone re-imported a NOFO document _for a different NOFO_ and then wiped out a bunch of content. 

In the event, we were able to restore from a backup, but it signalled to us that we should take some action around this.

This PR introduces a new view (`NofosConfirmReimportView`) which shows up when you upload a document to re-import but the document is found to have a different NOFO opportunity number, which suggests you may have the wrong document. At this point, you still _can_ reimport if you want, or you can back out of it and return to the original reimport screen. 

A couple things to note:
- Because we have to pass the NOFO data to a new view between requests, we are using `request.session` for the first time. This means the session data needs to be removed when we get the chance, so we do that on get requests to the "nofo_edit" page. 
- I am trying to keep things DRY here so I created some new static methods in my View classes because `NofosConfirmReimportView` has to essentially do all the same steps as the Overwrite view to overwrite the NOFO object.

| current import page | reimport page |
|--------|-------|
|  This is the current page we have in the app for reimporting      | This is the *new* page that is added in this PR      |
|     ![Screenshot 2025-01-29 at 12 29 28 PM](https://github.com/user-attachments/assets/4cb32751-a353-42bc-af47-0bf168ca7a7c)   |  ![Screenshot 2025-01-29 at 12 29 37 PM](https://github.com/user-attachments/assets/4b8890a1-2da4-4814-b0dc-828ab1c6c3a2)     |

### 2. Suppress the "DELETE" warning in tests

One of our tests tries to "archive" a published NOFO, and this is not allowed so it throws a warning. Annoyingly, it also meant we would see a warning when running our test suite. 

Now we don't.

| before | after |
|--------|-------|
|    <img width="647" alt="Screenshot 2025-01-30 at 11 50 08 AM" src="https://github.com/user-attachments/assets/db40d7ab-323c-4eca-915c-c68a08a35413" />    |    <img width="647" alt="Screenshot 2025-01-30 at 11 50 42 AM" src="https://github.com/user-attachments/assets/4dce013a-882c-497b-b0aa-0470818abe1c" />   |

