### PR TITLE
Improvements to the diff interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Fixed a bunch of things in the diff interface:
+  - Use full-word diffs, so `<del>January</del><ins>March</ins>` instead of `<del>Janu</del><ins>M</ins>ar<del>y</del><ins>ch</ins>`
+  - Show linebreaks that exist in body content (easier for lists, for example)
+  - Reclassify whitespace-only changes as "MATCH" not "UPDATE" (in markdown, they generally don't matter)
+  - Hide the "Basic information" subsection because it duplicates information
 - Fix for more list styles that were not importing correctly ("List Bullet1, Bullet 2", etc)
 
 ## [2.4.0] - 2025-02-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Use a MS 365 form for feedback instead of a Google Form
 - Breadcrumb links are no longer clickable (instead, they are just visual indicators)
 - When you open a NOFO Builder PDF in Acrobat, the Bookmarks tab will be open by default
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -1005,7 +1005,6 @@ ins {
   background-color: #aceebb;
 }
 
-del > br,
-ins > br {
+del + ins > br {
   display: none;
 }

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -1004,3 +1004,8 @@ del {
 ins {
   background-color: #aceebb;
 }
+
+del > br,
+ins > br {
+  display: none;
+}

--- a/bloom_nofos/bloom_nofos/templates/includes/feedback_link.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/feedback_link.html
@@ -2,7 +2,7 @@
     class="usa-link usa-link--external"
     rel="noreferrer"
     target="_blank"
-    href="https://docs.google.com/forms/d/e/1FAIpQLSdck-FeYXnp-LwsvD4lsdr7dfPOKbBb2ZW2hcoPZpWDYVtsRQ/viewform?usp=header"
+    href="https://forms.office.com/Pages/ResponsePage.aspx?id=ZQrp8hdH80WEeW57vbgMkchDgIu0IAJAnHQJqY67rEdUMzg1RURBV1hUR1FKQklHTloyMkJDNU05MC4u"
     >
   Give us feedback
 </a>

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -777,15 +777,23 @@ def get_cover_image(nofo):
 
 
 def html_diff(original, new):
-    matcher = SequenceMatcher(None, original, new)
-    result = []
+    def _tokenize(text):
+        """Splits text into words while keeping punctuation and spaces intact."""
+        return re.findall(r"\s+|\w+|\W", text)
 
     def _is_whitespace_only(text):
         return re.fullmatch(r"\s*", text) is not None  # Matches only whitespace
 
+    original_tokens = _tokenize(original)
+    new_tokens = _tokenize(new)
+
+    matcher = SequenceMatcher(None, original_tokens, new_tokens)
+    result = []
+
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
-        old_text = original[i1:i2]
-        new_text = new[j1:j2]
+        # Rebuild text from tokens
+        old_text = "".join(original_tokens[i1:i2])
+        new_text = "".join(new_tokens[j1:j2])
 
         if tag == "replace":
             if not _is_whitespace_only(old_text):

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -93,7 +93,17 @@
                 <td>
                   {{ subsection.status }}
                 </td>
-                <td><div class="diff">{{ subsection.diff|safe }}</div></td>
+                <td>
+                  <div class="diff">
+                    {% if subsection.status == 'ADD' %}
+                      <ins>{{ subsection.diff|safe|linebreaksbr }}</ins>
+                    {% elif  subsection.status == 'DELETE' %}
+                      <del>{{ subsection.diff|safe|linebreaksbr }}</del>
+                    {% elif subsection.status == 'UPDATE' %}
+                      {{ subsection.diff|safe|linebreaks }}
+                    {% endif %}
+                  </div>
+                </td>
               </tr>
             {% endif %}
             {% endfor %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -80,31 +80,33 @@
           </thead>
           <tbody>
             {% for subsection in section.subsections %}
-            {% if subsection.status != 'MATCH' %}
-              <tr>
-                <th scope="row">
-                  {# if the subsection.name value starts with "(#" #}
-                  {% if subsection.name|slice:":2" == "(#" %}
-                      <span class="text-base">{{ subsection.name }}</span>
-                  {% else %}
-                      {{ subsection.name }}
-                  {% endif %}
-                </th>
-                <td>
-                  {{ subsection.status }}
-                </td>
-                <td>
-                  <div class="diff">
-                    {% if subsection.status == 'ADD' %}
-                      <ins>{{ subsection.diff|safe|linebreaksbr }}</ins>
-                    {% elif  subsection.status == 'DELETE' %}
-                      <del>{{ subsection.diff|safe|linebreaksbr }}</del>
-                    {% elif subsection.status == 'UPDATE' %}
-                      {{ subsection.diff|safe|linebreaks }}
+            {% if subsection.name|lower != 'basic information' %}
+              {% if subsection.status != 'MATCH' %}
+                <tr>
+                  <th scope="row">
+                    {# if the subsection.name value starts with "(#" #}
+                    {% if subsection.name|slice:":2" == "(#" %}
+                        <span class="text-base">{{ subsection.name }}</span>
+                    {% else %}
+                        {{ subsection.name }}
                     {% endif %}
-                  </div>
-                </td>
-              </tr>
+                  </th>
+                  <td>
+                    {{ subsection.status }}
+                  </td>
+                  <td>
+                    <div class="diff">
+                      {% if subsection.status == 'ADD' %}
+                        <ins>{{ subsection.diff|safe|linebreaksbr }}</ins>
+                      {% elif  subsection.status == 'DELETE' %}
+                        <del>{{ subsection.diff|safe|linebreaksbr }}</del>
+                      {% elif subsection.status == 'UPDATE' %}
+                        {{ subsection.diff|safe|linebreaks }}
+                      {% endif %}
+                    </div>
+                  </td>
+                </tr>
+              {% endif %}
             {% endif %}
             {% endfor %}
           </tbody>

--- a/bloom_nofos/nofos/tests/test_compare.py
+++ b/bloom_nofos/nofos/tests/test_compare.py
@@ -8,13 +8,18 @@ class TestHtmlDiff(TestCase):
     def test_basic_text_change(self):
         original = "Groundhog Day!"
         new = "Valentines Day!"
-        expected = "<del>Grou</del><ins>Vale</ins>n<del>dhog</del><ins>tines</ins> Day!"
+        expected = "<del>Groundhog</del><ins>Valentines</ins> Day!"
         self.assertEqual(html_diff(original, new), expected)
 
     def test_whitespace_only_change(self):
-        original = "Groundhog Day!\n"
-        new = "Groundhog Day!  \n"
+        original = "Groundhog      Day!"
+        new = "Groundhog Day!"
         self.assertIsNone(html_diff(original, new))  # Whitespace only = None
+
+    def test_identical_strings(self):
+        original = "Groundhog Day!"
+        new = "Groundhog Day!"
+        self.assertIsNone(html_diff(original, new))  # No changes = None
 
     def test_text_added(self):
         original = "Groundhog"
@@ -27,16 +32,6 @@ class TestHtmlDiff(TestCase):
         new = "Day"
         expected = "<del>Groundhog </del>Day"
         self.assertEqual(html_diff(original, new), expected)
-
-    def test_mixed_text_and_whitespace_changes(self):
-        original = "Groundhog      Day!"
-        new = "Groundhog Day!"
-        self.assertIsNone(html_diff(original, new))  # Whitespace only = None
-
-    def test_identical_strings(self):
-        original = "Groundhog Day!"
-        new = "Groundhog Day!"
-        self.assertIsNone(html_diff(original, new))  # No changes = None
 
     def test_replace_with_partial_whitespace(self):
         original = "Groundhog Day!"
@@ -160,7 +155,7 @@ class TestCompareNofos(TestCase):
         self.assertEqual(subsection_update["name"], "(#3)")
         self.assertEqual(subsection_update["value"], "Go to 'Contacts and Support")
         self.assertIn(
-            "<del>Need</del><ins>Go</ins> <del>help?</del><ins>to</ins> <del>Visit c</del><ins>'C</ins>ontacts and <del>s</del><ins>S</ins>upport",
+            "<del>Need</del><ins>Go</ins> <del>help?</del><ins>to</ins> <del>Visit contacts</del><ins>'Contacts</ins> and <del>support</del><ins>Support</ins>",
             subsection_update["diff"],
         )
 
@@ -247,7 +242,7 @@ class TestCompareNofosMetadata(TestCase):
             subagency_update["value"], "Department of Groundhog Excellence (DOGE)"
         )
         self.assertIn(
-            "Department of G<del>uessing G</del>roundhog<del>s</del><ins> Excellence</ins> (D<ins>O</ins>G<del>G</del><ins>E</ins>)",
+            "Department of <del>Guessing</del><ins>Groundhog</ins> <del>Groundhogs</del><ins>Excellence</ins> (<del>DGG</del><ins>DOGE</ins>)",
             subagency_update["diff"],
         )
 


### PR DESCRIPTION
## Summary 

This PR makes a bunch of changes to the diff interface. If you thought it was good before, prepare to be WOW'd!!

 1. Use full-word diffs
 2. Show linebreaks that exist in body content (easier for lists, for example)
 3. Reclassify whitespace-only changes as "MATCH" not "UPDATE" (in markdown, they generally don't matter)
 4. Hide the "Basic information" subsection because it duplicates information

Here is a big before/after screenshot (new screenshot is much shorter), but each of these is explained more before.

| before | after |
|--------|-------|
|     ![localhost_8000_nofos_405_compare (1)](https://github.com/user-attachments/assets/c45820ed-f0dc-4863-ac23-207439311a72)   |   ![localhost_8000_nofos_405_compare](https://github.com/user-attachments/assets/b491587e-b4cf-409c-81a8-dc51ff58680b)    |

###  1. Use full-word diffs

Since "March" and "January" both have "ar" in the middle, we would get
really weird looking diffs when we deleted "January" and added March":

- `<del>Janu</del><ins>M</ins>ar<del>y</del><ins>ch</ins>`

Very weird and confusing.

Now it is like this:

- `<del>January</del><ins>March</ins>`

Clean!!

| before | after |
|--------|-------|
|   very hard to read     |   still slightly weird showing that we removed "1" and added "14", but generally much more readable     |
|    <img width="336" alt="Screenshot 2025-02-21 at 4 02 20 PM" src="https://github.com/user-attachments/assets/13cff07d-ebd4-4287-82dd-de463fcaad20" />    |    <img width="336" alt="Screenshot 2025-02-21 at 4 02 48 PM" src="https://github.com/user-attachments/assets/e397fcaf-2ca2-4ade-8cbe-b09736553f0f" />   |


### 2. Show linebreaks that exist in body content (easier for lists, for example)

When we have list elements in the body text, they were represented in one big glob before, which doesn't really give people a true representation of that content. Same idea with content that is multiple paragraphs broken up.

So now we show the linebreaks to give more of a true rendition of how that content is laid out.

| before | after |
|--------|-------|
|    <img width="989" alt="Screenshot 2025-02-21 at 4 26 09 PM" src="https://github.com/user-attachments/assets/10a6b4de-8ce6-4964-8aff-ba4f47d8eb7e" />    |     <img width="989" alt="Screenshot 2025-02-21 at 4 25 30 PM" src="https://github.com/user-attachments/assets/e64ca81b-a6f0-4645-9b62-e7aeb298fb7c" />  |


### 3. Reclassify whitespace-only changes as "MATCH" not "UPDATE"

We were seeing this kind of diff with the linebreaks after we saved it:

```
'This program is authorized under:<del>\r\n\r</del><ins>\n</ins>\n* The United States Leadership Against HIV/AIDS, Tuberculosis and Malaria Act of 2003, Public Law 108-25 (22 U.S.C. 7601, et seq.).<del>\r</del>\n* The Tom Lantos and Henry J. Hyde United States Global Leadership Against HIV/AIDS, Tuberculosis, and Malaria Reauthorization Act of 2008, Public Law 110-293.<del>\r</del>\n* The PEPFAR Stewardship and Oversight Act of 2013, Public Law 113-56.<del>\r</del>\n* Public Health Service Act (42 U.S.C. 242I).<ins>\n</ins>'
```

The part we care about is this: `<del>\r\n\r</del><ins>\n</ins>`.

Basically, this is the same change, just whitespace. So this would show up as an "update" when nothing material had changed. Now, we ignore stuff like this.

| before | after |
|--------|-------|
| says "UPDATE" but the only visible changes are whitespace-related |  N/A   |
|    <img width="976" alt="Screenshot 2025-02-21 at 4 04 20 PM" src="https://github.com/user-attachments/assets/cb6a9501-207b-4634-b442-ac734959534e" />    |     N/A   |


### 4. Hide the "Basic information" subsection because it duplicates information

The very first subsection is just metadata for the NOFO, so we don't consider it body content like everything else. All the changes in this section should be captured in the "Basic information" table above. 

This is what we do in the [`nofo_view`](https://github.com/HHS/simpler-grants-pdf-builder/blob/main/bloom_nofos/nofos/templates/nofos/nofo_view.html#L383) template as well. 

| before | after |
|--------|-------|
|    ![localhost_8000_nofos_405_compare (1)](https://github.com/user-attachments/assets/c1af4aec-8d6e-4b04-abdf-f563e0418fe2)   |    ![localhost_8000_nofos_405_compare](https://github.com/user-attachments/assets/d2238cc6-b911-4572-b3d0-8a3cad97faa2)   |

