### PR TITLE
Breadcrumb links now have a 5px top-border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning since version 1.0.0.
 
 - Temporarily set the "Live mode" timeout to 90 minutes
 - Add rounded corners by default to all inline images
+- Breadcrumb links now have a 5px top border
 - Allow empty sections
   - No longer creating a default empty subsection when a section is created
 

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -607,12 +607,13 @@ div[role="heading"] {
 }
 
 .header-nav--running-header {
+  height: 20mm;
   display: none;
   position: running(breadcrumbs);
 }
 
 .header-nav--running-header li a {
-  border-top: 4px solid var(--color--light-grey);
+  border-top: 5px solid var(--color--light-grey);
   color: var(--color--med-grey);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acf-white.css
@@ -130,7 +130,7 @@ h5 {
 /* Running header */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--acf-blue);
+  border-top-color: var(--color--acf-blue);
   color: var(--color--acf-blue);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acf.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acf.css
@@ -29,7 +29,7 @@
 /* Running header */
 
 .header-nav.header-nav--running-header li a {
-  border-top: 4px solid var(--color--light-grey);
+  border-top-color: var(--color--light-grey);
   color: var(--color--med-grey);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acl-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acl-white.css
@@ -126,7 +126,7 @@ h3 {
 /* Running header */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--acl-yellow);
+  border-top-color: var(--color--acl-yellow);
   color: var(--color--acl-blue);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-acl.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-acl.css
@@ -30,7 +30,7 @@ html {
 /* Running header */
 
 .header-nav.header-nav--running-header li a {
-  border-top: 4px solid var(--color--light-grey);
+  border-top-color: var(--color--light-grey);
   color: var(--color--med-grey);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-aspr.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-aspr.css
@@ -55,7 +55,7 @@ h6 {
 /* Running header */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--aspr-blue);
+  border-top-color: var(--color--aspr-blue);
   color: var(--color--aspr-blue);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
@@ -229,12 +229,12 @@ h4 {
 /* Section contents */
 
 .header-nav--running-header li a {
-  border-top: 4px solid var(--color--dhp-grey);
+  border-top-color: var(--color--dhp-grey);
   color: var(--color--med-grey);
 }
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--dhp-purple);
+  border-top-color: var(--color--dhp-purple);
   color: var(--color--dhp-purple);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-iod.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-iod.css
@@ -205,12 +205,12 @@ h4 {
 /* Section contents */
 
 .header-nav--running-header li a {
-  border-top: 4px solid var(--color--iod-grey);
+  border-top-color: var(--color--iod-grey);
   color: var(--color--iod-grey);
 }
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--iod-green);
+  border-top-color: var(--color--iod-green);
   color: var(--color--iod-teal);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc1.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc1.css
@@ -209,7 +209,7 @@ h4 {
 /* Section contents */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--ncipc-yellow);
+  border-top-color: var(--color--ncipc-yellow);
   color: var(--color--black);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc2.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc2.css
@@ -210,7 +210,7 @@ h4 {
 /* Section contents */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--ncipc-yellow);
+  border-top-color: var(--color--ncipc-yellow);
   color: var(--color--black);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
@@ -199,7 +199,7 @@ section.nofo--cover-page.nofo--cover-page--hero {
 /* Section contents */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--orr-red);
+  border-top-color: var(--color--orr-red);
   color: var(--color--black);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cdc.css
@@ -68,7 +68,7 @@ h6 {
 /* Running header */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--cdc-blue);
+  border-top-color: var(--color--cdc-blue);
   color: var(--color--cdc-blue);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-cms.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-cms.css
@@ -81,7 +81,7 @@ div[role="heading"] {
 /* Running header */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--cms-blue);
+  border-top-color: var(--color--cms-blue);
   color: var(--color--black);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-hrsa.css
@@ -44,17 +44,17 @@
 }
 
 .header-nav.header-nav--running-header li a {
-  border-top: 4px solid var(--color--light-grey);
+  border-top-color: var(--color--light-grey);
   color: var(--color--med-grey);
 }
 
 .header-nav.header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--hrsa-red);
+  border-top-color: var(--color--hrsa-red);
   color: var(--color--hrsa-red);
 }
 
 .section--title-page--header-nav a[aria-current] {
-  border-top: 4px solid var(--color--hrsa-blue);
+  border-top-color: var(--color--hrsa-blue);
 }
 
 /* Headings */

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs.css
@@ -63,7 +63,7 @@ div[role="heading"] {
 /* Running header */
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--ihs-blue);
+  border-top-color: var(--color--ihs-blue);
   color: var(--color--ihs-blue);
 }
 

--- a/bloom_nofos/bloom_nofos/static/theme-orientation-landscape.css
+++ b/bloom_nofos/bloom_nofos/static/theme-orientation-landscape.css
@@ -176,7 +176,7 @@ body[class^="landscape"] .grid-container {
 }
 
 .header-nav--running-header li a[aria-current] {
-  border-top: 4px solid var(--color--cdc-blue);
+  border-top-color: var(--color--cdc-blue);
   color: var(--color--cdc-blue);
 }
 


### PR DESCRIPTION
## Summary

This a very small PR that makes 2 styling updates:

- Make top border for breadcrumb links 5px
- Set the running header at 20mm height so they are flush against the top.

| before | after |
|--------|-------|
|   8mm gap in breadcrumb links     |  breadcrumb links are flush with the top of the page      |
|   <img width="1050" alt="Screenshot 2025-03-13 at 12 58 36 PM" src="https://github.com/user-attachments/assets/bdf7b066-1e63-4e4c-9959-afb6dadc28c3" />     |   <img width="1050" alt="Screenshot 2025-03-13 at 12 58 45 PM" src="https://github.com/user-attachments/assets/87278693-399f-4fe8-a5ad-3b5b651440b3" />    |

