### PR TITLE
Explain `429` status codes in the external links status table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning since version 1.0.0.
 ### Added
 
 - Added "Login.gov" user attributes to admin page
+- Add explanation for `429` links on the external links status table
 
 ### Changed
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_check_links.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_check_links.html
@@ -48,11 +48,18 @@
             <td>Manually check if link is working.</td>
           </tr>
           <tr>
-            <th scope="row">404 🔴 (Not Found)</th>
+            <th scope="row">404 ⛔️ (Not Found)</th>
             <td>
               This page can’t be found.
             </td>
             <td>Manually check if link is working.</td>
+          </tr>
+          <tr>
+            <th scope="row">429 ⛔️ (Too Many Requests)</th>
+            <td>
+              Too many requests sent in a short time period.
+            </td>
+            <td>Try again in 5 minutes.</td>
           </tr>
           <tr>
             <th scope="row">500 🟠 (Server error)</th>
@@ -66,6 +73,7 @@
 
       <p>Sometimes, links that won’t load for the NOFO Builder are fine when you click them.</p>
       <p><strong>For this reason, <em>always</em> manually check links that are <em>not</em> 200 🟢.</strong></p>
+      <p>If see lots of <strong>429</strong>s, you should just wait a bit.</p>
       <p>Learn more about <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status" target="_blank">HTTP response status codes</a>.</p>
     </div>
   </details>


### PR DESCRIPTION
## Summary

Very small PR. 

This was raised during our NOFO Builder retro, and it's easy so let's just do it.

| before | after |
|--------|-------|
|  429 not mentioned      |  429 _is_ mentioned      |
|   <img width="849" alt="Screenshot 2025-03-10 at 4 30 07 PM" src="https://github.com/user-attachments/assets/c363176e-94a0-4e4c-8a65-49db66d74a4a" />     |   <img width="849" alt="Screenshot 2025-03-10 at 4 29 19 PM" src="https://github.com/user-attachments/assets/b127517e-5134-42e6-97bc-043199badc54" />    |

Once this is merged, #226 is closed!
