### PR TITLE
Clean up some of the Audit history UI (very small PR)

### DIFF
--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -147,6 +147,10 @@ details > summary > span:hover {
   text-decoration: none;
 }
 
+.usa-tag.bg-group--not-uppercase {
+  text-transform: none;
+}
+
 /* Link check page */
 
 .pre--code-box {
@@ -305,10 +309,6 @@ details > summary > span:hover {
 
 /* header widget for NOFO */
 
-.nofo_edit .usa-tag.bg-group--not-uppercase {
-  text-transform: none;
-}
-
 .nofo_edit a.usa-tag--link {
   text-decoration: none;
 }
@@ -384,6 +384,11 @@ details > summary > span:hover {
   display: flex;
   align-items: baseline;
   gap: 20px;
+}
+
+.nofo_edit--audit-widget {
+  display: flex;
+  justify-content: space-between;
 }
 
 .nofo_edit .usa-summary-box__text p:last-of-type {

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -39,6 +39,15 @@ Edit “{{ nofo|nofo_name }}”
 {% endif %}
 </div>
 
+<div class="nofo_edit--audit-widget font-sans-md">
+  <span>
+    Last updated: <strong>{{ nofo.updated|date:'F j' }} at {{ nofo.updated|date:'g:i A' }}</strong>
+  </span>
+  <span>
+    <a href="{% url 'nofos:nofo_history' nofo.id %}">See all updates to this NOFO</a>
+  </span>
+</div>
+
 {% if nofo.status == 'published' %}
 <div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
   <div class="usa-summary-box__body">
@@ -71,13 +80,6 @@ Edit “{{ nofo|nofo_name }}”
     </h2>
     <div class="usa-summary-box__text">
       <ul class="usa-list usa-list--unstyled">
-        <li>
-          <p>
-            <a class="usa-button usa-button--outline" href="{% url 'nofos:nofo_history' nofo.id %}">
-              View audit history
-            </a>— See when this NOFO was modified and by whom
-          </p>
-        </li>
         <li>
           <p>
             <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' nofo.id %}">

--- a/bloom_nofos/nofos/templates/nofos/nofo_history.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history.html
@@ -2,7 +2,7 @@
 {% load static nofo_name tz %}
 
 {% block title %}
-  Audit History for "{{ nofo|nofo_name }}"
+  All updates for "{{ nofo|nofo_name }}"
 {% endblock %}
 
 {% block body_class %}nofo_history nofo_status--{{ nofo.status }}{% endblock %}
@@ -11,38 +11,38 @@
   {% with nofo|nofo_name as nofo_name_str %}
     {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
       {% url 'nofos:nofo_edit' nofo.id as back_href %}
-      {% include "includes/page_heading.html" with title="Audit history for “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
+      {% include "includes/page_heading.html" with title="All updates for “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
     {% endwith %}
   {% endwith %}
 
 
-<div class="margin-bottom-5">
+<div class="margin-top-2 margin-bottom-5">
   <span class="usa-tag usa-tag--big bg-group bg-group--not-uppercase bg-group--{{ nofo.group }}">{{ nofo.get_group_display }}</span>
 </div>
 
 <table class="usa-table" id="audit-events-table">
   <caption>
     <div>
-      <h2 class="margin-bottom-0">Recent Changes</h2>
+      <h2 class="margin-bottom-0">Latest Changes</h2>
     </div>
   </caption>
   <thead>
     <tr>
-      <th scope="col">Event</th>
+      <th scope="col"><span class="usa-sr-only">Event </span>Type</th>
       <th scope="col">Object</th>
       <th scope="col">User</th>
-      <th scope="col">Timestamp</th>
+      <th scope="col" class="w-20">Timestamp</th>
     </tr>
   </thead>
   <tbody id="audit-events-body">
     {% for event in audit_events %}
     <tr>
       <td>{{ event.event_type }}</td>
-      <td>{{ event.object_type }} - {{ event.object_description }}</td>
-      <td>{{ event.user }}</td>
+      <td><em>{{ event.object_type }}</em><br>{{ event.object_description }}</td>
+      <td>{{ event.user.email }}</td>
       {% timezone "America/New_York" %}
-        <td data-sort="{{ event.timestamp|date:"YmdHM" }}">
-          {{ event.timestamp|date:'M j' }}{% if event.timestamp|date:'M j' == today_m_j %}, {{ event.timestamp|date:'H:i' }}{% endif %}
+        <td>
+          {{ event.timestamp|date:'F j' }}, {{ event.timestamp|date:'g:i A' }}
         </td>
       {% endtimezone %}
     </tr>

--- a/bloom_nofos/nofos/templates/nofos/nofo_index.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_index.html
@@ -71,7 +71,7 @@
 						{% timezone "America/New_York" %}
 							<td data-sort="{{ nofo.updated|date:"YmdHM" }}">
 								<a href="{% url 'nofos:nofo_history' nofo.id %}" title="View audit history">
-									{{ nofo.updated|date:'M j' }}{% if nofo.updated|date:'M j' == today_m_j %}, {{ nofo.updated|date:'H:i' }}{% endif %}
+									{{ nofo.updated|date:'M j' }}{% if nofo.updated|date:'M j' == today_m_j %},<br>{{ nofo.updated|date:'g:i A' }}{% endif %}
 									<span class="usa-sr-only"> - View audit history for {% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}</span>
 								</a>
 							</td>

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -994,7 +994,6 @@ class NofoHistoryView(GroupAccessObjectMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["today_m_j"] = dateformat.format(timezone.now(), "M j")
         offset = int(self.request.GET.get("offset", 0))
 
         # Get audit events for this NOFO


### PR DESCRIPTION
Changes are as follows:

  Nofo index page:

  - change timestamp on index page to not use military time

  Nofo edit page:

  - remove "Audit history button": too noisy
  - add a "last updated" widget and a right-justified link to audit history

  Nofo audit page:

  - call them "Updates" instead of audits
  - move the little "group" badge a little lower (too tight before)
  - timestamp cell is more roomy
  - more distinction between the "event" object type and the actual changed object
  - only print email of user, not name
  - change timestamp to always include time, format it in a 12h format