### PR TITLE
Nullify clickable "top-nav" breadcrumb links on every page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Breadcrumb links are no longer clickable (instead, they are just visual indicators)
+- When you open a NOFO Builder PDF in Acrobat, the Bookmarks tab will be open by default
+
 ### Fixed
 
 - Fix for more list styles that were not importing correctly ("List Bullet1, Bullet 2", etc)

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -1207,6 +1207,7 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   }
 
   @prince-pdf {
+    /* Open Acrobat with bookmarks panel open by default */
     -prince-pdf-page-mode: show-bookmarks;
     prince-pdf-role-map: "H7" P;
   }
@@ -1228,6 +1229,12 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   }
   .bookmark-level-7 {
     -prince-bookmark-level: 7;
+  }
+
+  /* Render top-nav links inert */
+  .section--title-page--header-nav li a,
+  .header-nav--running-header li a {
+    -prince-link: none;
   }
 
   /* Page break rules */

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -1207,6 +1207,7 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   }
 
   @prince-pdf {
+    -prince-pdf-page-mode: show-bookmarks;
     prince-pdf-role-map: "H7" P;
   }
 


### PR DESCRIPTION
## Summary

This PR makes two changes to our final NOFO Builder PDF output:

- No longer have clickable top-nav breadcrumb links
- When opening in Acrobat, the Bookmarks tab will be open by default

The top-nav links being clickable was super annoying for screen readers, as they would be constantly reading all those links on every single page of the NOFOs, and there was no way to prevent this.

In the end, we decided that the best way forward is to leave the links in there so that they signpost where the user is in the NOFO (eg, it will indicate they are in section 3, for example), but to nullify them so they are no longer clickable.

To offset this, we also always want the Bookmarks tab to be open in Adobe, so that the structure of the NOFO is visible and navigable using in-app tools.