### PR TITLE
Compare NOFOs including text diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add new "{id}/compare" route for comparing a new NOFO document to an existing one
+
 ### Changed
 
 - Breadcrumb links are no longer clickable (instead, they are just visual indicators)

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -966,7 +966,8 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 /* compare page */
 
-.usa-alert--info.usa-alert--alpha .usa-alert__body {
+.usa-alert--warning.usa-alert--alpha .usa-alert__body {
+  border-left: 2px solid black;
   background-color: #f0f0f0;
 }
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -966,6 +966,10 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 /* compare page */
 
+.usa-alert--info.usa-alert--alpha .usa-alert__body {
+  background-color: #f0f0f0;
+}
+
 del {
   color: red;
   background-color: #ffebe9;

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -297,6 +297,10 @@ details > summary > span:hover {
   width: 132px;
 }
 
+.nofo_import.nofo_import--compare .submit-button {
+  width: 165px;
+}
+
 .nofo_import .submit-button.submit-button--loading {
   text-align: left;
 }
@@ -960,26 +964,13 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   font-size: 1rem;
 }
 
-/* comparison form */
+/* compare page */
 
-.comparison-form {
-  max-width: 100%;
+del {
+  color: red;
+  background-color: #ffebe9;
 }
 
-.comparison-form ul {
-  list-style: none;
-}
-
-.comparison-form summary {
-  margin-bottom: 10px;
-}
-
-.comparison-form .comparison-form--subsection-list li label {
-  display: flex;
-  align-items: baseline;
-  gap: 1em;
-}
-
-.comparison-form .diff {
-  margin: 10px 0;
+ins {
+  background-color: #aceebb;
 }

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -966,6 +966,19 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 /* compare page */
 
+.usa-alert--warning.usa-alert--alpha .usa-alert__body {
+  border-left: 2px solid black;
+  background-color: #f0f0f0;
+}
+
+.usa-alert--warning.usa-alert--alpha .usa-alert__text {
+  display: flex;
+}
+
+.usa-alert--warning.usa-alert--alpha .usa-tag {
+  height: 100%;
+}
+
 .nofo_compare caption h2 {
   margin-bottom: 0;
 }
@@ -974,13 +987,12 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   margin-bottom: 0.5rem;
 }
 
-.usa-alert--warning.usa-alert--alpha .usa-alert__body {
-  border-left: 2px solid black;
-  background-color: #f0f0f0;
+.nofo_compare .usa-table .diff {
+  word-break: break-word;
 }
 
 del {
-  color: red;
+  color: var(--color--usa-error-message);
   background-color: #ffebe9;
 }
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -966,6 +966,14 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 /* compare page */
 
+.nofo_compare caption h2 {
+  margin-bottom: 0;
+}
+
+.nofo_compare .usa-table caption {
+  margin-bottom: 0.5rem;
+}
+
 .usa-alert--warning.usa-alert--alpha .usa-alert__body {
   border-left: 2px solid black;
   background-color: #f0f0f0;

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -959,3 +959,27 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 .usa-error-message {
   font-size: 1rem;
 }
+
+/* comparison form */
+
+.comparison-form {
+  max-width: 100%;
+}
+
+.comparison-form ul {
+  list-style: none;
+}
+
+.comparison-form summary {
+  margin-bottom: 10px;
+}
+
+.comparison-form .comparison-form--subsection-list li label {
+  display: flex;
+  align-items: baseline;
+  gap: 1em;
+}
+
+.comparison-form .diff {
+  margin: 10px 0;
+}

--- a/bloom_nofos/bloom_nofos/templates/includes/feedback_link.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/feedback_link.html
@@ -1,0 +1,8 @@
+<a
+    class="usa-link usa-link--external"
+    rel="noreferrer"
+    target="_blank"
+    href="https://docs.google.com/forms/d/e/1FAIpQLSdck-FeYXnp-LwsvD4lsdr7dfPOKbBb2ZW2hcoPZpWDYVtsRQ/viewform?usp=header"
+    >
+  Give us feedback
+</a>

--- a/bloom_nofos/nofos/models.py
+++ b/bloom_nofos/nofos/models.py
@@ -536,3 +536,19 @@ class Subsection(models.Model):
     def get_absolute_url(self):
         nofo_id = self.section.nofo.id
         return reverse("nofos:subsection_edit", args=(nofo_id, self.id))
+
+    def get_previous_subsection(self):
+        """Returns the previous subsection in the same section."""
+        return (
+            self.section.subsections.filter(order__lt=self.order)
+            .order_by("-order")
+            .first()
+        )
+
+    def get_next_subsection(self):
+        """Returns the next subsection in the same section."""
+        return (
+            self.section.subsections.filter(order__gt=self.order)
+            .order_by("order")
+            .first()
+        )

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -803,7 +803,14 @@ def compare_nofos(new_nofo, old_nofo):
     - If a matched subsection has different content, marks it as updated.
 
     Returns:
-        list: A structured diff object containing sections and subsection changes.
+        list[dict]: A structured list of subsection diff objects, in this format:
+
+        {
+            "name": str,   # The name of the subsection
+            "status": str,  # One of "MATCH", "UPDATE", "ADD", or "DELETE"
+            "value": str,  # The body content of the new subsection (if applicable)
+            "diff": str (optional)  # An HTML-based diff string showing changes (only included if the content changed)
+        }
     """
     nofo_comparison = []
 
@@ -851,7 +858,7 @@ def compare_nofos(new_nofo, old_nofo):
                             {
                                 "name": new_subsection.name,
                                 "status": "UPDATE",
-                                "body": new_subsection.body,
+                                "value": new_subsection.body,
                                 "diff": _html_diff(
                                     matched_old_subsection.body, new_subsection.body
                                 ),
@@ -861,7 +868,7 @@ def compare_nofos(new_nofo, old_nofo):
                         section_comparison["subsections"].append(
                             {
                                 "name": new_subsection.name,
-                                "body": new_subsection.body,
+                                "value": new_subsection.body,
                                 "status": "MATCH",
                             }
                         )
@@ -870,7 +877,7 @@ def compare_nofos(new_nofo, old_nofo):
                     section_comparison["subsections"].append(
                         {
                             "name": new_subsection.name,
-                            "body": new_subsection.body,
+                            "value": new_subsection.body,
                             "diff": _html_diff("", new_subsection.body),
                             "status": "ADD",
                         }
@@ -889,7 +896,7 @@ def compare_nofos(new_nofo, old_nofo):
                     section_comparison["subsections"].append(
                         {
                             "name": old_subsection.name,
-                            "body": old_subsection.body,
+                            "value": old_subsection.body,
                             "diff": _html_diff(old_subsection.body, ""),
                             "status": "DELETE",
                         }
@@ -911,7 +918,14 @@ def compare_nofos_metadata(new_nofo, nofo):
     - Returns a structured diff showing changes.
 
     Returns:
-        list: A list of metadata changes, including diffs for modified fields.
+        list[dict]: A structured list of subsection diff objects, in this format:
+
+        {
+            "name": str,   # The name of the attribute
+            "status": str,  # One of "MATCH", "UPDATE", "ADD", or "DELETE"
+            "value": str,  # The value of the new attribute (if applicable)
+            "diff": str (optional)  # An HTML-based diff string showing changes (only included if the content changed)
+        }
     """
     nofo_metadata_comparison = []
 
@@ -951,7 +965,7 @@ def compare_nofos_metadata(new_nofo, nofo):
                 {
                     "name": field_name,
                     "status": status,
-                    "body": new_value,
+                    "value": new_value,
                     "diff": diff,
                 }
             )

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -812,6 +812,10 @@ def compare_nofos(new_nofo, old_nofo):
             "diff": str (optional)  # An HTML-based diff string showing changes (only included if the content changed)
         }
     """
+
+    def get_subsection_name_or_order(subsection):
+        return subsection.name or "(#{})".format(subsection.order)
+
     nofo_comparison = []
 
     for new_section in new_nofo.sections.all():
@@ -856,7 +860,9 @@ def compare_nofos(new_nofo, old_nofo):
                     if new_subsection.body != matched_old_subsection.body:
                         section_comparison["subsections"].append(
                             {
-                                "name": new_subsection.name,
+                                "name": get_subsection_name_or_order(
+                                    matched_old_subsection
+                                ),
                                 "status": "UPDATE",
                                 "value": new_subsection.body,
                                 "diff": _html_diff(
@@ -867,7 +873,9 @@ def compare_nofos(new_nofo, old_nofo):
                     else:
                         section_comparison["subsections"].append(
                             {
-                                "name": new_subsection.name,
+                                "name": get_subsection_name_or_order(
+                                    matched_old_subsection
+                                ),
                                 "value": new_subsection.body,
                                 "status": "MATCH",
                             }
@@ -876,7 +884,7 @@ def compare_nofos(new_nofo, old_nofo):
                     # If no match was found, it's a new addition
                     section_comparison["subsections"].append(
                         {
-                            "name": new_subsection.name,
+                            "name": get_subsection_name_or_order(new_subsection),
                             "value": new_subsection.body,
                             "diff": _html_diff("", new_subsection.body),
                             "status": "ADD",
@@ -895,7 +903,7 @@ def compare_nofos(new_nofo, old_nofo):
                 if not has_moved:
                     section_comparison["subsections"].append(
                         {
-                            "name": old_subsection.name,
+                            "name": get_subsection_name_or_order(old_subsection),
                             "value": old_subsection.body,
                             "diff": _html_diff(old_subsection.body, ""),
                             "status": "DELETE",

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -956,6 +956,8 @@ def compare_nofos_metadata(new_nofo, nofo):
             # the comparison NOFO has this appended automatically, this is not a true change
             new_value = new_value.replace("(COMPARE) ", "")
 
+        field_name = Nofo._meta.get_field(key).verbose_name
+
         if old_value != new_value:
             if not old_value:  # Value was missing before, now added
                 status = "ADD"
@@ -967,14 +969,20 @@ def compare_nofos_metadata(new_nofo, nofo):
                 status = "UPDATE"
                 diff = _html_diff(old_value, new_value)
 
-            field_name = Nofo._meta.get_field(key).verbose_name
-
             nofo_metadata_comparison.append(
                 {
                     "name": field_name,
                     "status": status,
                     "value": new_value,
                     "diff": diff,
+                }
+            )
+        else:
+            nofo_metadata_comparison.append(
+                {
+                    "name": field_name,
+                    "status": "MATCH",
+                    "value": new_value,
                 }
             )
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -8,6 +8,15 @@
 {% block body_class %}nofo_compare{% endblock %}
 
   {% block content %}
+  <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon usa-alert--alpha margin-bottom-3">
+    <div class="usa-alert__body bg-base-lightest">
+      <p class="usa-alert__text">
+        <span class="usa-tag bg-ink">Alpha</span>
+        <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it.</span>
+      </p>
+    </div>
+  </div>
+
   {% with nofo|nofo_name as nofo_name_str %}
     {% with "Compare a NOFO to “"|add:nofo_name_str|add:"”" as back_text %}
       {% url 'nofos:nofo_edit' nofo.id as back_href %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -32,15 +32,17 @@
     <p>After comparing this NOFO, you can <a href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">continue with re-importing</a> or <a href="{% url 'nofos:nofo_edit' nofo.id %}">return to the edit page</a>.</p>
 
     {% if nofo_comparison_metadata %}
-    <table class="usa-table usa-table--borderless">
+    <table class="usa-table usa-table--borderless w-100">
       <caption>
-        <h2>Basic information</h2>
+        <div>
+          <h2>Basic information</h2>
+        </div>
       </caption>
-      <thead>
+      <thead class="usa-sr-only">
         <tr>
-          <th scope="col">Attribute</th>
-          <th scope="col">Status</th>
-          <th scope="col">Content</th>
+          <th scope="col" class="w-15">Attribute</th>
+          <th scope="col" class="w-10">Status</th>
+          <th scope="col" class="w-75">Content</th>
         </tr>
       </thead>
       <tbody>
@@ -65,13 +67,15 @@
       {% for section in nofo_comparison %}
         <table class="usa-table usa-table--borderless">
           <caption>
-            <h2>{{ section.name }}</h2>
+            <div>
+              <h2>{{ section.name }}</h2>
+            </div>
           </caption>
-          <thead>
+          <thead class="usa-sr-only">
             <tr>
-              <th scope="col">Subsection</th>
-              <th scope="col">Status</th>
-              <th scope="col">Content</th>
+              <th scope="col" class="w-15">Subsection</th>
+              <th scope="col" class="w-10">Status</th>
+              <th scope="col" class="w-75">Content</th>
             </tr>
           </thead>
           <tbody>

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -83,7 +83,12 @@
             {% if subsection.status != 'MATCH' %}
               <tr>
                 <th scope="row">
-                  {{ subsection.name }}
+                  {# if the subsection.name value starts with "(#" #}
+                  {% if subsection.name|slice:":2" == "(#" %}
+                      <span class="text-base">{{ subsection.name }}</span>
+                  {% else %}
+                      {{ subsection.name }}
+                  {% endif %}
                 </th>
                 <td>
                   {{ subsection.status }}

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -8,10 +8,10 @@
 {% block body_class %}nofo_compare{% endblock %}
 
   {% block content %}
-  <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon usa-alert--alpha margin-bottom-3">
+  <div class="usa-alert usa-alert--warning usa-alert--slim usa-alert--no-icon usa-alert--alpha margin-bottom-3">
     <div class="usa-alert__body bg-base-lightest">
       <p class="usa-alert__text">
-        <span class="usa-tag bg-ink">Alpha</span>
+        <span class="usa-tag bg-gold text-ink">Beta</span>
         <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it.</span>
       </p>
     </div>
@@ -58,6 +58,18 @@
           </tbody>
         </table>
       {% endfor %}
-  {% endif %}
+    {% endif %}
+
+  <h3 class="margin-top-4" id="follow-up-actions">Follow-up actions</h3>
+  <ul class="usa-button-group margin-top-3">
+    <li class="usa-button-group__item">
+      <a class="usa-button" href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">
+        Re-import NOFO
+      </a>
+    </li>
+    <li class="usa-button-group__item">
+      <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button usa-button--outline">Never mind, I don’t want to re-import</a>
+    </li>
+  </ul>
   
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+{% load nofo_name %}
+
+{% block title %}
+  NOFO comparison result
+{% endblock %}
+
+{% block body_class %}nofo_compare{% endblock %}
+
+  {% block content %}
+  {% with nofo|nofo_name as nofo_name_str %}
+    {% with "Compare a NOFO to “"|add:nofo_name_str|add:"”" as back_text %}
+      {% url 'nofos:nofo_edit' nofo.id as back_href %}
+      {% include "includes/page_heading.html" with title="NOFO comparison result" back_text=back_text back_href=back_href only %}
+    {% endwith %}
+  {% endwith %}
+
+  {% if nofo_comparison %}
+      <p>
+        There are <strong>{{ num_changed_subsections }}</strong> subsection{{ num_changed_subsections|pluralize }} with changes in {{ num_changed_sections }} section{{ num_changed_sections|pluralize }}.
+      </p>
+
+      {% for section in nofo_comparison %}
+        <table class="usa-table usa-table--borderless">
+          <caption>
+            <h2>{{ section.name }}</h2>
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Subsection</th>
+              <th scope="col">Status</th>
+              <th scope="col">Content</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for subsection in section.subsections %}
+            {% if subsection.status != 'MATCH' %}
+              <tr>
+                <th scope="row">
+                  {{ subsection.name }}
+                </th>
+                <td>
+                  {{ subsection.status }}
+                </td>
+                <td><div class="diff">{{ subsection.diff|safe }}</div></td>
+              </tr>
+            {% endif %}
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endfor %}
+  {% endif %}
+  
+{% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -24,11 +24,44 @@
     {% endwith %}
   {% endwith %}
 
-  {% if nofo_comparison %}
-      <p>
-        There are <strong>{{ num_changed_subsections }}</strong> subsection{{ num_changed_subsections|pluralize }} with changes in {{ num_changed_sections }} section{{ num_changed_sections|pluralize }}.
-      </p>
 
+    <p>
+      There are <strong>{{ num_changed_subsections }}</strong> subsection{{ num_changed_subsections|pluralize }} with changes in {{ num_changed_sections }} section{{ num_changed_sections|pluralize }}.
+    </p>
+
+    <p>After comparing this NOFO, you can <a href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">continue with re-importing</a> or <a href="{% url 'nofos:nofo_edit' nofo.id %}">return to the edit page</a>.</p>
+
+    {% if nofo_comparison_metadata %}
+    <table class="usa-table usa-table--borderless">
+      <caption>
+        <h2>Basic information</h2>
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">Attribute</th>
+          <th scope="col">Status</th>
+          <th scope="col">Content</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for attribute in nofo_comparison_metadata %}
+        {% if attribute.status != 'MATCH' %}
+          <tr>
+            <th scope="row">
+              {{ attribute.name }}
+            </th>
+            <td>
+              {{ attribute.status }}
+            </td>
+            <td><div class="diff">{{ attribute.diff|safe }}</div></td>
+          </tr>
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+
+    {% if nofo_comparison %}
       {% for section in nofo_comparison %}
         <table class="usa-table usa-table--borderless">
           <caption>

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -12,7 +12,7 @@
     <div class="usa-alert__body bg-base-lightest">
       <p class="usa-alert__text">
         <span class="usa-tag bg-gold text-ink">Beta</span>
-        <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it.</span>
+        <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it. {% include "includes/feedback_link.html" %}.</span>
       </p>
     </div>
   </div>
@@ -113,5 +113,6 @@
       <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button usa-button--outline">Never mind, I don’t want to re-import</a>
     </li>
   </ul>
+  <p class="font-body-sm">Have thoughts on this page? {% include "includes/feedback_link.html" %}.</p>
   
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
@@ -8,10 +8,10 @@
 {% block body_class %}nofo_import nofo_import--compare{% endblock %}
 
 {% block content %}
-  <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon usa-alert--alpha margin-bottom-3">
+  <div class="usa-alert usa-alert--warning usa-alert--slim usa-alert--no-icon usa-alert--alpha margin-bottom-3">
     <div class="usa-alert__body bg-base-lightest">
       <p class="usa-alert__text">
-        <span class="usa-tag bg-ink">Alpha</span>
+        <span class="usa-tag bg-gold text-ink">Beta</span>
         <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it.</span>
       </p>
     </div>

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
@@ -59,8 +59,8 @@
                       class="subsection-checkbox"
                     />
                     <details>
-                      <summary>{{ subsection.name }}</summary>
-                      <div class="diff">{{ subsection.diff_body|safe }}</div>
+                      <summary>{{ subsection.name }} ({{ subsection.status }})</summary>
+                      <div class="diff">{{ subsection.diff|safe }}</div>
                     </details>
                   </label>
                 </li>

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
@@ -12,7 +12,7 @@
     <div class="usa-alert__body bg-base-lightest">
       <p class="usa-alert__text">
         <span class="usa-tag bg-gold text-ink">Beta</span>
-        <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it.</span>
+        <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it. {% include "includes/feedback_link.html" %}.</span>
       </p>
     </div>
   </div>

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
@@ -8,6 +8,15 @@
 {% block body_class %}nofo_import nofo_import--compare{% endblock %}
 
 {% block content %}
+  <div class="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon usa-alert--alpha margin-bottom-3">
+    <div class="usa-alert__body bg-base-lightest">
+      <p class="usa-alert__text">
+        <span class="usa-tag bg-ink">Alpha</span>
+        <span class="margin-left-1">Comparing NOFOs is an experimental feature and will change as we improve it.</span>
+      </p>
+    </div>
+  </div>
+
   {% with nofo|nofo_name as nofo_name_str %}
     {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
       {% url 'nofos:nofo_edit' nofo.id as back_href %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
@@ -15,8 +15,9 @@
     {% endwith %}
   {% endwith %}
 
-  <p>Select a NOFO file to compare to: {{ nofo|nofo_name }}</p>
-  <p>You will be able to see a diff of what has changed across sections.</p>
+  <p>Select a NOFO file to compare to <strong>{{ nofo.number }}</strong>.</p>
+
+  <p>Get a breakdown of what content has changed between the current version and your newly-uploaded document.</p>
 
   <form id="nofo-import--form" class="form-import--loading" method="post" enctype="multipart/form-data">
     {% csrf_token %}
@@ -35,66 +36,4 @@
 
     <button class="usa-button margin-top-3 submit-button" type="submit">Compare NOFOs</button>
   </form>
-
-  {% if nofo_comparison %}
-    <form id="comparison-form" class="usa-form margin-top-4 comparison-form">
-      <h2>Accept or Reject Changes</h2>
-
-      <p>
-        There are <strong>{{ num_changed_subsections }}</strong> subsection{{ num_changed_subsections|pluralize }} with changes in {{ num_changed_sections }} section{{ num_changed_sections|pluralize }}.
-      </p>
-
-      <ul>
-        {% for section in nofo_comparison %}
-          <li>
-            <h3>Section: {{ section.name }}</h3>
-            <ul class="comparison-form--subsection-list">
-              {% for subsection in section.subsections %}
-                <li>
-                  <label>
-                    <input
-                      type="checkbox"
-                      name="subsections"
-                      value="{{ subsection.name }}"
-                      class="subsection-checkbox"
-                    />
-                    <details>
-                      <summary>{{ subsection.name }} ({{ subsection.status }})</summary>
-                      <div class="diff">{{ subsection.diff|safe }}</div>
-                    </details>
-                  </label>
-                </li>
-              {% endfor %}
-            </ul>
-          </li>
-        {% endfor %}
-      </ul>
-
-      <div class="button-group margin-bottom-2">
-        <button type="button" class="usa-button usa-button--outline" id="select-all">Select All</button>
-        <button type="button" class="usa-button usa-button--outline" id="deselect-all">Deselect All</button>
-      </div>
-
-      <button type="submit" class="usa-button margin-top-3">Submit Changes</button>
-    </form>
-
-    <script>
-      document.addEventListener("DOMContentLoaded", function () {
-        const selectAllButton = document.getElementById("select-all");
-        const deselectAllButton = document.getElementById("deselect-all");
-        const checkboxes = document.querySelectorAll(".subsection-checkbox");
-
-        selectAllButton.addEventListener("click", function (event) {
-          event.preventDefault();
-          checkboxes.forEach((checkbox) => (checkbox.checked = true));
-        });
-
-        deselectAllButton.addEventListener("click", function (event) {
-          event.preventDefault();
-          checkboxes.forEach((checkbox) => (checkbox.checked = false));
-        });
-      });
-    </script>
-  {% endif %}
-  
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_compare.html
@@ -1,0 +1,100 @@
+{% extends 'base.html' %}
+{% load nofo_name %}
+
+{% block title %}
+  Compare a NOFO to “{% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}”
+{% endblock %}
+
+{% block body_class %}nofo_import nofo_import--compare{% endblock %}
+
+{% block content %}
+  {% with nofo|nofo_name as nofo_name_str %}
+    {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
+      {% url 'nofos:nofo_edit' nofo.id as back_href %}
+      {% include "includes/page_heading.html" with title="Compare a NOFO to “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
+    {% endwith %}
+  {% endwith %}
+
+  <p>Select a NOFO file to compare to: {{ nofo|nofo_name }}</p>
+  <p>You will be able to see a diff of what has changed across sections.</p>
+
+  <form id="nofo-import--form" class="form-import--loading" method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+
+    {% with id="nofo-import" label="Select NOFO file" hint="Accepts .docx or .html files." value=title %}
+      {% for message in messages %}
+        {% if "error" in message.tags %}
+          {% include "includes/file_input.html" with id=id label=label hint=hint error=message only %}
+        {% endif %}
+      {% empty %}
+        {% include "includes/file_input.html" with id=id label=label hint=hint only %}
+      {% endfor %}
+    {% endwith %}
+
+    {% include "includes/loading_horse.html" %}
+
+    <button class="usa-button margin-top-3 submit-button" type="submit">Compare NOFOs</button>
+  </form>
+
+  {% if nofo_comparison %}
+    <form id="comparison-form" class="usa-form margin-top-4 comparison-form">
+      <h2>Accept or Reject Changes</h2>
+
+      <p>
+        There are <strong>{{ num_changed_subsections }}</strong> subsection{{ num_changed_subsections|pluralize }} with changes in {{ num_changed_sections }} section{{ num_changed_sections|pluralize }}.
+      </p>
+
+      <ul>
+        {% for section in nofo_comparison %}
+          <li>
+            <h3>Section: {{ section.name }}</h3>
+            <ul class="comparison-form--subsection-list">
+              {% for subsection in section.subsections %}
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="subsections"
+                      value="{{ subsection.name }}"
+                      class="subsection-checkbox"
+                    />
+                    <details>
+                      <summary>{{ subsection.name }}</summary>
+                      <div class="diff">{{ subsection.diff_body|safe }}</div>
+                    </details>
+                  </label>
+                </li>
+              {% endfor %}
+            </ul>
+          </li>
+        {% endfor %}
+      </ul>
+
+      <div class="button-group margin-bottom-2">
+        <button type="button" class="usa-button usa-button--outline" id="select-all">Select All</button>
+        <button type="button" class="usa-button usa-button--outline" id="deselect-all">Deselect All</button>
+      </div>
+
+      <button type="submit" class="usa-button margin-top-3">Submit Changes</button>
+    </form>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        const selectAllButton = document.getElementById("select-all");
+        const deselectAllButton = document.getElementById("deselect-all");
+        const checkboxes = document.querySelectorAll(".subsection-checkbox");
+
+        selectAllButton.addEventListener("click", function (event) {
+          event.preventDefault();
+          checkboxes.forEach((checkbox) => (checkbox.checked = true));
+        });
+
+        deselectAllButton.addEventListener("click", function (event) {
+          event.preventDefault();
+          checkboxes.forEach((checkbox) => (checkbox.checked = false));
+        });
+      });
+    </script>
+  {% endif %}
+  
+{% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_import_overwrite.html
@@ -19,6 +19,14 @@
       </p>
     </div>
   </div>
+  <div class="usa-alert usa-alert--warning usa-alert--slim usa-alert--no-icon usa-alert--alpha margin-bottom-3">
+    <div class="usa-alert__body bg-base-lightest">
+      <p class="usa-alert__text">
+        <span class="usa-tag bg-gold text-ink">Beta</span>
+        <span class="margin-left-1"><a href="{% url 'nofos:nofo_import_compare' nofo.id %}">Compare your new document to see what’s new</a>.</span>
+      </p>
+    </div>
+  </div>
 
   {% with nofo|nofo_name as nofo_name_str %}
     {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
@@ -26,7 +34,6 @@
       {% include "includes/page_heading.html" with title="Re-import “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
     {% endwith %}
   {% endwith %}
-
   <form id="nofo-import--form" class="form-import--loading" method="post" enctype="multipart/form-data">
     {% csrf_token %}
 

--- a/bloom_nofos/nofos/tests/test_compare.py
+++ b/bloom_nofos/nofos/tests/test_compare.py
@@ -1,0 +1,113 @@
+from django.test import TestCase
+from ..models import Nofo, Section, Subsection
+from ..views import compare_nofos
+
+
+class TestCompareNofos(TestCase):
+    def setUp(self):
+        """
+        Sets up two NOFO objects (old and new) with sections and subsections.
+        """
+        self.old_nofo = Nofo.objects.create(title="Old NOFO", opdiv="Test OpDiv")
+        self.new_nofo = Nofo.objects.create(title="New NOFO", opdiv="Test OpDiv")
+
+        self.old_section = Section.objects.create(
+            name="Step 1",
+            nofo=self.old_nofo,
+            order=1,
+            html_id="step-1",
+        )
+        self.new_section = Section.objects.create(
+            name="Step 1",
+            nofo=self.new_nofo,
+            order=1,
+            html_id="step-1",
+        )
+
+        # Modify the first (default) subsection instead of creating a new one
+        # These two subsections will match
+        self.old_sub_1 = self.old_section.subsections.first()
+        self.old_sub_1.name = "Budget Requirements"
+        self.old_sub_1.body = "Budget must not exceed $100K."
+        self.old_sub_1.tag = "h3"
+        self.old_sub_1.save()
+
+        self.new_sub_1 = self.new_section.subsections.first()
+        self.new_sub_1.name = "Budget Requirements"
+        self.new_sub_1.body = "Budget must not exceed $100K."
+        self.new_sub_1.tag = "h3"
+        self.new_sub_1.save()
+
+        # Changed subsection (same name, different content)
+        self.old_sub_2 = Subsection.objects.create(
+            name="Application Process",
+            body="Submit before Jan 1.",
+            section=self.old_section,
+            order=3,
+            tag="h3",
+        )
+        self.new_sub_2 = Subsection.objects.create(
+            name="Application Process",
+            body="Submit before Feb 1.",
+            section=self.new_section,
+            order=3,
+            tag="h3",
+        )
+
+        # Added subsection (exists only in new NOFO)
+        self.new_sub_3 = Subsection.objects.create(
+            name="New NOFO Funding Guidelines",
+            body="Follow these new rules.",
+            section=self.new_section,
+            order=4,
+            tag="h3",
+        )
+
+        # Deleted subsection (exists only in old NOFO)
+        self.old_sub_4 = Subsection.objects.create(
+            name="Old NOFO Fee Requirements",
+            body="Processing fee is $50.",
+            section=self.old_section,
+            order=4,
+            tag="h3",
+        )
+
+    def test_compare_nofos(self):
+        """
+        Tests the compare_nofos function, ensuring it correctly identifies matches, updates, additions, and deletions.
+        """
+        result = compare_nofos(self.new_nofo, self.old_nofo)
+
+        # Ensure the result is structured correctly
+        self.assertEqual(len(result), 1)  # Only one section should be in the diff
+        self.assertEqual(result[0]["name"], "Step 1")
+
+        subsections = result[0]["subsections"]
+        self.assertEqual(len(subsections), 4)
+
+        # Match test
+        subsection_match = subsections[0]
+        self.assertEqual(subsection_match["status"], "MATCH")
+        self.assertEqual(subsection_match["name"], "Budget Requirements")
+        self.assertEqual(subsection_match["body"], "Budget must not exceed $100K.")
+
+        # Update test
+        subsection_update = subsections[1]
+        self.assertEqual(subsection_update["status"], "UPDATE")
+        self.assertEqual(subsection_update["name"], "Application Process")
+        self.assertEqual(subsection_update["body"], "Submit before Feb 1.")
+        self.assertIn(
+            "Submit before <del>Jan</del><ins>Feb</ins> 1.", subsection_update["diff"]
+        )
+
+        # Addition test
+        subsection_add = subsections[2]
+        self.assertEqual(subsection_add["status"], "ADD")
+        self.assertEqual(subsection_add["name"], "New NOFO Funding Guidelines")
+        self.assertEqual(subsection_add["body"], "Follow these new rules.")
+
+        # Deletion test
+        subsection_delete = subsections[3]
+        self.assertEqual(subsection_delete["name"], "Old NOFO Fee Requirements")
+        self.assertEqual(subsection_delete["body"], "Processing fee is $50.")
+        self.assertIn("<del>Processing fee is $50.</del>", subsection_delete["diff"])

--- a/bloom_nofos/nofos/tests/test_models.py
+++ b/bloom_nofos/nofos/tests/test_models.py
@@ -107,13 +107,6 @@ class SectionModelTest(TestCase):
 
     def test_valid_section_with_subsection(self):
         section = Section.objects.create(**self.valid_section_data)
-        subsection = Subsection.objects.create(
-            name="Test Subsection",
-            order=2,
-            section=section,
-            tag="h2",
-            html_id="1--test-section--test-subsection",
-        )
         section.full_clean()
 
     def test_automatic_order_assignment(self):
@@ -171,6 +164,8 @@ class SubsectionModelTest(TestCase):
         self.section = Section.objects.create(
             name="Test Section", order=1, nofo=self.nofo, html_id="1--test-section"
         )
+
+        # when sections are created, an empty subsection is created at "order=1"
         self.valid_subsection_data = {
             "name": "Test Subsection",
             "order": 2,
@@ -204,6 +199,34 @@ class SubsectionModelTest(TestCase):
     def test_valid_subsection_data(self):
         subsection = Subsection(**self.valid_subsection_data)
         subsection.full_clean()  # Should not raise ValidationError
+
+    def test_subsection_get_next(self):
+        subsection_data_2 = self.valid_subsection_data.copy()
+        subsection_data_2["name"] = "Test Subsection"
+        subsection_data_2["order"] = 3
+
+        subsection = Subsection.objects.create(**self.valid_subsection_data)
+        subsection_2 = Subsection.objects.create(**subsection_data_2)
+
+        self.assertEqual(subsection.get_next_subsection(), subsection_2)
+
+    def test_subsection_get_next_when_no_next(self):
+        subsection = Subsection.objects.create(**self.valid_subsection_data)
+
+        self.assertEqual(subsection.get_next_subsection(), None)
+
+    def test_subsection_get_previous(self):
+        # when a section is created, an empty subsection is created at "order=1"
+        first_subsection = self.section.subsections.first()
+        subsection = Subsection.objects.create(**self.valid_subsection_data)
+
+        self.assertEqual(subsection.get_previous_subsection(), first_subsection)
+
+    def test_subsection_get_previous_when_no_previous(self):
+        # when a section is created, an empty subsection is created at "order=1"
+        first_subsection = self.section.subsections.first()
+
+        self.assertEqual(first_subsection.get_previous_subsection(), None)
 
 
 class NofoArchiveTest(TestCase):

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
         name="nofo_import_overwrite",
     ),
     path(
+        "<int:pk>/compare",
+        views.NofosImportCompareView.as_view(),
+        name="nofo_import_compare",
+    ),
+    path(
         "<int:pk>/confirm-import/",
         views.NofosConfirmReimportView.as_view(),
         name="nofo_import_confirm_overwrite",

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -472,16 +472,12 @@ class NofosImportCompareView(NofosImportOverwriteView):
 
         for tag, i1, i2, j1, j2 in matcher.get_opcodes():
             if tag == "replace":
-                result.append(f'<del style="color: red;">{original[i1:i2]}</del>')
-                result.append(
-                    f'<ins style="background-color: yellow;">{new[j1:j2]}</ins>'
-                )
+                result.append(f"<del>{original[i1:i2]}</del>")
+                result.append(f"<ins>{new[j1:j2]}</ins>")
             elif tag == "delete":
-                result.append(f'<del style="color: red;">{original[i1:i2]}</del>')
+                result.append(f"<del>{original[i1:i2]}</del>")
             elif tag == "insert":
-                result.append(
-                    f'<ins style="background-color: yellow;">{new[j1:j2]}</ins>'
-                )
+                result.append(f"<ins>{new[j1:j2]}</ins>")
             elif tag == "equal":
                 result.append(original[i1:i2])
 
@@ -623,7 +619,7 @@ class NofosImportCompareView(NofosImportOverwriteView):
             new_nofo.group = request.user.group
             new_nofo.filename = filename
             suggest_all_nofo_fields(new_nofo, soup)
-            # new_nofo.save()
+            new_nofo.save()
 
             # Build the comparison object
             nofo_comparison = self.compare_nofo_sections(new_nofo, nofo)
@@ -631,13 +627,16 @@ class NofosImportCompareView(NofosImportOverwriteView):
             # Calculate the total number of changed sections
             num_changed_sections = len(nofo_comparison)
             # Calculate the total number of changed subsections
-            num_changed_subsections = sum(
-                len(section["subsections"]) for section in nofo_comparison
-            )
+
+            num_changed_subsections = 0
+            for section in nofo_comparison:
+                for subsection in section["subsections"]:
+                    if subsection["status"] != "MATCH":
+                        num_changed_subsections += 1
 
             return render(
                 request,
-                "nofos/nofo_import_compare.html",
+                "nofos/nofo_compare.html",
                 {
                     "nofo": nofo,
                     "new_nofo": new_nofo,

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -619,6 +619,11 @@ class NofosImportCompareView(NofosImportOverwriteView):
             new_nofo.group = request.user.group
             new_nofo.filename = filename
             suggest_all_nofo_fields(new_nofo, soup)
+
+            # give nofo a title that indicates it is a comparison NOFO
+            new_nofo.title = "(COMPARE) {}".format(new_nofo.title)
+            # archive this new NOFO immediately
+            new_nofo.archived = timezone.now().date()
             new_nofo.save()
 
             # Build the comparison object

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1,9 +1,6 @@
 import io
 import json
 
-from difflib import SequenceMatcher
-
-
 import docraptor
 from bs4 import BeautifulSoup
 from constance import config
@@ -62,6 +59,7 @@ from .nofo import (
     add_final_subsection_to_step_3,
     add_headings_to_nofo,
     add_page_breaks_to_headings,
+    compare_nofos,
     create_nofo,
     find_broken_links,
     find_external_link,
@@ -466,132 +464,6 @@ class NofosImportCompareView(NofosImportOverwriteView):
     template_name = "nofos/nofo_import_compare.html"
     redirect_url_name = "nofos:nofo_import_compare"
 
-    def html_diff(self, original, new):
-        matcher = SequenceMatcher(None, original, new)
-        result = []
-
-        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
-            if tag == "replace":
-                result.append(f"<del>{original[i1:i2]}</del>")
-                result.append(f"<ins>{new[j1:j2]}</ins>")
-            elif tag == "delete":
-                result.append(f"<del>{original[i1:i2]}</del>")
-            elif tag == "insert":
-                result.append(f"<ins>{new[j1:j2]}</ins>")
-            elif tag == "equal":
-                result.append(original[i1:i2])
-
-        return "".join(result)
-
-    def compare_nofo_sections(self, new_nofo, old_nofo):
-        """
-        Compares sections and subsections between an existing NOFO and a newly uploaded one.
-
-        - Identifies matched, added, and deleted subsections.
-        - Preserves order based on the new NOFO’s structure.
-        - If a matched subsection has different content, marks it as updated.
-
-        Returns:
-            list: A structured diff object containing sections and subsection changes.
-        """
-
-        nofo_comparison = []
-
-        for new_section in new_nofo.sections.all():
-            old_section = old_nofo.sections.filter(name=new_section.name).first()
-
-            section_comparison = {"name": new_section.name, "subsections": []}
-
-            # Get all subsections for comparison
-            new_subsections = list(new_section.subsections.all()) if new_section else []
-            old_subsections = list(old_section.subsections.all()) if old_section else []
-            max_length = max(len(new_subsections), len(old_subsections))
-
-            matched_subsections = set()  # Track matched subsection IDs
-
-            # Step 1: Iterate through both new and old subsections using the max index length
-            for index in range(max_length):
-                new_subsection = (
-                    new_subsections[index] if index < len(new_subsections) else None
-                )
-                old_subsection = (
-                    old_subsections[index] if index < len(old_subsections) else None
-                )
-
-                # First, check the new subsection (if it exists)
-                if new_subsection:
-                    matched_old_subsection = None
-
-                    # Look for a match in old subsections
-                    for os in old_subsections:
-                        if os.id in matched_subsections:
-                            continue  # Skip already matched
-
-                        if new_subsection.is_matching_subsection(os):
-                            matched_old_subsection = os
-                            # Mark as matched
-                            matched_subsections.add(new_subsection.id)
-                            matched_subsections.add(os.id)
-                            break
-
-                    if matched_old_subsection:
-                        # Check if body changed
-                        if new_subsection.body != matched_old_subsection.body:
-                            section_comparison["subsections"].append(
-                                {
-                                    "name": new_subsection.name,
-                                    "status": "UPDATE",
-                                    "body": new_subsection.body,
-                                    "diff": self.html_diff(
-                                        matched_old_subsection.body, new_subsection.body
-                                    ),
-                                }
-                            )
-                        else:
-                            section_comparison["subsections"].append(
-                                {
-                                    "name": new_subsection.name,
-                                    "body": new_subsection.body,
-                                    "status": "MATCH",
-                                }
-                            )
-                    else:
-                        # If no match was found, it's a new addition
-                        section_comparison["subsections"].append(
-                            {
-                                "name": new_subsection.name,
-                                "body": new_subsection.body,
-                                "diff": self.html_diff("", new_subsection.body),
-                                "status": "ADD",
-                            }
-                        )
-                        matched_subsections.add(new_subsection.id)
-
-                # Now, check the old subsection (if it exists)
-                if old_subsection and old_subsection.id not in matched_subsections:
-                    # Look for it in new NOFO subsections (maybe it was moved)
-                    has_moved = any(
-                        new.is_matching_subsection(old_subsection)
-                        for new in new_subsections
-                    )
-
-                    if not has_moved:
-                        section_comparison["subsections"].append(
-                            {
-                                "name": old_subsection.name,
-                                "body": old_subsection.body,
-                                "diff": self.html_diff(old_subsection.body, ""),
-                                "status": "DELETE",
-                            }
-                        )
-                        matched_subsections.add(old_subsection.id)
-
-            # Only add section comparison if there are changes
-            if section_comparison["subsections"]:
-                nofo_comparison.append(section_comparison)
-
-        return nofo_comparison
-
     def handle_nofo_create(self, request, soup, sections, filename, *args, **kwargs):
         """
         Create a new NOFO and then pass both in for a comparison.
@@ -627,7 +499,7 @@ class NofosImportCompareView(NofosImportOverwriteView):
             new_nofo.save()
 
             # Build the comparison object
-            nofo_comparison = self.compare_nofo_sections(new_nofo, nofo)
+            nofo_comparison = compare_nofos(new_nofo, nofo)
 
             # Calculate the total number of changed sections
             num_changed_sections = len(nofo_comparison)

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -60,6 +60,7 @@ from .nofo import (
     add_headings_to_nofo,
     add_page_breaks_to_headings,
     compare_nofos,
+    compare_nofos_metadata,
     create_nofo,
     find_broken_links,
     find_external_link,
@@ -500,6 +501,7 @@ class NofosImportCompareView(NofosImportOverwriteView):
 
             # Build the comparison object
             nofo_comparison = compare_nofos(new_nofo, nofo)
+            nofo_comparison_metadata = compare_nofos_metadata(new_nofo, nofo)
 
             # Calculate the total number of changed sections
             num_changed_sections = len(nofo_comparison)
@@ -518,6 +520,7 @@ class NofosImportCompareView(NofosImportOverwriteView):
                     "nofo": nofo,
                     "new_nofo": new_nofo,
                     "nofo_comparison": nofo_comparison,
+                    "nofo_comparison_metadata": nofo_comparison_metadata,
                     "num_changed_sections": num_changed_sections,
                     "num_changed_subsections": num_changed_subsections,
                 },


### PR DESCRIPTION
## Summary

- This is related to https://github.com/HHS/simpler-grants-pdf-builder/issues/125,
- It's also the continuation of #144, which has been closed.

### What is it?

The idea here is a UI concept for comparing a NOFO to another NOFO document. (The more expansive concept is to add a step like this on re-import, but I think that "compare" is a big enough feature on its own and something that we can ship and get feedback on before we make this part of the re-import flow.) 

The objective is to provide a simple way for people to identify changes that have happened since their last import, so they can see what the damage would be if they re-imported and overwrote what they currently have.

Only the NOOF attributes and subsections that have changed are shown on the comparison page. This means attributes/subsections that are:
- modified (text is changed)
- added (did not exist previously)
- deleted (used to exist, now doesn't) 

You can get to the "compare" screen from the reimport screen. I added a link using the little [Tag](https://designsystem.digital.gov/components/tag/) banner and ["slim" alert](https://designsystem.digital.gov/components/alert/) so that hopefully people will notice it. The little "BETA" message follows you throughout the compare flow since this is new and different.

In terms of a feedback form, I added a link to a Google Form in the "Beta" banner, and also at the very bottom of the "compare" page. It's kind of crappy sending people off-site, but I suspect the form will probably be used by 1 or 2 people max, so it's easy enough. Added a new template partial so that the link to the form is in 1 place and not 3 places.

### How to test this
- Make a "save as" version of an existing NOFO word doc you have.
- Add some changes to the new doc (slash add or remove some subsections)
- Import the first Word doc to create a new NOFO
- Go to the "re-import" page for your new NOFO
- Click the link in the "Beta" banner
- Import your "save as" version of the NOFO
- Be amazed

### screens 


| 're-import' screen | 'import' screen | 'diff' screen |
|--------|-------|-------|
|  <img width="1485" alt="Screenshot 2025-02-17 at 2 17 28 PM" src="https://github.com/user-attachments/assets/5330dafd-cdc5-4144-bdbe-809b1d841cc5" />   |   <img width="1453" alt="Screenshot 2025-02-19 at 2 54 02 PM" src="https://github.com/user-attachments/assets/4d0906c1-20d1-4e99-a97f-6e975ce58af5" />  |   ![localhost_8000_nofos_485_compare](https://github.com/user-attachments/assets/29bb06e5-0343-4266-a522-ade0497cd243)    |



### gif

Here's a gif of me actually doing it.

![Screen Recording 2025-02-17 at 2 23 12 PM](https://github.com/user-attachments/assets/7312ccab-2a5b-47e5-a6e7-9066c8cbae0e)

## TODO

~~@jtmst, I am _pretty_ sure we can use this "is_matching_subsection" method in your preserve_page_breaks stuff, but you would be more familiar with that. The idea is that you should be able to grab a new subsection from a different nofo and compare to an existing one, using a function call like this: `old_subsection.is_matching_subsection(new_subsection)`. It is not 100% since it doesn't do a comparison of text, but it should be close enough, and if we can delete some LoC, all the better.~~

Nvm, I looked at the code for this and it is approaching this problem in a different way. 
