### PR TITLE
Add 2 GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - 1.0.2 (Default)
+        - 1.0.3 (Edge)
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/NOFO.yml
+++ b/.github/ISSUE_TEMPLATE/NOFO.yml
@@ -1,0 +1,57 @@
+name: NOFO Builder Tickets
+description: Submit a request for a task related to NOFO Builder.
+title: "[Task]: " # Prefills issue title
+labels: ["nofo-builder", "triage"] # Optional labels
+
+body:
+  - type: input
+    id: task_name
+    attributes:
+      label: Task name
+      description: "What do you need us to do?"
+      placeholder: "e.g., Fix table alignment in the NOFO editor"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: task_type
+    attributes:
+      label: Type of task
+      description: "What kind of task is this?"
+      multiple: false
+      options:
+        - General suggestion
+        - I need help
+        - Bug
+        - UI enhancement
+
+  - type: textarea
+    id: task_description
+    attributes:
+      label: Description
+      description: "Write a detailed description of what you want accomplished. Be as specific as possible, please!"
+      placeholder: "Provide step-by-step details of the issue or request."
+    validations:
+      required: true
+
+  - type: textarea
+    id: upload_image
+    attributes:
+      label: Upload an image
+      description: "Please add [annotated] screenshots or mock-ups to show us what you're talking about."
+      placeholder: "Drag and drop or paste an image here."
+    validations:
+      required: false
+
+  - type: input
+    id: user_email
+    attributes:
+      label: Your email
+      description: "Enter your email so we know who you are and how we can get in touch with you."
+      placeholder: "e.g., your.email@example.com"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: "Thank you for submitting a request! We’ll review it as soon as possible."


### PR DESCRIPTION
For now, we are just testing these to see if they work.

Documentation is here:

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema