### PR TITLE
Scroll to the section you have just edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- When you save a subsection, the nofo_edit page loads at the top of that subsection
+  - Same when you add a new subsection
+  - Same with the "back" link
 - Change index page to show 4 groupings: in progress, published, paused, cancelled
   - Remove "all", since probably nobody uses this
 - "Add modifications" now finds all instances of "Announcement type: New" and changes them to say "Announcement type: Modified"

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -17,7 +17,7 @@
   --color--usa-accent-warm-hover: #c05600;
 }
 
-html {
+html:not(.html--nofo_edit) {
   scroll-behavior: smooth;
 }
 

--- a/bloom_nofos/bloom_nofos/templates/base_barebones.html
+++ b/bloom_nofos/bloom_nofos/templates/base_barebones.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 {% load static djversion_tags %}
-<html lang="en">
+<html lang="en" class="{% block html_class %}{% endblock %}">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -5,6 +5,8 @@
 Edit “{{ nofo|nofo_name }}”
 {% endblock %}
 
+{% block html_class %}html--nofo_edit{% endblock %}
+
 {% block body_class %}nofo_edit nofo_status--{{ nofo.status }}{% if nofo.modifications %} nofo--modifications{% endif %}{% if nofo.archived %} nofo--archived{% endif %}{% endblock %}
 
 {% block content %}
@@ -594,6 +596,10 @@ Edit “{{ nofo|nofo_name }}”
             }
         });
     });
+  });
+
+  window.addEventListener('load', function () {
+    document.documentElement.style.scrollBehavior = 'smooth';
   });
 </script>
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/subsection_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_edit.html
@@ -17,7 +17,7 @@
 {% block content %}
   {% with nofo|nofo_name as nofo_name_str %}
     <div class="back-link font-body-md margin-bottom-105">
-      <a href="{% url 'nofos:nofo_edit' nofo.id %}">Edit “{{ nofo_name_str }}”</a>
+      <a href="{% url 'nofos:nofo_edit' nofo.id %}#{{ subsection.html_id }}">Edit “{{ nofo_name_str }}”</a>
     </div>
     <div class="subsection_edit--header">
       <h1 class="font-heading-xl margin-y-0">Subsection: {% if subsection.name %}{{ subsection.name }}{% else %}(#{{ subsection.order }}){% endif %}</h1>

--- a/bloom_nofos/nofos/tests/test_subsection_create.py
+++ b/bloom_nofos/nofos/tests/test_subsection_create.py
@@ -1,7 +1,7 @@
-from django.test import TestCase, Client
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
 from django.urls import reverse
 from nofos.models import Nofo, Section, Subsection
-from django.contrib.auth import get_user_model
 
 User = get_user_model()
 

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1179,7 +1179,8 @@ class NofoSubsectionEditView(
                 self.object.section.name,
             ),
         )
-        return redirect("nofos:nofo_edit", pk=self.nofo.id)
+        url = reverse_lazy("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
+        return redirect("{}#{}".format(url, self.object.html_id))
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1127,7 +1127,8 @@ class NofoSubsectionCreateView(
         return response
 
     def get_success_url(self):
-        return reverse_lazy("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
+        url = reverse_lazy("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
+        return "{}#{}".format(url, self.object.html_id)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/bloom_nofos/users/views.py
+++ b/bloom_nofos/users/views.py
@@ -1,22 +1,16 @@
 import csv
-import json
-from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.forms import SetPasswordForm
 from django.contrib.auth.views import PasswordChangeView
-from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
-from django.utils.timezone import make_aware
 from django.views import View
 from django.views.decorators.http import require_http_methods
 from django.views.generic import DetailView
-from easyaudit.models import CRUDEvent
-from nofos.models import Nofo, Subsection
 
 from .auth.login_gov import LoginGovClient
 from .exports import export_nofo_report


### PR DESCRIPTION
## Summary

This PR is a small in terms of code, but larger in terms of modifying how editing works in the NOFO Builder. 

It changes the "Save" and "Back" actions when editing a subsection to load the NOFO edit page at the top of the current subsection, not at the top of the page. There are a couple of cards about this that showed up in the retro:

> After you edit and save a subsection, stay in the section area you're in, instead of directing you to the top of the document each time.

> I’d like to stay in the area of section I’m working on after I hit the ‘save’ button. Now it jumps to the top of the document.

Also, it does the same thing when you add a new subsection:

> I wish the “add subsection” button, when clicked, would land me in the same spot as where i clicked it (instead of me having to re-find that spot again)

This could be a jarring change, so I am ready to change it back if people don't like it. But there is enough demand for it that maybe everyone wants it and there's no issue here.

### Screenshot

Example of how using the "save" action and the "back" link work now.

![Screen Recording 2025-03-28 at 12 02 51 PM](https://github.com/user-attachments/assets/2c68cddf-5868-4424-9752-6f3f1d4c2eda)
