### PR TITLE
Add "Important" subsection after specific headings in step 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning since version 1.0.0.
 - Use a MS 365 form for feedback instead of a Google Form
 - Breadcrumb links are no longer clickable (instead, they are just visual indicators)
 - When you open a NOFO Builder PDF in Acrobat, the Bookmarks tab will be open by default
+- "Important: public information" callout box will appear after specific subsection titles in section 3 of new NOFOs
+  - If titles are not found, it will appear at the end like normal
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Versioning since version 1.0.0.
 - Use a MS 365 form for feedback instead of a Google Form
 - Breadcrumb links are no longer clickable (instead, they are just visual indicators)
 - When you open a NOFO Builder PDF in Acrobat, the Bookmarks tab will be open by default
-- "Important: public information" callout box will appear after specific subsection titles in section 3 of new NOFOs
-  - If titles are not found, it will appear at the end like normal
+- "Important: public information" callout box will appear after specific subsection names in section 3 of new NOFOs
+  - If no matching subsection names are found, it will appear at the end of section 3 like normal
 
 ### Fixed
 

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2473,7 +2473,7 @@ def add_final_subsection_to_step_3(sections):
     This function looks for a section named either "Step 3: Prepare Your Application"
     or "Step 3: Write Your Application" (case-insensitive).
 
-    If found, then looks for a subsection called "Other required forms" or "Standard forms".
+    If found, then looks for a subsection called "Other required forms", "Standard forms", or "Application components".
 
         If either of those are found, then a new subsection is added immediately afterwards.
         If none are found, then the new subsection is added as the final subsection.
@@ -2523,7 +2523,11 @@ def add_final_subsection_to_step_3(sections):
         "Step 3: Write Your Application",
     ]
 
-    subsection_names = ["Other required forms", "Standard forms"]
+    subsection_names = [
+        "Other required forms",
+        "Standard forms",
+        "Application components",
+    ]
 
     for section in sections:
         # case insensitive match

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2468,7 +2468,7 @@ Instead of just a title, insert a short description of your project and what it 
 
 def add_final_subsection_to_step_3(sections):
     """
-    This function accepts a list of section dicts, _not Section objects.
+    This function accepts a list of section dicts, _not_ Section objects.
 
     This function looks for a section named either "Step 3: Prepare Your Application"
     or "Step 3: Write Your Application" (case-insensitive).
@@ -2493,6 +2493,30 @@ def add_final_subsection_to_step_3(sections):
         "Step 3" section.
     """
 
+    def _insert_new_subsection_at_order_number(subsections, order_number):
+        """
+        Inserts an empty space in the list at the specified order_number.
+        Increments the order of all elements with order >= order_number.
+
+        :param subsections: List of subsection dictionaries with "order" values.
+        :param order_number: The order number where the space should be inserted.
+        """
+        new_public_information_subsection = PUBLIC_INFORMATION_SUBSECTION.copy()
+        new_public_information_subsection["order"] = order_number
+
+        if order_number <= len(subsections):
+            for subsection in subsections:
+                if subsection.get("order", 0) >= order_number:
+                    # increment order numbers
+                    subsection["order"] += subsection["order"] + 1
+
+            # insert at specific position in array
+            subsections.insert(order_number - 1, new_public_information_subsection)
+
+        else:
+            # insert at the end of the array
+            subsections.append(new_public_information_subsection)
+
     # The target section names to search for
     step_3_names = [
         "Step 3: Prepare Your Application",
@@ -2514,13 +2538,13 @@ def add_final_subsection_to_step_3(sections):
 
             order_number = None
 
-            # # find the new subsection to insert after
-            # for subsection in subsections:
-            #     if subsection.get("name", "").lower() in [
-            #         name.lower() for name in subsection_names
-            #     ]:
-            #         order_number = subsection.order + 1
-            #         break  # Stop loop once a matching subsection name is found
+            # find the new subsection to insert after
+            for subsection in subsections:
+                if subsection.get("name", "").lower() in [
+                    name.lower() for name in subsection_names
+                ]:
+                    order_number = subsection.get("order") + 1
+                    break  # Stop loop once a matching subsection name is found
 
             if not order_number:
                 # set as last order if not yet set
@@ -2528,14 +2552,7 @@ def add_final_subsection_to_step_3(sections):
                     max((sub.get("order", 0) for sub in subsections), default=0) + 1
                 )
 
-            # has no effect if last order
-            # section.insert_order_space(order_number)
-
-            new_public_information_subsection = PUBLIC_INFORMATION_SUBSECTION.copy()
-            new_public_information_subsection["order"] = order_number
-            subsections.append(new_public_information_subsection)
-
-            section["subsections"] = subsections
+            _insert_new_subsection_at_order_number(subsections, order_number)
 
             # Exit after adding new subsection
             break

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -1249,8 +1249,10 @@ class AddFinalSubsectionTests(TestCase):
         for subsection_name in [
             "Other required forms",
             "Standard forms",
+            "Application components",
             "OTHER REQUIRED FORMS",
             "StAnDaRd FoRmS",
+            "application components",
         ]:
             with self.subTest(subsection_name=subsection_name):
                 sections = self._get_sections_1_2_3()
@@ -1303,7 +1305,7 @@ class AddFinalSubsectionTests(TestCase):
         sections = self._get_sections_1_2_3()
 
         # Increment order number of initial subsection in Step 3
-        sections[2]["subsections"][0]["order"] = 3
+        sections[2]["subsections"][0]["order"] = 4
 
         # Manually add "Standard forms" to Step 3
         sections[2]["subsections"].insert(
@@ -1330,15 +1332,27 @@ class AddFinalSubsectionTests(TestCase):
                 "is_callout_box": False,
             },
         )
+        # Manually add "Application components" to Step 3
+        sections[2]["subsections"].insert(
+            2,
+            {
+                "name": "Application components",
+                "order": 3,
+                "tag": "h5",
+                "html_id": "",
+                "body": "Body content",
+                "is_callout_box": False,
+            },
+        )
 
         # Initial state should have 3 subsections in Step 3
-        self.assertEqual(len(sections[2].get("subsections")), 3)
+        self.assertEqual(len(sections[2].get("subsections")), 4)
 
         # Try to add the public information section
         add_final_subsection_to_step_3(sections)
 
         # Verify extra subsection in step 3
-        self.assertEqual(len(sections[2].get("subsections")), 4)
+        self.assertEqual(len(sections[2].get("subsections")), 5)
 
         # first subsection is "Standard forms"
         self.assertEqual(sections[2]["subsections"][0]["name"], "Standard forms")
@@ -1353,8 +1367,12 @@ class AddFinalSubsectionTests(TestCase):
         )
         # third subsection is "Other required forms"
         self.assertEqual(sections[2]["subsections"][2]["name"], "Other required forms")
+        # fourth subsection is "Application components"
+        self.assertEqual(
+            sections[2]["subsections"][3]["name"], "Application components"
+        )
         # last subsection is the initial one
-        self.assertEqual(sections[2]["subsections"][3]["name"], "Subsection 3.1")
+        self.assertEqual(sections[2]["subsections"][4]["name"], "Subsection 3.1")
 
 
 class AddHeadingsTests(TestCase):

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -1241,6 +1241,121 @@ class AddFinalSubsectionTests(TestCase):
             final_subsection.get("body"), PUBLIC_INFORMATION_SUBSECTION["body"]
         )
 
+    def test_add_public_information_section_after_specific_subsection_titles(self):
+        """
+        Test that the public information subsection is added _after_ different subsection titles.
+        """
+
+        for subsection_name in [
+            "Other required forms",
+            "Standard forms",
+            "OTHER REQUIRED FORMS",
+            "StAnDaRd FoRmS",
+        ]:
+            with self.subTest(subsection_name=subsection_name):
+                sections = self._get_sections_1_2_3()
+
+                # Increment order number of initial subsection in Step 3
+                sections[2]["subsections"][0]["order"] = 2
+
+                # Manually add the form subsection to Step 3
+                sections[2]["subsections"].insert(
+                    0,
+                    {
+                        "name": subsection_name,
+                        "order": 1,
+                        "tag": "h5",
+                        "html_id": "",
+                        "body": "Body content",
+                        "is_callout_box": False,
+                    },
+                )
+
+                # Initial state should have 2 subsections in Step 3
+                self.assertEqual(len(sections[2].get("subsections")), 2)
+
+                # Add the public information section
+                add_final_subsection_to_step_3(sections)
+
+                # Verify extra subsection in step 3
+                self.assertEqual(len(sections[2].get("subsections")), 3)
+
+                # first subsection is the title we specified
+                self.assertEqual(sections[2]["subsections"][0]["name"], subsection_name)
+                # second subsection is public information one
+                self.assertEqual(
+                    sections[2]["subsections"][1]["name"],
+                    PUBLIC_INFORMATION_SUBSECTION["name"],
+                )
+                self.assertEqual(
+                    sections[2]["subsections"][1]["body"],
+                    PUBLIC_INFORMATION_SUBSECTION["body"],
+                )
+                # last subsection is the initial one
+                self.assertEqual(
+                    sections[2]["subsections"][2]["name"], "Subsection 3.1"
+                )
+
+    def test_add_public_information_section_after_first_specific_subsection_title(self):
+        """
+        Test that the public information subsection is added _after_ the first subsection title matched.
+        """
+        sections = self._get_sections_1_2_3()
+
+        # Increment order number of initial subsection in Step 3
+        sections[2]["subsections"][0]["order"] = 3
+
+        # Manually add "Standard forms" to Step 3
+        sections[2]["subsections"].insert(
+            0,
+            {
+                "name": "Standard forms",
+                "order": 1,
+                "tag": "h5",
+                "html_id": "",
+                "body": "Body content",
+                "is_callout_box": False,
+            },
+        )
+
+        # Manually add "Other required forms" to Step 3
+        sections[2]["subsections"].insert(
+            1,
+            {
+                "name": "Other required forms",
+                "order": 2,
+                "tag": "h5",
+                "html_id": "",
+                "body": "Body content",
+                "is_callout_box": False,
+            },
+        )
+
+        # Initial state should have 3 subsections in Step 3
+        self.assertEqual(len(sections[2].get("subsections")), 3)
+
+        # Try to add the public information section
+        add_final_subsection_to_step_3(sections)
+
+        # Verify extra subsection in step 3
+        self.assertEqual(len(sections[2].get("subsections")), 4)
+
+        # first subsection is "Standard forms"
+        self.assertEqual(sections[2]["subsections"][0]["name"], "Standard forms")
+        # second subsection is public information one
+        self.assertEqual(
+            sections[2]["subsections"][1]["name"],
+            PUBLIC_INFORMATION_SUBSECTION["name"],
+        )
+        self.assertEqual(
+            sections[2]["subsections"][1]["body"],
+            PUBLIC_INFORMATION_SUBSECTION["body"],
+        )
+        # third subsection is "Other required forms"
+        self.assertEqual(sections[2]["subsections"][2]["name"], "Other required forms")
+        # last subsection is the initial one
+        self.assertEqual(sections[2]["subsections"][3]["name"], "Subsection 3.1")
+
 
 class AddHeadingsTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
 # Summary

This PR adds logic to the function that inserts a new subsection inside of "Step 3": https://github.com/HHS/simpler-grants-pdf-builder/pull/96

In particular, we add logic so that the new subsection can be inserted after specific headings, not just at the very end of Section 3. 

The headings we are looking for are:

- Other required forms
- Standard forms
- Application components

If multiple of these exist, the new subsection will be inserted after the first one we find. If none of them exist, the new subsection would be inserted at the end of section 3 (which is the current behaviour).

## Screenshots

| "Other required forms": before | "Other required forms": after |
|--------|-------|
|   <img width="787" alt="Screenshot 2025-02-26 at 4 13 14 PM" src="https://github.com/user-attachments/assets/da33400c-2072-4308-9aca-dc8754d4e916" />     |    <img width="787" alt="Screenshot 2025-02-26 at 4 12 29 PM" src="https://github.com/user-attachments/assets/a0f2c0c5-301b-4824-9514-097debe8f52b" />   |

| "Standard forms": before | "Standard forms": after |
|--------|-------|
| <img width="878" alt="Screenshot 2025-02-26 at 4 11 36 PM" src="https://github.com/user-attachments/assets/fa0c074a-45e9-40d9-bfc4-10f524e56cf8" /> |   <img width="878" alt="Screenshot 2025-02-26 at 4 11 00 PM" src="https://github.com/user-attachments/assets/479ea4c3-6619-42c2-96ad-288ade9dc4e1" /> | 

