### PR TITLE
Revert "Live mode" to 5 mins again

### DIFF
--- a/bloom_nofos/bloom_nofos/utils.py
+++ b/bloom_nofos/bloom_nofos/utils.py
@@ -41,7 +41,7 @@ def is_docraptor_live_mode_active(last_updated):
 
 
 def get_timedelta_for_docraptor_live_mode():
-    return timedelta(minutes=90)
+    return timedelta(minutes=5)
 
 
 def parse_docraptor_ip_addresses(ip_string: str):

--- a/bloom_nofos/nofos/tests/test_utils.py
+++ b/bloom_nofos/nofos/tests/test_utils.py
@@ -38,7 +38,7 @@ class CreateNofoAuditEventTests(TestCase):
     def test_valid_event_type_nofo_print_test(self):
         # Set DOCRAPTOR_LIVE_MODE to a past timestamp to simulate "test" mode
         with override_config(
-            DOCRAPTOR_LIVE_MODE=now() - timedelta(minutes=90, seconds=1)
+            DOCRAPTOR_LIVE_MODE=now() - timedelta(minutes=5, seconds=1)
         ):
             create_nofo_audit_event("nofo_print", self.nofo, self.user)
 


### PR DESCRIPTION
## Summary

Small PR that sets our "Live mode" timeout (back) to 5 mins. 

This reverts the change made in #271 

The presentation is over, so now back to normal.