### PR TITLE
Feat/retry in link checker

### DIFF
--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -28,13 +28,9 @@ from .utils import (
 )
 
 DEFAULT_NOFO_OPPORTUNITY_NUMBER = "NOFO #999"
-# Use Firefox user agent
-REQUEST_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:131.0) Gecko/20100101 Firefox/131.0"
-}
 
-# More realistic browser like request headers for GET requests
-REQUEST_HEADERS_GET = {
+# More realistic browser-like request headers (Firefox) for HTTP requests
+REQUEST_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:131.0) Gecko/20100101 Firefox/131.0",
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.5",
@@ -925,9 +921,9 @@ def _update_link_statuses(all_links):
                 try:
                     response = requests.get(
                         link["url"],
-                        timeout=7,
+                        timeout=5,
                         allow_redirects=True,
-                        headers=REQUEST_HEADERS_GET,
+                        headers=REQUEST_HEADERS,
                     )
                 except requests.RequestException:
                     # If GET also fails, use original HEAD response

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -133,6 +133,7 @@ def process_nofo_html(soup, top_heading_level):
     decompose_empty_tags(soup)
     combine_consecutive_links(soup)
     remove_google_tracking_info_from_links(soup)
+    replace_src_for_inline_images(soup)
     add_endnotes_header_if_exists(soup, top_heading_level)
     unwrap_nested_lists(soup)
     preserve_bookmark_targets(soup)

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -33,6 +33,22 @@ REQUEST_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:131.0) Gecko/20100101 Firefox/131.0"
 }
 
+# More realistic browser like request headers for GET requests
+REQUEST_HEADERS_GET = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:131.0) Gecko/20100101 Firefox/131.0",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate, br",
+    "DNT": "1",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Pragma": "no-cache",
+    "Cache-Control": "no-cache",
+}
 
 ###########################################################
 #################### NOFO IMPORT FUNCS ####################
@@ -117,7 +133,6 @@ def process_nofo_html(soup, top_heading_level):
     decompose_empty_tags(soup)
     combine_consecutive_links(soup)
     remove_google_tracking_info_from_links(soup)
-    replace_src_for_inline_images(soup)
     add_endnotes_header_if_exists(soup, top_heading_level)
     unwrap_nested_lists(soup)
     preserve_bookmark_targets(soup)
@@ -899,9 +914,24 @@ def _update_link_statuses(all_links):
 
     def check_link_status(link):
         try:
+            # First try HEAD request
             response = requests.head(
                 link["url"], timeout=5, allow_redirects=True, headers=REQUEST_HEADERS
             )
+
+            # If we get certain error codes that often work with GET, retry with GET
+            if response.status_code in [403, 405, 500, 501, 502, 503]:
+                try:
+                    response = requests.get(
+                        link["url"],
+                        timeout=7,
+                        allow_redirects=True,
+                        headers=REQUEST_HEADERS_GET,
+                    )
+                except requests.RequestException:
+                    # If GET also fails, use original HEAD response
+                    pass
+
             link["status"] = response.status_code
             if len(response.history):
                 link["redirect_url"] = response.url

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from freezegun import freeze_time
 
 from .models import Nofo, Section, Subsection
-from .nofo import DEFAULT_NOFO_OPPORTUNITY_NUMBER, REQUEST_HEADERS, REQUEST_HEADERS_GET
+from .nofo import DEFAULT_NOFO_OPPORTUNITY_NUMBER, REQUEST_HEADERS
 from .nofo import _get_all_id_attrs_for_nofo as get_all_id_attrs_for_nofo
 from .nofo import (
     _get_classnames_for_font_weight_bold as get_classnames_for_font_weight_bold,
@@ -2534,9 +2534,9 @@ class TestUpdateLinkStatuses(TestCase):
         # Verify GET was called after HEAD returned 500
         mock_get.assert_called_once_with(
             "https://example.com",
-            timeout=7,
+            timeout=5,
             allow_redirects=True,
-            headers=REQUEST_HEADERS_GET,
+            headers=REQUEST_HEADERS,
         )
 
         # Verify we got the 200 status from the GET request
@@ -2568,9 +2568,9 @@ class TestUpdateLinkStatuses(TestCase):
         # Verify GET was attempted
         mock_get.assert_called_once_with(
             "https://example.com",
-            timeout=7,
+            timeout=5,
             allow_redirects=True,
-            headers=REQUEST_HEADERS_GET,
+            headers=REQUEST_HEADERS,
         )
 
         # Verify we kept the 500 status from HEAD since GET failed
@@ -2605,9 +2605,9 @@ class TestUpdateLinkStatuses(TestCase):
         # Verify GET was called after HEAD returned 403
         mock_get.assert_called_once_with(
             "https://example.com",
-            timeout=7,
+            timeout=5,
             allow_redirects=True,
-            headers=REQUEST_HEADERS_GET,
+            headers=REQUEST_HEADERS,
         )
 
         # Verify we got the 200 status from the GET request
@@ -2642,9 +2642,9 @@ class TestUpdateLinkStatuses(TestCase):
         # Verify GET was called after HEAD returned 405
         mock_get.assert_called_once_with(
             "https://example.com",
-            timeout=7,
+            timeout=5,
             allow_redirects=True,
-            headers=REQUEST_HEADERS_GET,
+            headers=REQUEST_HEADERS,
         )
 
         # Verify we got the 200 status from the GET request

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from freezegun import freeze_time
 
 from .models import Nofo, Section, Subsection
-from .nofo import DEFAULT_NOFO_OPPORTUNITY_NUMBER
+from .nofo import DEFAULT_NOFO_OPPORTUNITY_NUMBER, REQUEST_HEADERS, REQUEST_HEADERS_GET
 from .nofo import _get_all_id_attrs_for_nofo as get_all_id_attrs_for_nofo
 from .nofo import (
     _get_classnames_for_font_weight_bold as get_classnames_for_font_weight_bold,
@@ -2504,6 +2504,151 @@ class TestUpdateLinkStatuses(TestCase):
         all_links = [{"url": "https://example.com", "status": ""}]
         update_link_statuses(all_links)
         self.assertIn("Error: Connection error", all_links[0]["error"])
+
+    @patch("nofos.nofo.requests.head")
+    @patch("nofos.nofo.requests.get")
+    def test_status_code_500_retries_with_get(self, mock_get, mock_head):
+        # First request (HEAD) returns 500
+        mock_head_response = MagicMock()
+        mock_head_response.status_code = 500
+        mock_head_response.history = []
+        mock_head.return_value = mock_head_response
+
+        # Second request (GET) returns 200
+        mock_get_response = MagicMock()
+        mock_get_response.status_code = 200
+        mock_get_response.history = []
+        mock_get.return_value = mock_get_response
+
+        all_links = [{"url": "https://example.com", "status": ""}]
+        update_link_statuses(all_links)
+
+        # Verify HEAD was called first
+        mock_head.assert_called_once_with(
+            "https://example.com",
+            timeout=5,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS,
+        )
+
+        # Verify GET was called after HEAD returned 500
+        mock_get.assert_called_once_with(
+            "https://example.com",
+            timeout=7,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS_GET,
+        )
+
+        # Verify we got the 200 status from the GET request
+        self.assertEqual(all_links[0]["status"], 200)
+
+    @patch("nofos.nofo.requests.head")
+    @patch("nofos.nofo.requests.get")
+    def test_status_code_500_get_also_fails(self, mock_get, mock_head):
+        # First request (HEAD) returns 500
+        mock_head_response = MagicMock()
+        mock_head_response.status_code = 500
+        mock_head_response.history = []
+        mock_head.return_value = mock_head_response
+
+        # GET request fails
+        mock_get.side_effect = requests.RequestException("GET failed")
+
+        all_links = [{"url": "https://example.com", "status": ""}]
+        update_link_statuses(all_links)
+
+        # Verify HEAD was called first
+        mock_head.assert_called_once_with(
+            "https://example.com",
+            timeout=5,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS,
+        )
+
+        # Verify GET was attempted
+        mock_get.assert_called_once_with(
+            "https://example.com",
+            timeout=7,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS_GET,
+        )
+
+        # Verify we kept the 500 status from HEAD since GET failed
+        self.assertEqual(all_links[0]["status"], 500)
+
+    @patch("nofos.nofo.requests.head")
+    @patch("nofos.nofo.requests.get")
+    def test_status_code_403_retries_with_get(self, mock_get, mock_head):
+        # First request (HEAD) returns 403
+        mock_head_response = MagicMock()
+        mock_head_response.status_code = 403
+        mock_head_response.history = []
+        mock_head.return_value = mock_head_response
+
+        # Second request (GET) returns 200
+        mock_get_response = MagicMock()
+        mock_get_response.status_code = 200
+        mock_get_response.history = []
+        mock_get.return_value = mock_get_response
+
+        all_links = [{"url": "https://example.com", "status": ""}]
+        update_link_statuses(all_links)
+
+        # Verify HEAD was called first
+        mock_head.assert_called_once_with(
+            "https://example.com",
+            timeout=5,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS,
+        )
+
+        # Verify GET was called after HEAD returned 403
+        mock_get.assert_called_once_with(
+            "https://example.com",
+            timeout=7,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS_GET,
+        )
+
+        # Verify we got the 200 status from the GET request
+        self.assertEqual(all_links[0]["status"], 200)
+
+    @patch("nofos.nofo.requests.head")
+    @patch("nofos.nofo.requests.get")
+    def test_status_code_405_retries_with_get(self, mock_get, mock_head):
+        # First request (HEAD) returns 405
+        mock_head_response = MagicMock()
+        mock_head_response.status_code = 405
+        mock_head_response.history = []
+        mock_head.return_value = mock_head_response
+
+        # Second request (GET) returns 200
+        mock_get_response = MagicMock()
+        mock_get_response.status_code = 200
+        mock_get_response.history = []
+        mock_get.return_value = mock_get_response
+
+        all_links = [{"url": "https://example.com", "status": ""}]
+        update_link_statuses(all_links)
+
+        # Verify HEAD was called first
+        mock_head.assert_called_once_with(
+            "https://example.com",
+            timeout=5,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS,
+        )
+
+        # Verify GET was called after HEAD returned 405
+        mock_get.assert_called_once_with(
+            "https://example.com",
+            timeout=7,
+            allow_redirects=True,
+            headers=REQUEST_HEADERS_GET,
+        )
+
+        # Verify we got the 200 status from the GET request
+        self.assertEqual(all_links[0]["status"], 200)
 
 
 #########################################################


### PR DESCRIPTION
Issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/194


Changes:
- Adds get request to be attempted for link checker if head request fails
- Adds more detailed request headers for get requests
- Unit tests to verify this logic

QA Steps:
- Upload a nofo that has a bunch of external links
- Run the link checker
- It should mostly return accurate results for good links/broken links*

* NOTE: Some link sources like eCFR are flaky, especially when running the checker multiple times in a row, I suspect they have some rate limiting/throttling/bot detection in place thats going to results inconsistent

Screenshots:
BEFORE CHANGES:  
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/3c0f3178-8799-4c5d-b7b6-7069123b9738" />

AFTER CHANGES:
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/e7bfe13e-cf94-469e-8865-d41e837888a2" />

