### PR TITLE
Small PR that lowers word count for callout box CSS and updates nav colours for DHP theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, and this project adheres to Semantic
 Versioning since version 1.0.0.
 
-[2.7.0] - 2025-03-05
+## Unreleased
 
 ### Added
 
+### Changed
+
+- Lower word count for smaller "Key dates"/"Key facts" callout boxes (>= 80 chars, up from >86)
+- Change top nav breadcrumb colours for section pages in DHP theme
+
+### Fixed
+
+## [2.7.0] - 2025-03-05
+
+### Added
+
+- Add hint text to "Add page break?" radio buttons
 - Adds login.gov as an authentication option
+
+### Changed
+
+- "Top" link is more visible on nofo_edit page
+- "Preview" tab is more visible (blue background)
+- Markdown Guide button is more visible (orange background)
+
+### Fixed
+
+- Don't apply default list-style-type styling to lists with "type" attribute
 
 ### Migrations
 
@@ -20,8 +42,7 @@ Versioning since version 1.0.0.
 ### Added
 
 - Add new theme: "CDC Portrait (DHP)"
-- Added the status to the edit_nofo actions box, with a link to the "edit
-  status" page
+- Added the status to the edit_nofo actions box, with a link to the "edit status" page
 
 ### Fixed
 
@@ -36,16 +57,13 @@ Versioning since version 1.0.0.
 
 ### Added
 
-- Add new "{id}/compare" route for comparing a new NOFO document to an existing
-  one
+- Add new "{id}/compare" route for comparing a new NOFO document to an existing one
 - Add a "modifications" status to published NOFOs:
   - Only "published" NOFOs can be modified
   - There is a 'modified' message on the cover page
-  - There is a new setting in the NOFO edit page allowing you to set a
-    modifications date
+  - There is a new setting in the NOFO edit page allowing you to set a modifications date
   - A "Modifications" section is added to the end of your NOFO:
-    - This section shows up in the table of contents, but it does not have a
-      section page
+    - This section shows up in the table of contents, but it does not have a section page
     - It comes with 1 subsection: a table for you to list changes and the date
       of those changes
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
@@ -200,7 +200,7 @@ h4 {
 /* Section title page */
 
 .section--title-page .section--title-page--header-nav > p {
-  color: var(--color--dhp-teal);
+  color: var(--color--black);
 }
 
 .section--title-page--header-nav li a {
@@ -210,7 +210,7 @@ h4 {
 
 .section--title-page--header-nav li a[aria-current] {
   border-top: 4px solid var(--color--dhp-purple);
-  color: var(--color--dhp-teal);
+  color: var(--color--dhp-purple);
 }
 
 .section--title-page {

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -367,7 +367,7 @@
           {% if nofo_theme_orientation == 'portrait' %}
             {% with callouts=section|get_floating_callout_boxes_from_section %}
               {% if callouts %}
-                <div class="section--content--right-col{% if callouts|get_combined_wordcount_for_subsections > 85 %} section--content--right-col--smaller{% endif %}">
+                <div class="section--content--right-col{% if callouts|get_combined_wordcount_for_subsections > 79 %} section--content--right-col--smaller{% endif %}">
                   {% for subsection in callouts %}
                     {% include "includes/callout_box.html" with subsection=subsection nofo=nofo break_colons=True only %}
                   {% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bloom-nofos"
-version = "2.6.0"
+version = "2.7.0"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

This PR is very small, and makes 2 changes:

1. Smaller callout text when 80 chars or more
2. Change colours of top nav items in DHP section pages

It also updates the version number in the `pyproject.toml` to match what is in our changelog.

The only visual change is to the top nav breadcrumb items on section pages in the DHP theme. They look less clown-y.

| before | after |
|--------|-------|
|    <img width="518" alt="Screenshot 2025-03-05 at 4 54 11 PM" src="https://github.com/user-attachments/assets/3bda42ee-5674-4f73-87f5-506f07a0627e" />    |   <img width="518" alt="Screenshot 2025-03-05 at 4 53 42 PM" src="https://github.com/user-attachments/assets/394db50c-3655-40fb-bb0a-b1093eb27b8d" />    |
