### PR TITLE
Automatically change "Announcement type/version" to "Modified"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- "Add modifications" now finds all instances of "Announcement type: New" and changes them to say "Announcement type: Modified"
+
 ### Fixed
 
 ## [2.10.0] - 2025-03-19

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2585,3 +2585,36 @@ def add_final_subsection_to_step_3(sections):
 
             # Exit after adding new subsection
             break
+
+
+def modifications_update_announcement_text(nofo):
+    """
+    Update announcement text in all subsection bodies of a given NOFO.
+    Usually this is just in 1 subsection ("Key facts"), but I guess it could be in others.
+
+    - Looks for "Announcement version: New" or "Announcement type: New" (case insensitive).
+    - Replaces them with "Announcement version: Modified" or "Announcement type: Modified".
+    - Mutates the NOFO object in place.
+
+    :param nofo: The NOFO object containing sections and subsections.
+    """
+    patterns = [
+        (
+            re.compile(r"Announcement version:\s*New", re.IGNORECASE),
+            "Announcement version: Modified",
+        ),
+        (
+            re.compile(r"Announcement type:\s*New", re.IGNORECASE),
+            "Announcement type: Modified",
+        ),
+    ]
+
+    for section in nofo.sections.all():
+        for subsection in section.subsections.all():
+            updated_body = subsection.body
+            for pattern, replacement in patterns:
+                updated_body = pattern.sub(replacement, updated_body)
+
+            if updated_body != subsection.body:
+                subsection.body = updated_body
+                subsection.save()

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -75,6 +75,7 @@ from .nofo import (
     get_sections_from_soup,
     get_step_2_section,
     get_subsections_from_sections,
+    modifications_update_announcement_text,
     overwrite_nofo,
     parse_uploaded_file_as_html_string,
     preserve_subsection_metadata,
@@ -783,6 +784,8 @@ class NofoEditModificationView(
 
         nofo.modifications = parsed_date
         nofo.save()
+
+        modifications_update_announcement_text(nofo)
 
         # Check if a "Modifications" section exists, create it if needed
         modifications_section, created = nofo.sections.get_or_create(


### PR DESCRIPTION
## Summary 

When you "add modifications" to a NOFO, there is now a new step:

- loop through all subsections
- look for "Announcement type: New" or "Announcement version: New"
- Update to "Announcement type/version: Modified"

Note that it also happens on every save of the NOFO modification date but like 🤷.

This is in response to our meeting with HRSA this morning. Reduces the chance of user error.

This is the section where this announcement type is in most NOFOs: 👇 

<img width="282" alt="Screenshot 2025-03-20 at 1 16 55 PM" src="https://github.com/user-attachments/assets/6c235ea3-890a-4086-a46e-4f74443094b6" />




