### PR TITLE
Add a tooltip to the callout box emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Added a tooltip to the box emoji that explains the subsection is a callout box
+
 ### Changed
 
 - "Live mode" timeout is 5 minutes
@@ -20,7 +22,7 @@ Versioning since version 1.0.0.
 ### Added
 
 - Reimporting a NOFO saves a past revision of that NOFO from now on
-  - We don't expose this in the UI yet, but it is now IMPOSSIBLE to wipe out your past NOFO by reimporting another NOFO over it.
+  - We don't expose this in the UI yet, but it is now IMPOSSIBLE to wipe out your past NOFO by reimporting another NOFO over it
 
 ### Changed
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -484,7 +484,7 @@ Edit “{{ nofo|nofo_name }}”
           <td class="nofo-edit-table--subsection--callout-box">
             {% if subsection.callout_box %}
               <span class="floating">
-                <span role="img" aria-label="Callout box" title="Callout box">📦</span>
+                <span role="img" aria-label="Callout box" title="This subsection is a callout box" class="usa-tooltip" data-position="bottom">📦</span>
               </span>
             {% endif %}
           </td>


### PR DESCRIPTION
## Summary

This PR adds a tooltip to the callout box emoji that says "This subsection is a callout box".

Very simple. 

Here's a screenshot:

<img width="700" alt="Screenshot 2025-03-18 at 12 01 24 PM" src="https://github.com/user-attachments/assets/734177cc-c6b6-4652-8870-7ee5effd56f2" />

---

And here is the USWDS page that shows how tooltips work: https://designsystem.digital.gov/components/tooltip/

Merging this PR closes #225 
