### PR TITLE
Change cover page "modifications" message for HRSA NOFOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Change cover page "modifications" message for HRSA NOFOs
+  - "Modified [date]. Review updates." → "Last modifed [date]. Review updates."
+
 ### Fixed
 
 ## [2.12.0] - 2025-03-31

--- a/bloom_nofos/bloom_nofos/static/theme-base.css
+++ b/bloom_nofos/bloom_nofos/static/theme-base.css
@@ -978,6 +978,7 @@ section.section .section--title-page::before {
 }
 
 .nofo--cover-page--callout-box {
+  display: inline-block;
   margin-right: -15px; /* same as right margin, right-align text */
 }
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -325,7 +325,9 @@ Edit “{{ nofo|nofo_name }}”
     {% if nofo.modifications %}
       <tr>
         <th scope="row">Modification date</th>
-        <td class="nofo-modifications-message">“Modified {{ nofo.modifications|date:"F j, Y" }}. <a class="text-base" href="#modifications">Review updates</a>.”</td>
+        <td class="nofo-modifications-message">
+          “Last modified {{ nofo.modifications|date:"F j, Y" }}. <a class="text-base" href="#modifications">Review updates</a>.”
+        </td>
         <td><a href="{% url 'nofos:nofo_modifications' nofo.id %}">Edit<span class="usa-sr-only"> modification date</span></a></td>
       </tr>
     {% endif %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit_modifications.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit_modifications.html
@@ -19,7 +19,7 @@
 
   <p>The current modification message is:</p>
 
-  <blockquote>Modified {{ nofo.modifications|date:"F j, Y" }}. <a class="text-base" href="#modifications">Review updates</a>.</blockquote>
+  <blockquote>Last modified {{ nofo.modifications|date:"F j, Y" }}. <a class="text-base" href="#modifications">Review updates</a>.</blockquote>
 
   <br>
   

--- a/bloom_nofos/nofos/templates/nofos/nofo_view.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_view.html
@@ -117,7 +117,9 @@
         {% if nofo.modifications %}
         <div class="callout-box nofo--cover-page--callout-box">
           <div class="callout-box--contents">
-            <p><strong>Modified {{ nofo.modifications|date:"F j, Y" }}. <a href="#section--modifications">Review updates</a>.</strong></p>
+            <p>
+              <strong>Last modified {{ nofo.modifications|date:"F j, Y" }}. <a href="#section--modifications">Review updates</a>.</strong>
+            </p>
           </div>
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary

This is a small PR that changes the message on the front cover of the NOFO.

Previous: `Modified [date]. Review updates.`
New: `Last modified [date]. Review updates.`

It is slightly more explicit than before, I think.

| before | after |
|--------|-------|
|   <img width="331" alt="Screenshot 2025-04-03 at 11 04 31 AM" src="https://github.com/user-attachments/assets/d862e57a-789f-4905-9100-024c5c2811eb" />     |   <img width="331" alt="Screenshot 2025-04-03 at 11 04 09 AM" src="https://github.com/user-attachments/assets/e5229adf-f4c6-4f03-946d-3df596b8067e" />    |

