### PR TITLE
Match the error and tooltip colours in nofo_edit view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning since version 1.0.0.
 - Allow page break styles within tables
 - Allow empty sections
   - No longer creating a default empty subsection when a section is created
+- Error message tooltips match colour blocks at the top on nofo_edit page
 
 ### Fixed
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -11,6 +11,8 @@
   --color--usa-error-bg-light: #f3e1e4;
   --color--usa-error-bg-dark: #8b0a03;
   --color--usa-error-bg-darker: #775540;
+  --color--usa-emergency-light: #ffe7d4;
+  --color--usa-emergency: #9c3d10;
   --color--usa-accent-warm: #fa9441;
   --color--usa-accent-warm-hover: #c05600;
 }
@@ -632,12 +634,57 @@ label.usa-label {
   font-weight: 400;
 }
 
+/* broken link error + tooltip */
 .nofo_edit .nofo-edit-table--subsection--body a.nofo_edit--broken-link,
+.nofo_edit
+  .nofo-edit-table--subsection--name.nofo_edit--heading-error
+  span.floating {
+  color: var(--color--usa-emergency);
+  background-color: var(--color--usa-emergency-light);
+}
+
+.nofo_edit
+  .nofo-edit-table--subsection--body
+  a.nofo_edit--broken-link
+  + .usa-tooltip__body,
+.nofo_edit
+  .nofo-edit-table--subsection--body
+  a.nofo_edit--broken-link
+  + .usa-tooltip__body--top {
+  background-color: var(--color--usa-emergency);
+}
+
+.nofo_edit
+  .nofo-edit-table--subsection--body
+  a.nofo_edit--broken-link
+  + .usa-tooltip__body--bottom:after {
+  border-bottom-color: var(--color--usa-emergency);
+}
+
+/* heading  error + tooltip */
 .nofo_edit
   .nofo-edit-table--subsection--name.nofo_edit--heading-error
   span.floating {
   color: var(--color--usa-error-message);
   background-color: var(--color--usa-error-bg-light);
+}
+
+.nofo_edit
+  .nofo-edit-table--subsection--name.nofo_edit--heading-error
+  span.floating
+  .usa-tooltip__body,
+.nofo_edit
+  .nofo-edit-table--subsection--name.nofo_edit--heading-error
+  span.floating
+  .usa-tooltip__body--top {
+  background-color: var(--color--usa-error-bg-dark);
+}
+
+.nofo_edit
+  .nofo-edit-table--subsection--name.nofo_edit--heading-error
+  span.floating
+  .usa-tooltip__body--bottom:after {
+  border-bottom-color: var(--color--usa-error-bg-dark);
 }
 
 .nofo_edit


### PR DESCRIPTION
## Summary

We have some colour blocks at the top for broken links, heading errors, and h7s.

The h7s aren't really errors, but the other two are like: "hey, go fix this".

One of the feedback comments was that we should match the tooltip colours with the colour blocks that we use for the errors.

This isn't really a huge deal, but it's also an easy fix to make, so why not just do it?

### Screenshots

#### error message for broken links 

| before | after |
|--------|-------|
|   <img width="211" alt="Screenshot 2025-03-15 at 5 24 00 PM" src="https://github.com/user-attachments/assets/61c5a634-3613-4310-a6b9-921f849ae042" />     |   <img width="211" alt="Screenshot 2025-03-15 at 5 23 16 PM" src="https://github.com/user-attachments/assets/ec1656c3-952f-49dd-88c3-0cb082561179" />    |

#### error message for incorrectly nested headers

 
| before | after |
|--------|-------|
|   <img width="273" alt="Screenshot 2025-03-15 at 5 24 24 PM" src="https://github.com/user-attachments/assets/a76e1892-54d2-4485-99b1-013a91689b06" />     |    <img width="273" alt="Screenshot 2025-03-15 at 5 24 48 PM" src="https://github.com/user-attachments/assets/773cd602-f5f9-4b73-a45b-6d77155ea9f5" />   |

