### PR TITLE
"Live mode" timeout is 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- "Live mode" timeout is 5 minutes
+
 ### Fixed
 
 ## [2.9.0] - 2025-03-18

--- a/bloom_nofos/bloom_nofos/utils.py
+++ b/bloom_nofos/bloom_nofos/utils.py
@@ -41,7 +41,7 @@ def is_docraptor_live_mode_active(last_updated):
 
 
 def get_timedelta_for_docraptor_live_mode():
-    return timedelta(minutes=90)
+    return timedelta(minutes=5)
 
 
 def parse_docraptor_ip_addresses(ip_string: str):

--- a/bloom_nofos/nofos/tests/test_utils.py
+++ b/bloom_nofos/nofos/tests/test_utils.py
@@ -38,7 +38,7 @@ class CreateNofoAuditEventTests(TestCase):
     def test_valid_event_type_nofo_print_test(self):
         # Set DOCRAPTOR_LIVE_MODE to a past timestamp to simulate "test" mode
         with override_config(
-            DOCRAPTOR_LIVE_MODE=now() - timedelta(minutes=90, seconds=1)
+            DOCRAPTOR_LIVE_MODE=now() - timedelta(minutes=5, seconds=1)
         ):
             create_nofo_audit_event("nofo_print", self.nofo, self.user)
 


### PR DESCRIPTION
## Summary

This was extended in order to not revert during a demo but now the demo is over.