### PR TITLE
Fix/login gov integration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ For local development, the application will:
 
 1. Place your Login.gov certificate files in `bloom_nofos/bloom_nofos/certs/`:
    - `login-gov-private.pem`
-   - `login-gov-public.pem`
+   - `login-gov-public.crt`
 
 2. No additional configuration needed - the application will automatically use
    these files if Secret Manager access fails
@@ -191,6 +191,7 @@ For local development, the application will:
    gcloud config set project bloom-nofos-1
    gcloud auth application-default set-quota-project bloom-nofos-1
    ```
+  4.  This will fetch the private key for you to use, the public keys should be commited to the bloom_nofos/bloom_nofos/certs directory 
 
 ## Build and run as a Docker container
 

--- a/bloom_nofos/bloom_nofos/context_processors.py
+++ b/bloom_nofos/bloom_nofos/context_processors.py
@@ -1,20 +1,23 @@
 from constance import config
 from django.conf import settings
 
-from .utils import is_docraptor_live_mode_active, parse_docraptor_ip_addresses
+from .utils import is_docraptor_live_mode_active
 
 
-def add_docraptor_live_mode(request):
+def template_context(request):
+    """
+    Provides specific settings variables to all templates.
+    Only passes the exact settings needed rather than the entire settings object.
+    """
+    # Get DocRaptor live mode status
     last_updated = getattr(config, "DOCRAPTOR_LIVE_MODE")
     docraptor_live_mode = is_docraptor_live_mode_active(last_updated)
 
-    return {"DOCRAPTOR_LIVE_MODE": docraptor_live_mode}
+    # Get Login.gov enabled status
+    login_gov_enabled = getattr(settings, "LOGIN_GOV", {}).get("ENABLED", False)
 
-
-def add_github_sha(request):
-    return {"GITHUB_SHA": settings.GITHUB_SHA}
-
-
-def settings_context(request):
-    """Makes selected Django settings available to all templates."""
-    return {"settings": settings}
+    return {
+        "DOCRAPTOR_LIVE_MODE": docraptor_live_mode,
+        "GITHUB_SHA": settings.GITHUB_SHA,
+        "LOGIN_GOV_ENABLED": login_gov_enabled,
+    }

--- a/bloom_nofos/bloom_nofos/settings.py
+++ b/bloom_nofos/bloom_nofos/settings.py
@@ -88,7 +88,6 @@ SESSION_COOKIE_SECURE = is_prod
 CSRF_COOKIE_SECURE = is_prod
 CSRF_COOKIE_HTTPONLY = False
 SECURE_BROWSER_XSS_FILTER = is_prod
-SESSION_COOKIE_SAMESITE = None
 
 # X-Frame-Options
 X_FRAME_OPTIONS = "DENY"
@@ -155,9 +154,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "djversion.context_processors.version",
-                "bloom_nofos.context_processors.add_docraptor_live_mode",
-                "bloom_nofos.context_processors.add_github_sha",
-                "bloom_nofos.context_processors.settings_context",
+                "bloom_nofos.context_processors.template_context",
             ],
         },
     },

--- a/bloom_nofos/users/admin.py
+++ b/bloom_nofos/users/admin.py
@@ -17,6 +17,7 @@ class BloomUserAdmin(UserAdmin):
         "is_superuser_status",
         "is_staff_status",
         "is_active",
+        "has_login_gov",
         "formatted_last_login",
     )
 
@@ -25,8 +26,14 @@ class BloomUserAdmin(UserAdmin):
         if obj.last_login:
             # Ensure the datetime is timezone-aware and localized
             local_last_login = localtime(obj.last_login)
-            return local_last_login.strftime("%d\u00A0%b,\u00A0%H:%M")
+            return local_last_login.strftime("%d\u00a0%b,\u00a0%H:%M")
         return "—"
+
+    def has_login_gov(self, obj):
+        return bool(obj.login_gov_user_id)
+
+    has_login_gov.short_description = "Login.gov user"
+    has_login_gov.boolean = True
 
     formatted_last_login.short_description = "Last Login"
     formatted_last_login.admin_order_field = "last_login"
@@ -56,6 +63,7 @@ class BloomUserAdmin(UserAdmin):
                     "group",
                     "password",
                     "force_password_reset",
+                    "login_gov_user_id",
                 )
             },
         ),
@@ -82,6 +90,7 @@ class BloomUserAdmin(UserAdmin):
                     "password1",
                     "password2",
                     "force_password_reset",
+                    "login_gov_user_id",
                 ),
             },
         ),

--- a/bloom_nofos/users/templates/users/login.html
+++ b/bloom_nofos/users/templates/users/login.html
@@ -50,7 +50,7 @@
     <button class="usa-button margin-top-3" type="submit">Login</button>
 </form>
 
-{% if settings.LOGIN_GOV.ENABLED %}
+{% if LOGIN_GOV_ENABLED %}
     <!-- Login.gov login button -->
     <div class="margin-top-4 login-gov-container">
         <p class="text-center">- or -</p>

--- a/bloom_nofos/users/templates/users/login.html
+++ b/bloom_nofos/users/templates/users/login.html
@@ -1,7 +1,14 @@
 {% extends "base.html" %}
 
+{% block title %}
+  Login — NOFO Web Flow
+{% endblock %}
+
+{% block content %}
+{% include "includes/page_heading.html" with title="Login" only %}
+
 {% if messages %}
-<div class="messages">
+<div class="messages margin-top-4">
     {% for message in messages %}
     <div class="usa-alert usa-alert--{{ message.tags }}">
         <div class="usa-alert__body">
@@ -11,13 +18,6 @@
     {% endfor %}
 </div>
 {% endif %}
-
-{% block title %}
-  Login — NOFO Web Flow
-{% endblock %}
-
-{% block content %}
-{% include "includes/page_heading.html" with title="Login" only %}
 
 {% if next %}
   {% if user.is_authenticated %}


### PR DESCRIPTION
Issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/231

Description:
Fixes up some problems with our initial login.gov integration, including:
- Limits settings passed to templates to only whats needed
- Fixes issue with error messages not rendering on login failures
- Updates some readme text to reflect recent changes
- Add login info to the admin user view and user list
- Remove SESSION_COOKIE_SAMESITE = None from settings

Screenshots:
<img width="1117" alt="Screenshot 2025-03-07 at 12 40 17 PM" src="https://github.com/user-attachments/assets/675a2a62-dfc7-4442-9c28-341d3df7c07f" />
<img width="1117" alt="Screenshot 2025-03-07 at 12 40 25 PM" src="https://github.com/user-attachments/assets/8cbe6674-7961-4a5a-8f7f-26af45b43af3" />
<img width="1117" alt="Screenshot 2025-03-07 at 11 49 19 AM" src="https://github.com/user-attachments/assets/ddc84d8a-29e6-4897-92f2-9bcc6ea9b955" />
