### PR TITLE
Fix Before you begin page so that "step 2" links are dynamic

### DIFF
--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -1018,6 +1018,23 @@ def compare_nofos_metadata(new_nofo, nofo):
 ###########################################################
 
 
+def get_step_2_section(nofo):
+    """
+    Retrieves the section that either contains 'Step 2' in its name,
+    or falls back to the section with order=2. If neither exist, returns None.
+    """
+    sections = nofo.sections.all()
+
+    # Try to get section containing "Step 2" (case-insensitive)
+    step_2_section = sections.filter(name__icontains="Step 2").first()
+
+    # If no match, try to get section with order=2
+    if not step_2_section:
+        step_2_section = sections.filter(order=2).first()
+
+    return step_2_section  # Returns None if nothing matches
+
+
 def _get_next_subsection(section, subsection, with_tag=False):
     """
     Recursively find the next subsection in the given section based on the order.

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -241,11 +241,19 @@
         <p>If you believe you are a good candidate for this funding opportunity, secure your <a href="https://sam.gov">SAM.gov</a> and <a href="https://grants.gov">Grants.gov</a> registrations now. If you are already registered, make sure your registrations are active and up-to-date.</p>
         <p class="section--before-you-begin--psuedo-header">SAM.gov registration (this can take several weeks)</p>
         <p>You must have an active account with SAM.gov. This includes having a Unique Entity Identifier (UEI).</p>
-        <a href="#step-2-get-ready-to-apply">See Step 2: Get Ready to Apply</a>
+        {% if step_2_section %}
+          <a href="#{{ step_2_section.html_id }}">See {{ step_2_section.name }}</a>
+        {% else %}
+          <p class="highlight-strong">STEP 2 SECTION MISSING</p>
+        {% endif %}
 
         <p class="section--before-you-begin--psuedo-header">Grants.gov registration (this can take several days)</p>
         <p>You must have an active Grants.gov registration. Doing so requires a Login.gov registration as well.</p>
-        <a href="#step-2-get-ready-to-apply">See Step 2: Get Ready to Apply</a>
+        {% if step_2_section %}
+          <a href="#{{ step_2_section.html_id }}">See {{ step_2_section.name }}</a>
+        {% else %}
+          <p class="highlight-strong">STEP 2 SECTION MISSING</p>
+        {% endif %}
       {% endif %}
 
       <p class="section--before-you-begin--psuedo-header">Apply by the application due date</p>

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -69,6 +69,7 @@ from .nofo import (
     find_same_or_higher_heading_levels_consecutive,
     get_cover_image,
     get_sections_from_soup,
+    get_step_2_section,
     get_subsections_from_sections,
     overwrite_nofo,
     parse_uploaded_file_as_html_string,
@@ -170,6 +171,8 @@ class NofosDetailView(DetailView):
         )
 
         context["nofo_cover_image"] = get_cover_image(self.object)
+
+        context["step_2_section"] = get_step_2_section(self.object)
 
         return context
 


### PR DESCRIPTION
## Summary

This PR fixes a bug (technically) where the step 2 links in the BYB page were hard coded. This meant that if there was a differently-named "Step 2", the links would break. 

NOW, we pull the Step 2 dynamically, and if we don't have one we show a big load highlighted error message that someone will notice before it goes to publish.

| before | after | no step 2
|--------|-------|-------|
|   before: hardcoded links     |  now: dynamic links     |  if no step 2: show warning message     |
|     <img width="715" alt="Screenshot 2025-03-11 at 11 52 40 AM" src="https://github.com/user-attachments/assets/240197e6-8d8d-48ad-96e8-8440246b75b5" />   |    <img width="715" alt="Screenshot 2025-03-11 at 11 53 15 AM" src="https://github.com/user-attachments/assets/9be5b890-c478-4e67-b791-758fe96a62c1" />   |  <img width="715" alt="Screenshot 2025-03-11 at 11 53 57 AM" src="https://github.com/user-attachments/assets/72be4186-e5cb-4cc6-9abc-8d8fcf594a78" />    |

