### PR TITLE
Migration to add public info subsection to existing NOFOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning since version 1.0.0.
 - Add inline images for CDC-RFA-CE-25-0114
 - Can use 'page-break' to add a page-break in markdown body
 - Add confirmation page for re-importing a NOFO if the IDs don't match up
+- Add "Important: public information" callout box to section 3 of new NOFOs
 
 ### Changed
 
@@ -41,6 +42,7 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Retry failed external link requests so that more of them will show up green
 - H7 warning notice at the top of a NOFO now handles h7s in markdown body as
   well
 - Preserve heading links for h7 headings (other heading levels worked before,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,7 @@ Versioning since version 1.0.0.
 
 ### Migrations
 
-- Add public information subsection to Step 3 if it doesn't already exist in
-  existing NOFOs
+- Add public information subsection to Step 3 if it doesn't already exist
 
 ## [2.3.0] - 2025-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning since version 1.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [2.4.0] - 2025-02-13
+
+### Added
+
 - Add classes to Table of Contents based on number of items
   - The idea is to shrink the table of contents a bit if lots of items show up
 - Add a new icon for "award" (only for 2 CDC NOFOs for now)
@@ -41,6 +49,11 @@ Versioning since version 1.0.0.
 - Page breaks were not possible to add to subsections without a heading
 - page-break-after was briefly not working
 - Small ToC links are all the same colour
+
+### Migrations
+
+- Add public information subsection to Step 3 if it doesn't already exist in
+  existing NOFOs
 
 ## [2.3.0] - 2025-01-17
 

--- a/bloom_nofos/nofos/migrations/0090_add_public_information_subsection.py
+++ b/bloom_nofos/nofos/migrations/0090_add_public_information_subsection.py
@@ -1,0 +1,81 @@
+# Generated manually
+
+from django.db import migrations
+
+PUBLIC_INFORMATION_SUBSECTION = {
+    "name": "Important: public information",
+    "tag": "h5",
+    "html_id": "",
+    "is_callout_box": True,
+    "body": """
+When filling out your SF-424 form, pay attention to Box 15: Descriptive Title of Applicant's Project.
+
+We share what you put there with [USAspending](https://www.usaspending.gov). This is where the public goes to learn how the federal government spends their money.
+
+Instead of just a title, insert a short description of your project and what it will do.
+
+[See instructions and examples](https://www.hhs.gov/sites/default/files/hhs-writing-award-descriptions.pdf).
+""",
+}
+
+
+def add_public_information_subsection(apps, schema_editor):
+    """
+    Add the public information subsection to Step 3 of existing NOFOs if it doesn't already exist.
+    """
+    Section = apps.get_model("nofos", "Section")
+    Subsection = apps.get_model("nofos", "Subsection")
+
+    # The target section names to search for
+    step_3_names = [
+        "Step 3: Prepare Your Application",
+        "Step 3: Write Your Application",
+    ]
+
+    # Find all Step 3 sections
+    step_3_sections = Section.objects.filter(
+        name__iregex=r"^Step 3: (Prepare|Write) Your Application$"
+    )
+
+    for section in step_3_sections:
+        # Check if public information subsection already exists
+        if not Subsection.objects.filter(
+            section=section, name=PUBLIC_INFORMATION_SUBSECTION["name"]
+        ).exists():
+            # Get the highest order number in this section
+            last_order = (
+                Subsection.objects.filter(section=section).order_by("-order").first()
+            )
+            new_order = (last_order.order + 1) if last_order else 1
+
+            # Create new subsection
+            Subsection.objects.create(
+                section=section,
+                name=PUBLIC_INFORMATION_SUBSECTION["name"],
+                tag=PUBLIC_INFORMATION_SUBSECTION["tag"],
+                html_id="",  # This will be set by add_headings_to_nofo later
+                callout_box=PUBLIC_INFORMATION_SUBSECTION["is_callout_box"],
+                body=PUBLIC_INFORMATION_SUBSECTION["body"],
+                order=new_order,
+            )
+
+
+def reverse_func(apps, schema_editor):
+    """
+    Reverse the migration by removing all public information subsections.
+    """
+    Subsection = apps.get_model("nofos", "Subsection")
+    Subsection.objects.filter(name=PUBLIC_INFORMATION_SUBSECTION["name"]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "nofos",
+            "0089_alter_nofo_theme",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(add_public_information_subsection, reverse_func),
+    ]

--- a/bloom_nofos/nofos/migrations/0090_add_public_information_subsection.py
+++ b/bloom_nofos/nofos/migrations/0090_add_public_information_subsection.py
@@ -26,15 +26,16 @@ def add_public_information_subsection(apps, schema_editor):
     Section = apps.get_model("nofos", "Section")
     Subsection = apps.get_model("nofos", "Subsection")
 
-    # The target section names to search for
-    step_3_names = [
-        "Step 3: Prepare Your Application",
-        "Step 3: Write Your Application",
-    ]
-
-    # Find all Step 3 sections
+    # Find all Step 3 sections in NOFOs that are NOT published and NOT archived
     step_3_sections = Section.objects.filter(
-        name__iregex=r"^Step 3: (Prepare|Write) Your Application$"
+        name__iregex=r"^Step 3: (Prepare|Write) Your Application$",
+        nofo__status__in=[
+            "draft",
+            "active",
+            "ready-for-qa",
+            "review",
+        ],  # Exclude "published"
+        nofo__archived__isnull=True,  # Exclude archived NOFOs
     )
 
     for section in step_3_sections:

--- a/bloom_nofos/nofos/migrations/0090_add_public_information_subsection.py
+++ b/bloom_nofos/nofos/migrations/0090_add_public_information_subsection.py
@@ -5,7 +5,7 @@ from django.db import migrations
 PUBLIC_INFORMATION_SUBSECTION = {
     "name": "Important: public information",
     "tag": "h5",
-    "html_id": "",
+    "html_id": "9999--important-public-information",
     "is_callout_box": True,
     "body": """
 When filling out your SF-424 form, pay attention to Box 15: Descriptive Title of Applicant's Project.
@@ -53,7 +53,7 @@ def add_public_information_subsection(apps, schema_editor):
                 section=section,
                 name=PUBLIC_INFORMATION_SUBSECTION["name"],
                 tag=PUBLIC_INFORMATION_SUBSECTION["tag"],
-                html_id="",  # This will be set by add_headings_to_nofo later
+                html_id=PUBLIC_INFORMATION_SUBSECTION["html_id"],
                 callout_box=PUBLIC_INFORMATION_SUBSECTION["is_callout_box"],
                 body=PUBLIC_INFORMATION_SUBSECTION["body"],
                 order=new_order,
@@ -65,7 +65,10 @@ def reverse_func(apps, schema_editor):
     Reverse the migration by removing all public information subsections.
     """
     Subsection = apps.get_model("nofos", "Subsection")
-    Subsection.objects.filter(name=PUBLIC_INFORMATION_SUBSECTION["name"]).delete()
+    Subsection.objects.filter(
+        name=PUBLIC_INFORMATION_SUBSECTION["name"],
+        html_id="9999--important-public-information",
+    ).delete()
 
 
 class Migration(migrations.Migration):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bloom-nofos"
-version = "2.3.0"
+version = "2.4.0"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
Mimics the logic in add_final_subsection_to_step_3 but for a migration to add the PUBLIC_INFORMATION_SUBSECTION to existing NOFOs.