### PR TITLE
Update style map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning since version 1.0.0.
 - Change top nav breadcrumb colours for section pages in DHP theme
 - Rotate certs for login.gov staging
 - Remove "local" cert: only 2 envs exist now
+- Update style map for "w:" and "heading 8" styles
 
 ### Fixed
 

--- a/bloom_nofos/nofos/nofo_markdown.py
+++ b/bloom_nofos/nofos/nofo_markdown.py
@@ -31,6 +31,9 @@ class NofoMarkdownConverter(MarkdownConverter):
         if el.get("role") == "heading":
             return str(el)
 
+        if el.get("class") and "heading-8" in el.get("class"):
+            return str(el)
+
         # Else, return text, which is what process_text would return
         return text
 

--- a/bloom_nofos/nofos/tests/test_nofo_markdown.py
+++ b/bloom_nofos/nofos/tests/test_nofo_markdown.py
@@ -359,12 +359,30 @@ class NofoMarkdownConverterDIVTest(TestCase):
     maxDiff = None
 
     def test_div_role_heading(self):
-        html = '<h6>Component funding</h6><div><div aria-level="7" role="heading">Overview</div><p>We fund all cooperative agreements using component funding.</p>'
+        html = '<h6>Component funding</h6><div aria-level="7" role="heading">Overview</div><p>We fund all cooperative agreements using component funding.</p>'
         expected_html = '###### Component funding\n\n<div aria-level="7" role="heading">Overview</div>We fund all cooperative agreements using component funding.'
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_html)
 
-    def test_div_no_role_heading(self):
+    def test_div_class_heading_8(self):
+        html = '<h6>Component funding</h6><div class="heading-8">Overview</div><p>We fund all cooperative agreements using component funding.</p>'
+        expected_html = '###### Component funding\n\n<div class="heading-8">Overview</div>We fund all cooperative agreements using component funding.'
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_html)
+
+    def test_div_class_heading_9(self):
+        html = '<h6>Component funding</h6><div class="heading-9">Overview</div><p>We fund all cooperative agreements using component funding.</p>'
+        expected_html = "###### Component funding\n\nOverviewWe fund all cooperative agreements using component funding."
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_html)
+
+    def test_div_class_empty(self):
+        html = '<h6>Component funding</h6><div class="">Overview</div><p>We fund all cooperative agreements using component funding.</p>'
+        expected_html = "###### Component funding\n\nOverviewWe fund all cooperative agreements using component funding."
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_html)
+
+    def test_div_no_role_heading_no_class(self):
         html = "<h6>Component funding</h6><div>Overview</div><p>We fund all cooperative agreements using component funding.</p>"
         expected_html = "###### Component funding\n\nOverviewWe fund all cooperative agreements using component funding."
         md_body = md(html)
@@ -383,6 +401,12 @@ class NofoMarkdownConverterDIVTest(TestCase):
     def test_div_no_role_heading_with_nested_elements(self):
         html = "<div><span>Overview</span><strong>Important</strong></div>"
         expected_html = "Overview**Important**"
+        md_body = md(html)
+        self.assertEqual(md_body.strip(), expected_html)
+
+    def test_div_role_heading_class_heading_8(self):
+        html = '<h6>Component funding</h6><div aria-level="7" role="heading">Overview</div><div class="heading-8">Introduction</div><p>We fund all cooperative agreements using component funding.</p>'
+        expected_html = '###### Component funding\n\n<div aria-level="7" role="heading">Overview</div><div class="heading-8">Introduction</div>We fund all cooperative agreements using component funding.'
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_html)
 

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -149,6 +149,7 @@ style_map_manager = StyleMapManager(
         "non-row element in table",
         "Normal_0",
         "v:",
+        "w:",
         "office-word:",
     ]
 )
@@ -341,6 +342,11 @@ style_map_manager.add_style(
     style_rule="p[style-name='heading 7'] => div[role='heading'][aria-level='7']",
     location_in_nofo="Step 1 > Summary > Funding Strategy > Component Funding > Overview",
     note="This is how we represent H7s",
+)
+style_map_manager.add_style(
+    style_rule="p[style-name='heading 8'] => div.heading-8",
+    location_in_nofo="Step 1 > Approach > Strategies and activities > Component 1 > Required activities (years 1 and 2)",
+    note="This is an H8, which we don't formally support",
 )
 style_map_manager.add_style(
     style_rule="p[style-name='Default'] => p",


### PR DESCRIPTION
## Summary

This PR updates our style mapping to accommodate 2 new styles:

- those that start with "w:" 
- "heading 8"

Note that we don't support heading-8s, but we do want to be able to identify them when they happen, so I've kept them as divs with a classname rather than just a paragraph tag or something generic.