### PR TITLE
[Bugfix] Fix Safari-specific page-break bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Solve "page break" floating at the top in Safari
 - Login page once again displays errors correctly
 
 ## [2.7.0] - 2025-03-05

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -733,6 +733,24 @@ label.usa-label {
   font-size: 12px;
 }
 
+/* Target only safari */
+_::-webkit-full-page-media,
+_:future,
+:root .nofo_edit table th.nofo-edit-table--subsection--name.page-break-before {
+  position: relative;
+}
+
+_::-webkit-full-page-media,
+_:future,
+:root
+  .nofo_edit
+  table
+  th.nofo-edit-table--subsection--name.page-break-before::before {
+  right: -270%;
+  left: unset;
+  transform: none;
+}
+
 .nofo_edit table th.nofo-edit-table--subsection--name.column-break-before,
 .nofo_edit table th.nofo-edit-table--subsection--name.column-break-before ~ td {
   border-top: 1px dotted #5c5c5c;


### PR DESCRIPTION
## Summary

This is a small PR that fixes a visual bug we have only in the Safari browser.

In the nofo_edit view, the "page-break" `::before` element was not contained by the `<tr>` element, and so would float up to the top of the browser window.

Added some hacky CSS to put it where we expect, although it won't work on a mobile screen.

| subsection page-break | floats to the top of the page |
|--------|-------|
|   <img width="1016" alt="Screenshot 2025-03-11 at 10 26 45 AM" src="https://github.com/user-attachments/assets/5570b0e8-d7cc-4dff-abdb-5336c653e92c" />     |    <img width="1016" alt="Screenshot 2025-03-11 at 10 26 28 AM" src="https://github.com/user-attachments/assets/947d6a66-bc58-4024-a367-8d15fb34bf06" />   |

