### PR TITLE
[BUG] Fix the ToC lists and section page lists

### DIFF
--- a/bloom_nofos/bloom_nofos/static/shared.css
+++ b/bloom_nofos/bloom_nofos/static/shared.css
@@ -206,8 +206,8 @@ ul ul ul ul ul ul:not([type]):not(.usa-list--unstyled) {
   list-style-type: circle;
 }
 
-div.martor-preview ol ol,
-div.martor-preview ul ul {
+.subsection_edit div.martor-preview ol ol,
+.subsection_edit div.martor-preview ul ul {
   margin-top: 0;
   margin-bottom: 5px;
 }

--- a/bloom_nofos/bloom_nofos/static/shared.css
+++ b/bloom_nofos/bloom_nofos/static/shared.css
@@ -175,34 +175,34 @@
 
 /* List CSS */
 
-ol ol:not([type]) {
+ol ol:not([type]):not(.usa-list--unstyled) {
   list-style-type: lower-alpha;
 }
 
-ol ol ol:not([type]) {
+ol ol ol:not([type]):not(.usa-list--unstyled) {
   list-style-type: lower-roman;
 }
 
-ul ul ul ul:not([type]) {
+ul ul ul ul:not([type]):not(.usa-list--unstyled) {
   list-style-type: none;
 }
 
-ul ul ul ul:not([type]) > li:before {
+ul ul ul ul:not([type]):not(.usa-list--unstyled) > li:before {
   content: "⁃";
   margin-left: -14px;
   margin-right: 8px;
 }
 
-ul ul ul ul ul:not([type]) {
+ul ul ul ul ul:not([type]):not(.usa-list--unstyled) {
   list-style-type: disc;
 }
 
-ul ul ul ul ul:not([type]) > li:before {
+ul ul ul ul ul:not([type]):not(.usa-list--unstyled) > li:before {
   content: none;
   margin-right: 0;
 }
 
-ul ul ul ul ul ul:not([type]) {
+ul ul ul ul ul ul:not([type]):not(.usa-list--unstyled) {
   list-style-type: circle;
 }
 

--- a/bloom_nofos/bloom_nofos/templates/base_barebones.html
+++ b/bloom_nofos/bloom_nofos/templates/base_barebones.html
@@ -19,13 +19,12 @@
 
     <!-- Includes -->
     <link href="{% static 'uswds/uswds.css' %}" rel="stylesheet">
-    {% block uswds_css %}{% endblock %}
-    {% block css %}{% endblock %}
-
     <link href="{% static 'shared.css' %}" rel="stylesheet">
     {% block base_css %}
       <link href="{% static 'theme-base.css' %}" type="text/css" media="all" rel="stylesheet">
     {% endblock %}
+    {% block uswds_css %}{% endblock %}
+    {% block css %}{% endblock %}
     {% block uswds_js %}{% endblock %}
     {% block js %}{% endblock %}
 


### PR DESCRIPTION
## Summary

In my exuberance to fix the list problems in #228, I accidentally caused 2 issues:

1. Table of contents lists would have small roman characters as markers ("a", "b", "c", etc) 
2. Section page header listings were invisible in the CDC theme (this was due to CSS cascading, not lists per sé)

This commit fixes both of these issues.

### table of contents problem

| before | after |
|--------|-------|
|   <img width="801" alt="Screenshot 2025-03-04 at 4 28 45 PM" src="https://github.com/user-attachments/assets/f1d2ea62-533d-4a53-8c4d-da54f6ad91cf" />     |    <img width="801" alt="Screenshot 2025-03-04 at 4 27 45 PM" src="https://github.com/user-attachments/assets/936ad0a6-2985-4ef7-9c60-c215cbf6744a" />   |



### section page problem

| before | after |
|--------|-------|
|    <img width="801" alt="Screenshot 2025-03-04 at 4 28 34 PM" src="https://github.com/user-attachments/assets/03444e61-dc7e-4c10-afa6-121d810eb577" />    |   <img width="801" alt="Screenshot 2025-03-04 at 4 28 08 PM" src="https://github.com/user-attachments/assets/01a73af9-2ff6-40c8-8fdb-73ae9a2dc1da" />    |


