### PR TITLE
Ignore login.gov directories and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ debug_output.html
 
 # export file
 export_links.csv
+
+# Login.gov certificates
+login-gov-cert*.pem
+certs/
+*.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- H7 warning notice at the top of a NOFO now handles h7s in markdown body as well
+- Preserve heading links for h7 headings (other heading levels worked before, but not h7s)
 - Remove unneeded nested lists "li > ul > li" for BYB page and appendices
 - Page breaks were not possible to add to subsections without a heading
 - page-break-after was briefly not working


### PR DESCRIPTION
## Summary

This is a very small PR that is all about DX.

Basically, since the Login.gov PR (#200) is up, I have had this `bloom_nofos/bloom_nofos/certs` directory in my app and it is constantly getting flagged by git as a new file on all other branches. Very annoying!

We can't exactly merge in the login.gov stuff yet, but we _can_ merge in this change to the `.gitignore` file and it will make switching branches seamless.