### PR TITLE
Fix newlines in image alt text, remove "Jump to a step", extend "live mode" timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Temporarily set the "Live mode" timeout to 90 minutes
 - Add rounded corners by default to all inline images
 - Allow empty sections
   - No longer creating a default empty subsection when a section is created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Remove "Jump to a step": we don't have links here anymore so they should go
 - Normalize whitespace for MS Word AI-generated alt text
 
 ## [2.8.0] - 2025-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Add rounded corners by default to all inline images
 - Allow empty sections
   - No longer creating a default empty subsection when a section is created
 
 ### Fixed
+
+- Normalize whitespace for MS Word AI-generated alt text
 
 ## [2.8.0] - 2025-03-12
 

--- a/bloom_nofos/bloom_nofos/static/shared.css
+++ b/bloom_nofos/bloom_nofos/static/shared.css
@@ -190,6 +190,12 @@
   background-color: var(--color--yellow);
 }
 
+.martor-preview img,
+.nofo-edit-table--subsection--body img,
+.section--content img {
+  border-radius: 10px;
+}
+
 /* List CSS */
 
 ol ol:not([type]):not(.usa-list--unstyled) {

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -566,7 +566,7 @@ div[role="heading"] {
 
 .header-nav {
   width: 100%;
-  height: 20mm;
+  height: 12mm;
 }
 
 .header-nav ol {
@@ -898,13 +898,6 @@ section.section .section--title-page::before {
 
 .section--title-page--header-nav {
   padding: 0mm 20mm;
-}
-
-.section--title-page--header-nav p {
-  font-size: 10pt;
-  font-weight: 700;
-  margin-bottom: 8px;
-  margin-top: 8px;
 }
 
 .section--title-page--header-nav a[aria-current] {

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
@@ -199,10 +199,6 @@ h4 {
 
 /* Section title page */
 
-.section--title-page .section--title-page--header-nav > p {
-  color: var(--color--black);
-}
-
 .section--title-page--header-nav li a {
   border-top: 4px solid var(--color--dhp-grey);
   color: var(--color--med-grey);

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-iod.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-iod.css
@@ -175,10 +175,6 @@ h4 {
 
 /* Section title page */
 
-.section--title-page .section--title-page--header-nav > p {
-  color: var(--color--iod-teal);
-}
-
 .section--title-page--header-nav li a {
   border-top: 4px solid var(--color--iod-grey);
   color: var(--color--iod-grey);

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
@@ -169,10 +169,6 @@ section.nofo--cover-page.nofo--cover-page--hero {
 
 /* Section title page */
 
-.section--title-page .section--title-page--header-nav > p {
-  color: var(--color--black);
-}
-
 .section--title-page--header-nav li a {
   border-top: 4px solid var(--color--white);
   color: var(--color--black);

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -231,8 +231,7 @@ section.before-you-begin {
 
 /* Section title page */
 
-.section--title-page .section--title-page--header-nav > ol,
-.section--title-page .section--title-page--header-nav > p {
+.section--title-page .section--title-page--header-nav > ol {
   margin-left: -5mm;
 }
 

--- a/bloom_nofos/bloom_nofos/utils.py
+++ b/bloom_nofos/bloom_nofos/utils.py
@@ -33,7 +33,7 @@ def cast_to_boolean(value_str):
 
 
 def is_docraptor_live_mode_active(last_updated):
-    # Check if the timestamp is more than 2 minutes old
+    # Check if the timestamp is more than 5 minutes old
     if last_updated and now() - last_updated < get_timedelta_for_docraptor_live_mode():
         return True
 
@@ -41,7 +41,7 @@ def is_docraptor_live_mode_active(last_updated):
 
 
 def get_timedelta_for_docraptor_live_mode():
-    return timedelta(minutes=5)
+    return timedelta(minutes=90)
 
 
 def parse_docraptor_ip_addresses(ip_string: str):

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -119,6 +119,7 @@ def process_nofo_html(soup, top_heading_level):
             file.write(str(soup))
 
     decompose_instructions_tables(soup)
+    normalize_whitespace_img_alt_text(soup)
     join_nested_lists(soup)
     add_strongs_to_soup(soup)
     preserve_bookmark_links(soup)
@@ -136,6 +137,13 @@ def process_nofo_html(soup, top_heading_level):
     preserve_bookmark_targets(soup)
 
     soup = add_em_to_de_minimis(soup)
+
+    for a in soup.find_all("a"):
+        print("a.text", a.text)
+
+    for img in soup.find_all("img"):
+        alt_text = img.get("alt", "No alt text")  # Get alt text, or use fallback
+        print("alt_text", repr(alt_text))
 
     return soup
 
@@ -2450,6 +2458,20 @@ def decompose_instructions_tables(soup):
                 or re.match(r".+-specific instructions", table_text_lowercase)
             ):
                 table.decompose()
+
+
+def normalize_whitespace_img_alt_text(soup):
+    """
+    This function mutates the soup!
+
+    Normalize whitespace in image alt text by replacing all occurrences
+    of double newlines (\n\n) with a single newline (\n).
+
+    :param soup: BeautifulSoup object to modify in place.
+    """
+    for img in soup.find_all("img"):
+        if img.has_attr("alt"):
+            img["alt"] = img["alt"].replace("\n\n", "\n")
 
 
 ###########################################################

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -287,7 +287,6 @@
       {% if section.has_section_page %}
         <div class="title-page section--title-page">
           <div class="header-nav section--title-page--header-nav">
-            <p>Jump to a step</p>
             <ol>
               {% spaceless %}
               {% with nofo.sections.all|dictsort:"order"|filter_breadcrumb_sections as breadcrumb_sections %}

--- a/bloom_nofos/nofos/tests/test_utils.py
+++ b/bloom_nofos/nofos/tests/test_utils.py
@@ -38,7 +38,7 @@ class CreateNofoAuditEventTests(TestCase):
     def test_valid_event_type_nofo_print_test(self):
         # Set DOCRAPTOR_LIVE_MODE to a past timestamp to simulate "test" mode
         with override_config(
-            DOCRAPTOR_LIVE_MODE=now() - timedelta(minutes=5, seconds=1)
+            DOCRAPTOR_LIVE_MODE=now() - timedelta(minutes=90, seconds=1)
         ):
             create_nofo_audit_event("nofo_print", self.nofo, self.user)
 


### PR DESCRIPTION
## Summary

This PR makes 4 changes so that we are ready for a demo later today.

1. Replace double newlines in alt text so that images render properly in markdown
2. Add rounded corners to inline images by default
3. Remove the "Jump to a step" line in section title pages
4. Extend timeout for "live mode" to 90 minutes

### 1. & 2. Replace double newlines in alt text + Rounded corners

When you import an image into Word, you get auto-created alt text like this:

```
A turtle in a tank.

AI-generated content may be incorrect.
```

Because there are 2 newlines in there, it breaks our markdown rendering, so we replace `\n\n` in image alt texts with `\n`.

Also add styling so that inline images have rounded corners.

| before | after |
|--------|-------|
|     <img width="835" alt="Screenshot 2025-03-13 at 12 04 50 PM" src="https://github.com/user-attachments/assets/2e8d3a88-dde4-47a2-83ec-24e3b21c2c0d" />   |  <img width="835" alt="Screenshot 2025-03-13 at 12 04 32 PM" src="https://github.com/user-attachments/assets/4d41452f-86be-4f10-b937-b5a5f781c52a" />     |


### 3. Remove the "Jump to a step" line in section title pages

Since we removed the clickable breadcrumb links (#214), they no longer function as links (you can't click them).

So we should have also removed the "Jump to step" line, because you can't jump to a step anymore.

Also modified the design to remove some of the top padding so that the breadcrumb links sit flush against the top of the section title page.

| before | after |
|--------|-------|
|  <img width="925" alt="Screenshot 2025-03-13 at 12 04 05 PM" src="https://github.com/user-attachments/assets/25055b38-55cd-4d68-a4a1-d0283a84f27a" />      |    <img width="925" alt="Screenshot 2025-03-13 at 12 03 41 PM" src="https://github.com/user-attachments/assets/5fdd9def-712f-4a80-8cfa-816a31ba7d62" />   |


## 4. Extend timeout for "live mode" to 90 minutes

We are doing a demo later and we don't want the "live mode" setting to revert, so we are extending the timeout temporarily to 90 minutes.
