### PR TITLE
Add h7 processing to link preservation

### DIFF
--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -630,16 +630,6 @@ def get_subsections_from_sections(sections, top_heading_level="h1"):
 
         return newTags[tag_name]
 
-    def is_h7(tag):
-        if (
-            tag.name == "div"
-            and tag.get("role") == "heading"
-            and tag.has_attr("aria-level")
-        ):
-            return True
-
-        return False
-
     def extract_first_header(td):
         for tag_name in heading_tags:
             header_element = td.find(tag_name)
@@ -1966,6 +1956,17 @@ def preserve_bookmark_targets(soup):
                 link.decompose()
 
 
+def is_h7(tag):
+    """
+    Checks if a tag is an H7 heading (div with heading role and aria-level).
+    """
+    return (
+        tag.name == "div"
+        and tag.get("role") == "heading"
+        and tag.has_attr("aria-level")
+    )
+
+
 def preserve_heading_links(soup):
     """
     This function mutates the soup!
@@ -2022,52 +2023,54 @@ def preserve_heading_links(soup):
             heading["id"] = anchor["id"]
             anchor.decompose()  # Remove the empty <a> tag
 
-    # List of all heading tags to check
-    heading_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
+    # Get all headings (h1-h6 and h7s)
+    headings = []
 
-    # Check each heading tag
-    for tag in heading_tags:
-        # Find all heading tags in the document
-        headings = soup.find_all(tag)
+    # Find regular heading tags
+    for tag in ["h1", "h2", "h3", "h4", "h5", "h6"]:
+        headings.extend(soup.find_all(tag))
 
-        # Check each heading
-        for heading in headings:
-            # Store found empty anchors
-            heading_id_anchors = []
-            preceding_id_anchors = []
+    # Find H7 divs
+    headings.extend(soup.find_all(is_h7))
 
-            # Find empty <a> tags immediately preceding the heading
-            previous_sibling = heading.find_previous_sibling()
+    # Process all headings
+    for heading in headings:
+        # Store found empty anchors
+        heading_id_anchors = []
+        preceding_id_anchors = []
 
-            # Traverse back through preceding siblings
-            while previous_sibling and _is_valid_anchor_or_paragraph_containing_anchors(
-                previous_sibling
-            ):
-                if previous_sibling.name == "a":
-                    # Append single valid <a> tag
-                    preceding_id_anchors.append(previous_sibling)
-                elif previous_sibling.name == "p":
-                    # For valid <p>, add all <a> children
-                    preceding_id_anchors.extend(
-                        previous_sibling.find_all("a", recursive=False)
-                    )
-                previous_sibling = previous_sibling.find_previous_sibling()
+        # Find empty <a> tags immediately preceding the heading
+        previous_sibling = heading.find_previous_sibling()
 
-            # Process all preceding empty <a> tags
-            for preceding_anchor in reversed(preceding_id_anchors):
-                if not preceding_anchor.text.strip():
-                    _transfer_id_and_decompose(heading=heading, anchor=preceding_anchor)
+        # Traverse back through preceding siblings
+        while previous_sibling and _is_valid_anchor_or_paragraph_containing_anchors(
+            previous_sibling
+        ):
+            if previous_sibling.name == "a":
+                # Append single valid <a> tag
+                preceding_id_anchors.append(previous_sibling)
+            elif previous_sibling.name == "p":
+                # For valid <p>, add all <a> children
+                preceding_id_anchors.extend(
+                    previous_sibling.find_all("a", recursive=False)
+                )
+            previous_sibling = previous_sibling.find_previous_sibling()
 
-            # Find direct child anchor tags that are empty
-            for a in heading.find_all("a", recursive=False):
-                if a.get_text(strip=True) == "" and not a.contents:
-                    heading_id_anchors.append(a)
+        # Process all preceding empty <a> tags
+        for preceding_anchor in reversed(preceding_id_anchors):
+            if not preceding_anchor.text.strip():
+                _transfer_id_and_decompose(heading=heading, anchor=preceding_anchor)
 
-            # Process all internal empty <a> tags
-            for heading_anchor in heading_id_anchors:
-                # Check if the <a> tag is empty
-                if not heading_anchor.text.strip():
-                    _transfer_id_and_decompose(heading=heading, anchor=heading_anchor)
+        # Find direct child anchor tags that are empty
+        for a in heading.find_all("a", recursive=False):
+            if a.get_text(strip=True) == "" and not a.contents:
+                heading_id_anchors.append(a)
+
+        # Process all internal empty <a> tags
+        for heading_anchor in heading_id_anchors:
+            # Check if the <a> tag is empty
+            if not heading_anchor.text.strip():
+                _transfer_id_and_decompose(heading=heading, anchor=heading_anchor)
 
 
 def preserve_table_heading_links(soup):

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -4380,40 +4380,29 @@ class PreserveHeadingLinksTest(TestCase):
         self,
     ):
         """H7 heading with a direct child anchor should get the anchor's ID and remove the anchor."""
-        html = """
-        <div role="heading" aria-level="7">
-            <a id="h7-direct-link"></a>
-            Some H7 Heading Text
-        </div>
-        """
+        html = '<div role="heading" aria-level="7"><a id="h7-direct-link"></a>Some H7 Heading Text</div>'
         soup = BeautifulSoup(html, "html.parser")
         preserve_heading_links(soup)
         result = str(soup)
-        expected = '<div role="heading" aria-level="7" id="h7-direct-link">Some H7 Heading Text</div>'
+        expected = '<div aria-level="7" id="h7-direct-link" role="heading">Some H7 Heading Text</div>'
         self.assertEqual(result, expected)
 
     def test_h7_with_preceding_anchor_transfers_id_and_removes_anchor(
         self,
     ):
         """H7 heading with a preceding anchor should get the anchor's ID and remove the anchor."""
-        html = """
-        <a id="h7-preceding-link"></a>
-        <div role="heading" aria-level="7">Some H7 Heading Text</div>
-        """
+        html = '<a id="h7-preceding-link"></a><div role="heading" aria-level="7">Some H7 Heading Text</div>'
         soup = BeautifulSoup(html, "html.parser")
         preserve_heading_links(soup)
         result = str(soup)
-        expected = '<div role="heading" aria-level="7" id="h7-preceding-link">Some H7 Heading Text</div>'
+        expected = '<div aria-level="7" id="h7-preceding-link" role="heading">Some H7 Heading Text</div>'
         self.assertEqual(result, expected)
 
     def test_regular_div_ignores_preceding_anchor(
         self,
     ):
         """Regular div without heading role should not get ID from preceding anchor."""
-        html = """
-        <a id="some-link"></a>
-        <div>Regular div content</div>
-        """
+        html = '<a id="some-link"></a><div>Regular div content</div>'
         soup = BeautifulSoup(html, "html.parser")
         preserve_heading_links(soup)
         result = str(soup)

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -4376,6 +4376,50 @@ class PreserveHeadingLinksTest(TestCase):
         expected = '<h4 id="_About_Priority_Populations_inside">About priority populations</h4><a href="#_About_Priority_Populations_inside">Link to h4</a><a href="#_About_Priority_Populations_inside">Link to preceding</a><a href="#_About_Priority_Populations_inside">Link to inside</a>'
         self.assertEqual(result, expected)
 
+    def test_h7_with_direct_child_anchor_transfers_id_and_removes_anchor(
+        self,
+    ):
+        """H7 heading with a direct child anchor should get the anchor's ID and remove the anchor."""
+        html = """
+        <div role="heading" aria-level="7">
+            <a id="h7-direct-link"></a>
+            Some H7 Heading Text
+        </div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        preserve_heading_links(soup)
+        result = str(soup)
+        expected = '<div role="heading" aria-level="7" id="h7-direct-link">Some H7 Heading Text</div>'
+        self.assertEqual(result, expected)
+
+    def test_h7_with_preceding_anchor_transfers_id_and_removes_anchor(
+        self,
+    ):
+        """H7 heading with a preceding anchor should get the anchor's ID and remove the anchor."""
+        html = """
+        <a id="h7-preceding-link"></a>
+        <div role="heading" aria-level="7">Some H7 Heading Text</div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        preserve_heading_links(soup)
+        result = str(soup)
+        expected = '<div role="heading" aria-level="7" id="h7-preceding-link">Some H7 Heading Text</div>'
+        self.assertEqual(result, expected)
+
+    def test_regular_div_ignores_preceding_anchor(
+        self,
+    ):
+        """Regular div without heading role should not get ID from preceding anchor."""
+        html = """
+        <a id="some-link"></a>
+        <div>Regular div content</div>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        preserve_heading_links(soup)
+        result = str(soup)
+        expected = '<a id="some-link"></a><div>Regular div content</div>'
+        self.assertEqual(result, expected)
+
 
 class PreserveTableHeadingLinksTest(TestCase):
     def test_empty_anchor_with_table_heading_id(self):


### PR DESCRIPTION
issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/203

Changes:
- defines is_h7 at the module level so it can be reused
- reworks tag handling in preserve_heading_links method to account for h7s
- The actual changes here are really just 2027-2037, the rest of LoC is just nesting changing
- Adds unit tests for h7 link preservation

QA Steps:
- Import a nofo with h7 headings (like CDC-00009)
- Verify there are no broken links 