### PR TITLE
Do not apply default list-types to list elements with "type" attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add hint text to "Add page break?" radio buttons
+
 ### Changed
 
+- "Top" link is more visible on nofo_edit page
+- "Preview" tab is more visible (blue background)
+- Markdown Guide button is more visible (orange background)
+
 ### Fixed
+
+- Don't apply default list-style-type styling to lists with "type" attribute
 
 ## [2.6.0] - 2025-02-27
 

--- a/bloom_nofos/bloom_nofos/static/shared.css
+++ b/bloom_nofos/bloom_nofos/static/shared.css
@@ -173,6 +173,45 @@
   background-color: var(--color--yellow);
 }
 
+/* List CSS */
+
+ol ol:not([type]) {
+  list-style-type: lower-alpha;
+}
+
+ol ol ol:not([type]) {
+  list-style-type: lower-roman;
+}
+
+ul ul ul ul:not([type]) {
+  list-style-type: none;
+}
+
+ul ul ul ul:not([type]) > li:before {
+  content: "⁃";
+  margin-left: -14px;
+  margin-right: 8px;
+}
+
+ul ul ul ul ul:not([type]) {
+  list-style-type: disc;
+}
+
+ul ul ul ul ul:not([type]) > li:before {
+  content: none;
+  margin-right: 0;
+}
+
+ul ul ul ul ul ul:not([type]) {
+  list-style-type: circle;
+}
+
+div.martor-preview ol ol,
+div.martor-preview ul ul {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+
 @media screen {
   /* Remove right padding from last nav item */
   .usa-nav__primary-item:not(.usa-nav__primary-item__right-padding):last-of-type

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -568,14 +568,6 @@ label.usa-label {
   border-radius: 0.25rem;
 }
 
-.nofo_edit ol ol {
-  list-style-type: lower-alpha;
-}
-
-.nofo_edit ol ol ol {
-  list-style-type: lower-roman;
-}
-
 .nofo_edit .page-break--hr--container {
   position: relative;
 }

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -452,37 +452,6 @@ ol ol:last-child {
   margin-bottom: 0.5rem;
 }
 
-ol ol {
-  list-style-type: lower-alpha;
-}
-
-ol ol ol {
-  list-style-type: lower-roman;
-}
-
-ul ul ul ul {
-  list-style-type: none;
-}
-
-ul ul ul ul > li:before {
-  content: "⁃";
-  margin-left: -14px;
-  margin-right: 8px;
-}
-
-ul ul ul ul ul {
-  list-style-type: disc;
-}
-
-ul ul ul ul ul > li:before {
-  content: none;
-  margin-right: 0;
-}
-
-ul ul ul ul ul ul {
-  list-style-type: circle;
-}
-
 img.usa-icon--check_box_outline_blank {
   height: 17px;
   width: 17px;

--- a/bloom_nofos/bloom_nofos/templates/base_barebones.html
+++ b/bloom_nofos/bloom_nofos/templates/base_barebones.html
@@ -19,12 +19,13 @@
 
     <!-- Includes -->
     <link href="{% static 'uswds/uswds.css' %}" rel="stylesheet">
+    {% block uswds_css %}{% endblock %}
+    {% block css %}{% endblock %}
+
     <link href="{% static 'shared.css' %}" rel="stylesheet">
     {% block base_css %}
       <link href="{% static 'theme-base.css' %}" type="text/css" media="all" rel="stylesheet">
     {% endblock %}
-    {% block uswds_css %}{% endblock %}
-    {% block css %}{% endblock %}
     {% block uswds_js %}{% endblock %}
     {% block js %}{% endblock %}
 


### PR DESCRIPTION
## Summary

This commit does 2 things:

- does not apply standard list types to `<ol>` and `<ul>` elements with "type" attributes
- also make sure that our `<ol>` and `<ul>` styling is applied to all views, the html view, the edit view, and the "preview" view.

Here's a before and after. It's a bit hard to see, but you gotta trust me:

| before | after |
|--------|-------|
|  `ol` should be: `A`, `1`, `a`, `I`, `a` <br> `ol` is: `A`, `a`, `i`, `i`, `i` <br><br> `ul` should be all squares<br> `ul` is not all squares   |    `ol` should be: `A`, `1`, `a`, `I`, `a` <br>   `ul` is all squares |
|     <img width="676" alt="Screenshot 2025-03-04 at 12 20 47 PM" src="https://github.com/user-attachments/assets/31c45d4a-27f0-46a8-a946-0b76b30c1272" />   |    <img width="676" alt="Screenshot 2025-03-04 at 12 19 26 PM" src="https://github.com/user-attachments/assets/d3f2f90d-367a-40f8-bb4b-5cb3b453b123" />   |

### Testing

To test this PR, you can add this HTML to a given subsection:

```html
##### Ordered lists

<ol type="A">
  <li>List item A
    <ol type="1">
      <li>
        List item A.1
        <ol type="a">
          <li>List item A.1.a
            <ol type="I">
              <li>List item A.1.a.I
                <ol type="a"><li>List item A.1.a.I.a</li></ol>
              </li>
            </ol>
          </li>
        </ol>
      </li>
    </ol>
  </li>
</ol>

##### Unordered lists

<ul type="square">
  <li>List item 1
    <ul type="square">
      <li>List item 1.1
          <ul type="square">
            <li>List item 1.1.1
              <ul type="square">
                <li>List item 1.1.1.1
                  <ul type="square">
                    <li>List item 1.1.1.1.1</li>
                  </ul>
                </li>
              </ul>
            </li>
          </ul>
      </li>
    </ul>
  </li>
</ul>
```