### PR TITLE
audit page added with tests and infinite scroll

### DIFF
--- a/bloom_nofos/nofos/partials/audit_events_rows.html
+++ b/bloom_nofos/nofos/partials/audit_events_rows.html
@@ -1,8 +1,0 @@
-{% for event in audit_events %}
-<tr>
-    <td>{{ event.event_type }}</td>
-    <td>{{ event.object_type }} - {{ event.object_description }}</td>
-    <td>{{ event.user }}</td>
-    <td>{{ event.timestamp }}</td>
-</tr>
-{% endfor %}

--- a/bloom_nofos/nofos/partials/audit_events_rows.html
+++ b/bloom_nofos/nofos/partials/audit_events_rows.html
@@ -1,0 +1,8 @@
+{% for event in audit_events %}
+<tr>
+    <td>{{ event.event_type }}</td>
+    <td>{{ event.object_type }} - {{ event.object_description }}</td>
+    <td>{{ event.user }}</td>
+    <td>{{ event.timestamp }}</td>
+</tr>
+{% endfor %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -325,7 +325,7 @@ Edit “{{ nofo|nofo_name }}”
     {% if nofo.cover_image and nofo.cover != 'nofo--cover-page--text' %}
       <tr>
         <th scope="row">Cover alt text</th>
-        <td>{% if nofo.cover_image_alt_text %}""{% endif%}{{ nofo.cover_image_alt_text|get_value_or_none:"alt text" }}{% if nofo.cover_image_alt_text %}""{% endif %}</td>
+        <td>{% if nofo.cover_image_alt_text %}“{% endif%}{{ nofo.cover_image_alt_text|get_value_or_none:"alt text" }}{% if nofo.cover_image_alt_text %}”{% endif %}</td>
         <td><a href="{% url 'nofos:nofo_edit_cover_image' nofo.id %}">Edit<span class="usa-sr-only"> cover image alt text</span></a></td>
       </tr>
     {% endif %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -73,6 +73,13 @@ Edit “{{ nofo|nofo_name }}”
       <ul class="usa-list usa-list--unstyled">
         <li>
           <p>
+            <a class="usa-button usa-button--outline" href="{% url 'nofos:nofo_history' nofo.id %}">
+              View audit history
+            </a>— See when this NOFO was modified and by whom
+          </p>
+        </li>
+        <li>
+          <p>
             <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' nofo.id %}">
               Check external links
             </a>— There are {{ external_links|length }} external links in this NOFO
@@ -318,7 +325,7 @@ Edit “{{ nofo|nofo_name }}”
     {% if nofo.cover_image and nofo.cover != 'nofo--cover-page--text' %}
       <tr>
         <th scope="row">Cover alt text</th>
-        <td>{% if nofo.cover_image_alt_text %}“{% endif%}{{ nofo.cover_image_alt_text|get_value_or_none:"alt text" }}{% if nofo.cover_image_alt_text %}”{% endif %}</td>
+        <td>{% if nofo.cover_image_alt_text %}""{% endif%}{{ nofo.cover_image_alt_text|get_value_or_none:"alt text" }}{% if nofo.cover_image_alt_text %}""{% endif %}</td>
         <td><a href="{% url 'nofos:nofo_edit_cover_image' nofo.id %}">Edit<span class="usa-sr-only"> cover image alt text</span></a></td>
       </tr>
     {% endif %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_history.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history.html
@@ -8,11 +8,13 @@
 {% block body_class %}nofo_history nofo_status--{{ nofo.status }}{% endblock %}
 
 {% block content %}
-<div class="back-link font-body-md">
-  <a href="{% url 'nofos:nofo_edit' nofo.id %}">Back to NOFO</a>
-</div>
+  {% with nofo|nofo_name as nofo_name_str %}
+    {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
+      {% url 'nofos:nofo_edit' nofo.id as back_href %}
+      {% include "includes/page_heading.html" with title="Audit history for “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
+    {% endwith %}
+  {% endwith %}
 
-<h1>Audit History for "{{ nofo|nofo_name }}"</h1>
 
 <div class="margin-bottom-5">
   <span class="usa-tag usa-tag--big bg-group bg-group--not-uppercase bg-group--{{ nofo.group }}">{{ nofo.get_group_display }}</span>
@@ -58,7 +60,7 @@
 {% endif %}
 
 <script>
-document.getElementById('load-more-btn').addEventListener('click', async function() {
+document.getElementById('load-more-btn')?.addEventListener('click', async function() {
     const button = this;
     const offset = button.dataset.nextOffset;
     button.disabled = true;
@@ -76,9 +78,13 @@ document.getElementById('load-more-btn').addEventListener('click', async functio
         const newRows = doc.getElementById('audit-events-body').children;
         const currentTable = document.getElementById('audit-events-body');
         
+        const fragment = new DocumentFragment();
+
         Array.from(newRows).forEach(row => {
-            currentTable.appendChild(row.cloneNode(true));
+            fragment.appendChild(row.cloneNode(true));
         });
+
+        currentTable.appendChild(fragment);
         
         // Update or remove the button
         const hasMore = doc.getElementById('load-more-btn');
@@ -90,6 +96,7 @@ document.getElementById('load-more-btn').addEventListener('click', async functio
             button.remove();
         }
     } catch (error) {
+        console.error('Error loading more events:', error);
         button.textContent = 'Error loading more events. Try again.';
         button.disabled = false;
     }

--- a/bloom_nofos/nofos/templates/nofos/nofo_history.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static nofo_name %}
+{% load static nofo_name tz %}
 
 {% block title %}
   Audit History for "{{ nofo|nofo_name }}"
@@ -40,7 +40,11 @@
       <td>{{ event.event_type }}</td>
       <td>{{ event.object_type }} - {{ event.object_description }}</td>
       <td>{{ event.user }}</td>
-      <td>{{ event.timestamp }}</td>
+      {% timezone "America/New_York" %}
+        <td data-sort="{{ event.timestamp|date:"YmdHM" }}">
+          {{ event.timestamp|date:'M j' }}{% if event.timestamp|date:'M j' == today_m_j %}, {{ event.timestamp|date:'H:i' }}{% endif %}
+        </td>
+      {% endtimezone %}
     </tr>
     {% empty %}
     <tr>

--- a/bloom_nofos/nofos/templates/nofos/nofo_history.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history.html
@@ -1,0 +1,99 @@
+{% extends 'base.html' %}
+{% load static nofo_name %}
+
+{% block title %}
+  Audit History for "{{ nofo|nofo_name }}"
+{% endblock %}
+
+{% block body_class %}nofo_history nofo_status--{{ nofo.status }}{% endblock %}
+
+{% block content %}
+<div class="back-link font-body-md">
+  <a href="{% url 'nofos:nofo_edit' nofo.id %}">Back to NOFO</a>
+</div>
+
+<h1>Audit History for "{{ nofo|nofo_name }}"</h1>
+
+<div class="margin-bottom-5">
+  <span class="usa-tag usa-tag--big bg-group bg-group--not-uppercase bg-group--{{ nofo.group }}">{{ nofo.get_group_display }}</span>
+</div>
+
+<table class="usa-table" id="audit-events-table">
+  <caption>
+    <div>
+      <h2 class="margin-bottom-0">Recent Changes</h2>
+    </div>
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">Event</th>
+      <th scope="col">Object</th>
+      <th scope="col">User</th>
+      <th scope="col">Timestamp</th>
+    </tr>
+  </thead>
+  <tbody id="audit-events-body">
+    {% for event in audit_events %}
+    <tr>
+      <td>{{ event.event_type }}</td>
+      <td>{{ event.object_type }} - {{ event.object_description }}</td>
+      <td>{{ event.user }}</td>
+      <td>{{ event.timestamp }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="4" class="text-center">No audit events found.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{% if has_more %}
+  <div class="text-center margin-y-3">
+    <button class="usa-button" id="load-more-btn" 
+            data-next-offset="{{ next_offset }}">
+      Load More Events
+    </button>
+  </div>
+{% endif %}
+
+<script>
+document.getElementById('load-more-btn').addEventListener('click', async function() {
+    const button = this;
+    const offset = button.dataset.nextOffset;
+    button.disabled = true;
+    button.textContent = 'Loading...';
+    
+    try {
+        const response = await fetch(`?offset=${offset}`);
+        const html = await response.text();
+        
+        // Parse the new content
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        
+        // Get new rows and append them
+        const newRows = doc.getElementById('audit-events-body').children;
+        const currentTable = document.getElementById('audit-events-body');
+        
+        Array.from(newRows).forEach(row => {
+            currentTable.appendChild(row.cloneNode(true));
+        });
+        
+        // Update or remove the button
+        const hasMore = doc.getElementById('load-more-btn');
+        if (hasMore) {
+            button.dataset.nextOffset = hasMore.dataset.nextOffset;
+            button.disabled = false;
+            button.textContent = 'Load More Events';
+        } else {
+            button.remove();
+        }
+    } catch (error) {
+        button.textContent = 'Error loading more events. Try again.';
+        button.disabled = false;
+    }
+});
+</script>
+
+{% endblock %} 

--- a/bloom_nofos/nofos/templates/nofos/nofo_index.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_index.html
@@ -69,7 +69,12 @@
 						<td>{% if nofo.coach %}{{ nofo.get_coach_display }}{% else %}<span class="usa-sr-only">No coach assigned</span><span aria-hidden="true">—</span>{% endif %}</td>
 						<td>{% if nofo.designer %}{{ nofo.get_designer_display }}{% else %}<span class="usa-sr-only">No designer assigned</span><span aria-hidden="true">—</span>{% endif %}</td>
 						{% timezone "America/New_York" %}
-							<td data-sort="{{ nofo.updated|date:"YmdHM" }}">{{ nofo.updated|date:'M j' }}{% if nofo.updated|date:'M j' == today_m_j %}, {{ nofo.updated|date:'H:i' }}{% endif %}</td>
+							<td data-sort="{{ nofo.updated|date:"YmdHM" }}">
+								<a href="{% url 'nofos:nofo_history' nofo.id %}" title="View audit history">
+									{{ nofo.updated|date:'M j' }}{% if nofo.updated|date:'M j' == today_m_j %}, {{ nofo.updated|date:'H:i' }}{% endif %}
+									<span class="usa-sr-only"> - View audit history for {% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}</span>
+								</a>
+							</td>
 						{% endtimezone %}
 						<td><a href="{% url 'nofos:nofo_view' nofo.id %}">View<span class="usa-sr-only"> {% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}</span></a></td>
 					</tr>

--- a/bloom_nofos/nofos/tests/test_history.py
+++ b/bloom_nofos/nofos/tests/test_history.py
@@ -127,23 +127,3 @@ class NofoHistoryViewTests(TestCase):
         self.assertContains(response, subsection_event.get_event_type_display())
         self.assertContains(response, "Section")
         self.assertContains(response, "Subsection")
-
-    def test_history_view_handles_invalid_json(self):
-        """Test that history view handles invalid JSON in changed_fields gracefully"""
-        # Create an event with invalid JSON
-        event = CRUDEvent.objects.create(
-            event_type=CRUDEvent.UPDATE,
-            object_id=self.nofo.id,
-            content_type=self.nofo_content_type,
-            object_repr=str(self.nofo),
-            user=self.user,
-            datetime=timezone.now(),
-            changed_fields="{invalid json",
-        )
-
-        url = reverse("nofos:nofo_history", args=[self.nofo.id])
-        response = self.client.get(url)
-
-        # Should not raise an error and should show the default event type
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, event.get_event_type_display())

--- a/bloom_nofos/nofos/tests/test_history.py
+++ b/bloom_nofos/nofos/tests/test_history.py
@@ -1,0 +1,149 @@
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from easyaudit.models import CRUDEvent
+
+from ..models import Nofo, Section, Subsection
+
+User = get_user_model()
+
+
+class NofoHistoryViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(email="test@example.com", password="testpass123")
+
+        self.nofo = Nofo.objects.create(
+            title="Test NOFO",
+            number="TEST-2024-01",
+            group="bloom",
+            opdiv="test-opdiv",
+        )
+
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Test Section",
+            order=1,
+        )
+
+        self.subsection = Subsection.objects.create(
+            section=self.section,
+            name="Test Subsection",
+            order=2,
+            body="Test content",
+            tag="h2",
+            html_id="test-subsection-2",
+        )
+
+        # Get content types for our models
+        self.nofo_content_type = ContentType.objects.get_for_model(Nofo)
+        self.section_content_type = ContentType.objects.get_for_model(Section)
+        self.subsection_content_type = ContentType.objects.get_for_model(Subsection)
+
+    def test_history_view_shows_regular_crud_events(self):
+        """Test that history view shows regular CRUD events"""
+        # Create a test CRUD event
+        event = CRUDEvent.objects.create(
+            event_type=CRUDEvent.CREATE,
+            object_id=self.nofo.id,
+            content_type=self.nofo_content_type,
+            object_repr=str(self.nofo),
+            user=self.user,
+            datetime=timezone.now(),
+        )
+
+        url = reverse("nofos:nofo_history", args=[self.nofo.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, event.get_event_type_display())
+        self.assertContains(response, str(self.nofo))
+
+    def test_history_view_shows_custom_audit_events(self):
+        """Test that history view shows custom audit events (import, print, reimport)"""
+        # Create a NOFO import event
+        import_event = CRUDEvent.objects.create(
+            event_type=CRUDEvent.UPDATE,
+            object_id=self.nofo.id,
+            content_type=self.nofo_content_type,
+            object_repr=str(self.nofo),
+            user=self.user,
+            datetime=timezone.now(),
+            changed_fields='{"action": "nofo_import", "updated": ["2024-01-01 12:00:00.000000"]}',
+        )
+
+        # Create a NOFO print event with test mode
+        print_event = CRUDEvent.objects.create(
+            event_type=CRUDEvent.UPDATE,
+            object_id=self.nofo.id,
+            content_type=self.nofo_content_type,
+            object_repr=str(self.nofo),
+            user=self.user,
+            datetime=timezone.now(),
+            changed_fields='{"action": "nofo_print", "updated": ["2024-01-01 12:00:00.000000"], "print_mode": ["test"]}',
+        )
+
+        url = reverse("nofos:nofo_history", args=[self.nofo.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "NOFO Imported")
+        self.assertContains(response, "NOFO Printed (test mode)")
+
+    def test_history_view_shows_section_and_subsection_events(self):
+        """Test that history view shows events from sections and subsections"""
+        # Create a section update event
+        section_event = CRUDEvent.objects.create(
+            event_type=CRUDEvent.UPDATE,
+            object_id=self.section.id,
+            content_type=self.section_content_type,
+            object_repr=str(self.section),
+            user=self.user,
+            datetime=timezone.now(),
+        )
+
+        # Create a subsection update event
+        subsection_event = CRUDEvent.objects.create(
+            event_type=CRUDEvent.UPDATE,
+            object_id=self.subsection.id,
+            content_type=self.subsection_content_type,
+            object_repr=str(self.subsection),
+            user=self.user,
+            datetime=timezone.now(),
+        )
+
+        url = reverse("nofos:nofo_history", args=[self.nofo.id])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, section_event.get_event_type_display())
+        self.assertContains(response, subsection_event.get_event_type_display())
+        self.assertContains(response, "Section")
+        self.assertContains(response, "Subsection")
+
+    def test_history_view_handles_invalid_json(self):
+        """Test that history view handles invalid JSON in changed_fields gracefully"""
+        # Create an event with invalid JSON
+        event = CRUDEvent.objects.create(
+            event_type=CRUDEvent.UPDATE,
+            object_id=self.nofo.id,
+            content_type=self.nofo_content_type,
+            object_repr=str(self.nofo),
+            user=self.user,
+            datetime=timezone.now(),
+            changed_fields="{invalid json",
+        )
+
+        url = reverse("nofos:nofo_history", args=[self.nofo.id])
+        response = self.client.get(url)
+
+        # Should not raise an error and should show the default event type
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, event.get_event_type_display())

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -8,6 +8,11 @@ urlpatterns = [
     path("import", views.NofosImportNewView.as_view(), name="nofo_import"),
     path("<int:pk>/delete", views.NofosArchiveView.as_view(), name="nofo_archive"),
     path(
+        "<int:pk>/history",
+        views.NofoHistoryView.as_view(),
+        name="nofo_history",
+    ),
+    path(
         "<int:pk>/import",
         views.NofosImportOverwriteView.as_view(),
         name="nofo_import_overwrite",

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -991,6 +991,7 @@ class NofoHistoryView(GroupAccessObjectMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["today_m_j"] = dateformat.format(timezone.now(), "M j")
         offset = int(self.request.GET.get("offset", 0))
 
         # Get audit events for this NOFO


### PR DESCRIPTION
Issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/171

Changes:
- Adds button to edit page linking to audit page
- Adds Audit page at /nofo/{id}/history
- Adds unit tests audit page logic
- Adds link from index page on updated timestamp

screenshots:
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/99b80b04-45d3-41b2-9ec5-49d8ddeba46d" />

