### PR TITLE
Show previous heading level on new subsection page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Versioning since version 1.0.0.
 
 - Added initial version of RandyReport on account pages
   - The name will have to change for sure
+- Add default column classes to HTML tables on import
+  - Previously, it was just markdown tables
+- Show previous heading level on "create subsection" page
 
 ### Changed
 
-### Migrations
+### Fixed
 
 ## [2.11.0] - 2025-03-21
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -1131,6 +1131,31 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   font-size: 1rem;
 }
 
+/* create page */
+
+.subsection_create .previous-subsection-widget {
+  border: 2px solid #c9c9c9;
+  border-radius: 0.25rem;
+  padding: 8px 12px;
+  max-width: 450px;
+}
+
+.subsection_create .previous-subsection-widget p {
+  margin-bottom: 4px;
+}
+
+.previous-subsection--section {
+  font-size: 1rem;
+}
+.previous-subsection--subsection {
+  font-size: 1.15rem;
+  margin-bottom: 0;
+}
+
+.previous-subsection--tag {
+  font-variant: small-caps;
+}
+
 /* compare page */
 
 .usa-alert--warning.usa-alert--alpha .usa-alert__body {

--- a/bloom_nofos/nofos/templates/nofos/subsection_create.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_create.html
@@ -2,7 +2,7 @@
 {% load static nofo_name input_type get_value_or_none whitespaceless %}
 
 {% block title %}
-  Subsection: {% if subsection.name %}{{ subsection.name }}{% else %}(#{{ subsection.order }}){% endif %}
+  New subsection
 {% endblock %}
 
 {% block css %}
@@ -26,6 +26,21 @@
   
   <p>Create a new subsection after {% if prev_subsection.name %}“{{ prev_subsection.name }}”{% else %}(#{{ prev_subsection.order }}){% endif %} in “{{ prev_subsection.section.name }}”.</p>
 
+  {% if prev_subsection_with_tag %}
+  <h2 class="font-serif-md margin-top-4">Previous subsection{% if prev_subsection_with_tag.name != prev_subsection.name %} with a heading{% endif %}</h2>
+  <div class="previous-subsection-widget">
+    <p class="previous-subsection--section text-base-dark">{{ prev_subsection_with_tag.section.name }}</p>
+    <p class="previous-subsection--subsection">
+      <a href="{% url 'nofos:subsection_edit' nofo.id prev_subsection_with_tag.section.id prev_subsection_with_tag.id %}" class="usa-link usa-link--external" target="blank" title="{{ prev_subsection_with_tag.name }} (Opens in a new tab)">
+        {{ prev_subsection_with_tag.name }}
+        (<span class="previous-subsection--tag">{{ prev_subsection_with_tag.tag }}</span>)
+      </a>
+    </p>
+  </div>
+  {% endif %}
+
+  <h2 class="font-serif-lg margin-top-4 margin-bottom-0">Your new subsection</h2>
+
   <form class="form" method="post">
     {% csrf_token %}
     <fieldset class="usa-fieldset">
@@ -48,7 +63,7 @@
       <div class="form-group width-mobile">
         <label class="usa-label" for="tag">Heading level</label>
         <div class="usa-hint" id="tag--hint-1">
-          Required if name exists
+          Required if name exists. {% if prev_subsection_with_tag %}Last heading: <span class="previous-subsection--tag">{{ prev_subsection_with_tag.tag }}</span>.{% endif %}
         </div>
         {% if form.errors.tag %}
           <div class="usa-error-message" id="tag--error">

--- a/bloom_nofos/nofos/tests/test_subsection_create.py
+++ b/bloom_nofos/nofos/tests/test_subsection_create.py
@@ -1,0 +1,100 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from nofos.models import Nofo, Section, Subsection
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class NofoSubsectionCreateViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(email="test@example.com", password="testpass123")
+
+        self.nofo = Nofo.objects.create(
+            title="Test NOFO", short_name="test", group="bloom", opdiv="ACF"
+        )
+        self.section = Section.objects.create(nofo=self.nofo, name="Section", order=1)
+
+        self.sub_with_tag = Subsection.objects.create(
+            section=self.section, name="Subsection 1", order=1, tag="h2"
+        )
+        # subsection 2 does not have a name or a tag
+        self.sub_no_tag = Subsection.objects.create(
+            section=self.section, order=2, body="Hello, I am subsection 2"
+        )
+
+    def test_missing_prev_subsection_returns_400(self):
+        url = reverse(
+            "nofos:subsection_create",
+            kwargs={
+                "pk": self.nofo.id,
+                "section_pk": self.nofo.sections.first().id,
+            },
+        )
+
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_valid_get_request_renders_template(self):
+        url = reverse(
+            "nofos:subsection_create",
+            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
+        )
+        url += f"?prev_subsection={self.sub_with_tag.id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "nofos/subsection_create.html")
+
+    def test_finds_previous_subsection(self):
+        url = reverse(
+            "nofos:subsection_create",
+            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
+        )
+        url += f"?prev_subsection={self.sub_with_tag.id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        # includes "with a heading"
+        self.assertNotContains(response, "Previous subsection with a heading")
+        self.assertContains(response, "Subsection 1")  # Subsection 1 is previous
+
+    def test_finds_previous_subsection_with_tag(self):
+        url = reverse(
+            "nofos:subsection_create",
+            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
+        )
+        url += f"?prev_subsection={self.sub_no_tag.id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        # includes "with a heading"
+        self.assertContains(response, "Previous subsection with a heading")
+        self.assertContains(response, "Subsection 1")  # Subsection 1 is previous
+
+    def test_successfully_creates_subsection(self):
+        url = reverse(
+            "nofos:subsection_create",
+            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
+        )
+        url += f"?prev_subsection={self.sub_with_tag.id}"
+        response = self.client.post(
+            url,
+            {
+                "name": "New Subsection",
+                "tag": "h3",
+                "body": "Test content",
+                "html_class": "",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Created new subsection:")
+        self.assertEqual(Subsection.objects.filter(section=self.section).count(), 3)

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1087,6 +1087,16 @@ class NofoSubsectionCreateView(
         # Fetch previous subsection
         self.prev_subsection = get_object_or_404(Subsection, pk=self.prev_subsection_id)
 
+        # loop until you find the next previous subsection with a tag
+        self.prev_subsection_with_tag = self.prev_subsection
+        while (
+            self.prev_subsection_with_tag is not None
+            and not self.prev_subsection_with_tag.tag
+        ):
+            self.prev_subsection_with_tag = (
+                self.prev_subsection_with_tag.get_previous_subsection()
+            )
+
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
@@ -1124,6 +1134,7 @@ class NofoSubsectionCreateView(
         context["subsection"] = self.object
         context["nofo"] = self.nofo
         context["prev_subsection"] = self.prev_subsection
+        context["prev_subsection_with_tag"] = self.prev_subsection_with_tag
         return context
 
 


### PR DESCRIPTION
## Summary

This PR shows the previous subsection (and heading level) on the "new subsection" page.

This came from a ticket that we got in our feedback sessions, which said:

> From the Add Subsection area, it would very helpful to have which Heading level it currently is, we have to toggle back and while we are focusing on other area’s i forget.

It is a smart point and not that complicated to build, so I built it. 

There is a slight complication, where if the previous subsection does not have a title, then we have to find the one before that (could loop forever), but in practice, this would almost always just be the previous to the previous one. So we always make sure to show the heading level.

### Screenshots 

| before | after |
|--------|-------|
| cannot tell what previous heading level was       |   show previous subsection with tag. also show tag in hint text.   |
|   <img width="1472" alt="Screenshot 2025-03-26 at 3 48 39 PM" src="https://github.com/user-attachments/assets/e9a061d2-ec79-4249-9085-7c334c52cd67" />     |   <img width="1472" alt="Screenshot 2025-03-26 at 3 46 57 PM" src="https://github.com/user-attachments/assets/3202274a-d618-4271-bc31-4e220cbd3789" />    |

