### PR TITLE
Show audit events since modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Show audit events since modifying a NOFO on its own page
+  - Also provide a markdown table that people can copy and paste
+- Show the modification date in the subsection edit page for the mods table
+- Add links in nofo_edit page "actions" box to new audit page and mods date
 - Added initial version of RandyReport on account pages
   - The name will have to change for sure
 - Add default column classes to HTML tables on import

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -166,6 +166,26 @@ details > summary > span:hover {
 label.usa-label {
   margin-bottom: 0.25rem;
 }
+
+.outline-box {
+  border: 2px solid #c9c9c9;
+  border-radius: 0.25rem;
+  padding: 8px 12px;
+  max-width: 450px;
+}
+
+.outline-box p:not(:last-of-type) {
+  margin-bottom: 4px;
+}
+
+.outline-box .outline-box--heading {
+  font-size: 1rem;
+}
+.outline-box .outline-box--content {
+  font-size: 1.15rem;
+  margin-bottom: 0;
+}
+
 /* Link check page */
 
 .pre--code-box {
@@ -1129,31 +1149,6 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 .usa-error-message {
   font-size: 1rem;
-}
-
-/* create page */
-
-.subsection_create .previous-subsection-widget {
-  border: 2px solid #c9c9c9;
-  border-radius: 0.25rem;
-  padding: 8px 12px;
-  max-width: 450px;
-}
-
-.subsection_create .previous-subsection-widget p {
-  margin-bottom: 4px;
-}
-
-.previous-subsection--section {
-  font-size: 1rem;
-}
-.previous-subsection--subsection {
-  font-size: 1.15rem;
-  margin-bottom: 0;
-}
-
-.previous-subsection--tag {
-  font-variant: small-caps;
 }
 
 /* compare page */

--- a/bloom_nofos/nofos/audits.py
+++ b/bloom_nofos/nofos/audits.py
@@ -31,6 +31,70 @@ def deduplicate_audit_events_by_day_and_object(events):
     return list(deduplicated.values())
 
 
+def format_audit_event(event):
+    """
+    Takes a CRUDEvent and returns a formatted dictionary for display in the UI.
+    Includes enhanced labels and object details.
+    """
+    event_details = {
+        "event_type": event.get_event_type_display(),
+        "object_type": event.content_type.model.title(),
+        "object_description": event.object_repr,
+        "user": event.user,
+        "timestamp": event.datetime,
+        "raw_event": event,
+    }
+
+    # Get html_id if it's available (safe fallback)
+    try:
+        event_details["object_html_id"] = (
+            json.loads(event.object_json_repr)[0].get("fields", {}).get("html_id", "")
+        )
+    except Exception:
+        event_details["object_html_id"] = ""
+
+    # Improve object description for subsection edits
+    if event.content_type.model == "subsection":
+        try:
+            subsection = Subsection.objects.get(id=event.object_id)
+            name = subsection.name or "#{}".format(subsection.order)
+            event_details["object_description"] = f"{subsection.section.name} - {name}"
+        except Subsection.DoesNotExist:
+            pass
+
+    # Handle custom audit events
+    if event.changed_fields:
+        try:
+            changed_fields = json.loads(event.changed_fields)
+
+            if isinstance(changed_fields, dict):
+                # Handle custom actions
+                if "action" in changed_fields:
+                    action = changed_fields["action"]
+                    if action == "nofo_import":
+                        event_details["event_type"] = "NOFO Imported"
+                    elif action == "nofo_print":
+                        event_details["event_type"] = "NOFO Printed"
+                        if "print_mode" in changed_fields:
+                            event_details[
+                                "event_type"
+                            ] += f" ({changed_fields['print_mode'][0]} mode)"
+                    elif action == "nofo_reimport":
+                        event_details["event_type"] = "NOFO Re-imported"
+
+                # Improve object description for Nofo field changes
+                elif event.content_type.model == "nofo":
+                    field_name = next(iter(changed_fields.keys()))
+                    formatted_field = " ".join(
+                        word.title() for word in field_name.split("_")
+                    )
+                    event_details["object_description"] = formatted_field
+        except Exception:
+            pass
+
+    return event_details
+
+
 def get_audit_events_for_nofo(nofo, reverse=True):
     """
     Return all audit events related to the given NOFO: the NOFO object,

--- a/bloom_nofos/nofos/audits.py
+++ b/bloom_nofos/nofos/audits.py
@@ -1,8 +1,8 @@
 import json
 from collections import OrderedDict
 
-
 from easyaudit.models import CRUDEvent
+
 from .models import Subsection
 
 

--- a/bloom_nofos/nofos/audits.py
+++ b/bloom_nofos/nofos/audits.py
@@ -1,6 +1,34 @@
 import json
+from collections import OrderedDict
+
+
 from easyaudit.models import CRUDEvent
 from .models import Subsection
+
+
+def deduplicate_audit_events_by_day_and_object(events):
+    """
+    Deduplicate audit events so that only the most recent event
+    for a given object (type + description) on a given day is kept.
+
+    Args:
+        events (list of dict): A list of audit event dictionaries, each with
+        'object_type', 'object_description', and 'timestamp' keys.
+
+    Returns:
+        list: Deduplicated list of events, keeping the latest per object per day.
+    """
+    deduplicated = OrderedDict()
+
+    for event in events:
+        key = (
+            event["object_type"],
+            event["object_description"],
+            event["timestamp"].date(),  # Use only the date
+        )
+        deduplicated[key] = event  # Overwrites earlier events on same object + day
+
+    return list(deduplicated.values())
 
 
 def get_audit_events_for_nofo(nofo, reverse=True):

--- a/bloom_nofos/nofos/audits.py
+++ b/bloom_nofos/nofos/audits.py
@@ -1,0 +1,55 @@
+import json
+from easyaudit.models import CRUDEvent
+from .models import Subsection
+
+
+def get_audit_events_for_nofo(nofo, reverse=True):
+    """
+    Return all audit events related to the given NOFO: the NOFO object,
+    its sections, and its subsections.
+    """
+
+    def _filter_updated_events(events):
+        """Remove events where only the 'updated' field changed."""
+        filtered_events = []
+        for event in events:
+            if event.event_type != CRUDEvent.UPDATE:
+                filtered_events.append(event)
+                continue
+            try:
+                changed = json.loads(event.changed_fields or "{}")
+                if not (
+                    changed.keys() == {"updated"} or list(changed.keys()) == ["updated"]
+                ):
+                    filtered_events.append(event)
+            except Exception:
+                filtered_events.append(event)
+        return filtered_events
+
+    # Get audit events for the NOFO
+    nofo_events = CRUDEvent.objects.filter(
+        object_id=nofo.id, content_type__model="nofo"
+    )
+    nofo_events = _filter_updated_events(nofo_events)
+
+    # Get audit events for Sections
+    section_ids = list(nofo.sections.values_list("id", flat=True))
+    section_events = CRUDEvent.objects.filter(
+        object_id__in=[str(sid) for sid in section_ids],
+        content_type__model="section",
+    )
+
+    # Get audit events for Subsections
+    subsection_ids = list(
+        Subsection.objects.filter(section__nofo=nofo).values_list("id", flat=True)
+    )
+    subsection_events = CRUDEvent.objects.filter(
+        object_id__in=[str(sid) for sid in subsection_ids],
+        content_type__model="subsection",
+    )
+
+    return sorted(
+        list(nofo_events) + list(section_events) + list(subsection_events),
+        key=lambda e: e.datetime,
+        reverse=reverse,
+    )

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit.html
@@ -88,12 +88,9 @@ Edit “{{ nofo|nofo_name }}”
       NOFO is ‘<a href="{% url 'nofos:nofo_edit_status' nofo.id %}">{{ nofo.get_status_display }}</a>’ with modifications.
     </h2>
     <div class="usa-summary-box__text">
-      <p>This NOFO has been modified since being published</a>.</p>
-      <p>You can edit the content of this NOFO, but be sure to update the “<a href="#modifications">Modifications</a>” section at the end of this NOFO with:</p>
-      <ul class="usa-list">
-        <li>A description of the changes you made</li>
-        <li>The date you made those changes</li>
-      </ul>
+      <p>Make sure to update the “<a href="#modifications">Modifications</a>” section at the end of this NOFO with the changes you’ve made since publication.</p>
+      <p><a href="{% url 'nofos:nofo_history_modifications' nofo.id %}">See changes made since this NOFO was modified</a>.</p>
+      <p>Last modification date on cover page: <a href="{% url 'nofos:nofo_modifications' nofo.id %}">{{ nofo.modifications|date:"F j, Y" }}</a>.</p>
     </div>
   </div>
 </div>

--- a/bloom_nofos/nofos/templates/nofos/nofo_history.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history.html
@@ -50,6 +50,9 @@
   <caption>
     <div>
       <h2 class="margin-bottom-0">Latest Changes</h2>
+      {% if nofo.modifications %}
+        <p>You can also see <a href="{% url 'nofos:nofo_history_modifications' nofo.id %}">all updates since this NOFO was modified</a>.</p>
+      {% endif %}
     </div>
   </caption>
   <thead>

--- a/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
@@ -58,12 +58,8 @@
     {% endif %}
 
   {% else %}
-    <div class="usa-alert usa-alert--info">
-      <div class="usa-alert__body">
-        <p class="usa-alert__text">
-          This NOFO has no modification date set. No modification history available.
-        </p>
-      </div>
-    </div>
+    <p>
+      This NOFO has no modification date set. No modification history available.
+    </p>
   {% endif %}
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
@@ -14,8 +14,8 @@
   {% endwith %}
 
   {% if modification_date %}
-    <p class="text-base margin-bottom-4">
-      Showing all changes made <strong>after {{ modification_date|localtime|date:"F j, Y, g:i a" }}</strong>.
+    <p class="margin-bottom-4">
+      Showing all changes made since adding modifications on <strong>{{ modification_date|localtime|date:"F j, Y, g:i a" }}</strong>
     </p>
 
     {% if modification_events %}
@@ -26,13 +26,11 @@
               <strong>{{ event.event_type }}</strong>
             </div>
             <div>
-              {{ event.object_type }}: {{ event.object_description }}
+              ({{ event.object_type }}) {{ event.object_description }}
             </div>
-            <div class="text-base text-gray-700">
+            <div class="text-base">
               {% timezone "America/New_York" %}
-                <td>
-                  {{ event.timestamp|date:'F j' }}, {{ event.timestamp|date:'g:i A' }}
-                </td>
+                {{ event.timestamp|date:'F j' }}, {{ event.timestamp|date:'g:i A' }}
               {% endtimezone %}
             </div>
           </li>

--- a/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
@@ -9,35 +9,64 @@
   {% with nofo|nofo_name as nofo_name_str %}
     {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
       {% url 'nofos:nofo_edit' nofo.id as back_href %}
-      {% include "includes/page_heading.html" with title="Modification history for “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
+      {% include "includes/page_heading.html" with title="Updates since modifying “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
     {% endwith %}
   {% endwith %}
 
   {% if modification_date %}
-    <p class="margin-bottom-4">
-      Showing all changes made since adding modifications on <strong>{{ modification_date|localtime|date:"F j, Y, g:i a" }}</strong>
+  <section class="usa-prose margin-top-1">
+    <p>
+      All changes made since adding modifications on <strong>{{ modification_date|localtime|date:"F j, Y, g:i a" }}</strong>
     </p>
+    <ul>
+      <li><a href="#html-table">As an HTML table</a></li>
+      <li><a href="#markdown-table">As a Markdown table</a></li>
+    </ul>
+  </section>
+    
 
     {% if modification_events %}
-      <ul class="usa-list">
-        {% for event in modification_events %}
-          <li>
-            <div>
-              <strong>{{ event.event_type }}</strong>
-            </div>
-            <div>
-              ({{ event.object_type }}) {{ event.object_description }}
-            </div>
-            <div class="text-base">
-              {% timezone "America/New_York" %}
+      <table class="usa-table" id="audit-events-table">
+        <caption>
+          <div>
+            <h2 id="html-table" class="margin-bottom-0 font-serif-lg">Changes since NOFO was modified (HTML table)</h2>
+            {% if nofo.modifications %}
+              <p>You can also see <a href="{% url 'nofos:nofo_history' nofo.id %}">all updates since this NOFO was created</a>.</p>
+            {% endif %}
+          </div>
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col"><span class="usa-sr-only">Event </span>Type</th>
+            <th scope="col">Object</th>
+            <th scope="col">User</th>
+            <th scope="col" class="w-20">Timestamp</th>
+          </tr>
+        </thead>
+        <tbody id="audit-events-body">
+          {% for event in modification_events %}
+          <tr>
+            <td>{{ event.event_type }}</td>
+            <td><em>{{ event.object_type }}</em><br>{{ event.object_description }}</td>
+            <td>{{ event.user.email }}</td>
+            {% timezone "America/New_York" %}
+              <td>
                 {{ event.timestamp|date:'F j' }}, {{ event.timestamp|date:'g:i A' }}
-              {% endtimezone %}
-            </div>
-          </li>
-        {% endfor %}
-      </ul>
+              </td>
+            {% endtimezone %}
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="4" class="text-center">No audit events found.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
 
-      <h2 class="margin-top-4 font-serif-md">As a markdown table</h3>
+      <h2 id="markdown-table" class="margin-top-4 font-serif-lg">Changes since NOFO was modified (Markdown table)</h3>
+      {% if modifications_subsection %}
+        <p><a class="usa-link usa-link--external" target="_blank" href="{% url 'nofos:subsection_edit' nofo.id modifications_subsection.section.id modifications_subsection.id %}">Link to “Modifications” subsection</a>.</p>
+      {% endif %}
       <div class="bg-base-lightest padding-3 radius-md margin-bottom-3 overflow-auto">
         <code>
           | Modification description | Date updated |</br>

--- a/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% load static nofo_name tz %}
+
+{% block title %}
+  Modification history for “{{ nofo|nofo_name }}”
+{% endblock %}
+
+{% block content %}
+  {% with nofo|nofo_name as nofo_name_str %}
+    {% with "Edit “"|add:nofo_name_str|add:"”" as back_text %}
+      {% url 'nofos:nofo_edit' nofo.id as back_href %}
+      {% include "includes/page_heading.html" with title="Modification history for “"|add:nofo_name_str|add:"”" back_text=back_text back_href=back_href only %}
+    {% endwith %}
+  {% endwith %}
+
+  {% if modification_date %}
+    <p class="text-base margin-bottom-4">
+      Showing all changes made <strong>after {{ modification_date|localtime|date:"F j, Y, g:i a" }}</strong>.
+    </p>
+
+    {% if modification_events %}
+      <ul class="usa-list">
+        {% for event in modification_events %}
+          <li class="margin-bottom-2">
+            <div>
+              <strong>{{ event.event_type }}</strong> —
+              {{ event.object_type }}: {{ event.object_description }}
+            </div>
+            <div class="text-base text-gray-700">
+              {% timezone "America/New_York" %}
+                <td>
+                  {{ event.timestamp|date:'F j' }}, {{ event.timestamp|date:'g:i A' }}
+                </td>
+              {% endtimezone %}
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>No changes found after the modification date.</p>
+    {% endif %}
+
+  {% else %}
+    <div class="usa-alert usa-alert--info">
+      <div class="usa-alert__body">
+        <p class="usa-alert__text">
+          This NOFO has no modification date set. No modification history available.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_history_modifications.html
@@ -21,9 +21,11 @@
     {% if modification_events %}
       <ul class="usa-list">
         {% for event in modification_events %}
-          <li class="margin-bottom-2">
+          <li>
             <div>
-              <strong>{{ event.event_type }}</strong> —
+              <strong>{{ event.event_type }}</strong>
+            </div>
+            <div>
               {{ event.object_type }}: {{ event.object_description }}
             </div>
             <div class="text-base text-gray-700">
@@ -36,6 +38,21 @@
           </li>
         {% endfor %}
       </ul>
+
+      <h2 class="margin-top-4 font-serif-md">As a markdown table</h3>
+      <div class="bg-base-lightest padding-3 radius-md margin-bottom-3 overflow-auto">
+        <code>
+          | Modification description | Date updated |</br>
+          |--------------------------|--------------|</br>
+          {% for event in modification_events %}
+          {% if event.object_html_id %}
+            | Updated “[{{ event.object_description }}](#{{ event.object_html_id }})” | {{ event.timestamp|date:"F j, Y" }} |</br>
+          {% else %}
+            | Updated “{{ event.object_description }}” | {{ event.timestamp|date:"F j, Y" }} |</br>
+          {% endif %}
+          {% endfor %}
+          </code>
+      </div>
     {% else %}
       <p>No changes found after the modification date.</p>
     {% endif %}

--- a/bloom_nofos/nofos/templates/nofos/subsection_create.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_create.html
@@ -28,18 +28,18 @@
 
   {% if prev_subsection_with_tag %}
   <h2 class="font-serif-md margin-top-4">Previous subsection{% if prev_subsection_with_tag.name != prev_subsection.name %} with a heading{% endif %}</h2>
-  <div class="previous-subsection-widget">
-    <p class="previous-subsection--section text-base-dark">{{ prev_subsection_with_tag.section.name }}</p>
-    <p class="previous-subsection--subsection">
+  <div class="previous-subsection-widget outline-box">
+    <p class="outline-box--heading text-base-dark">{{ prev_subsection_with_tag.section.name }}</p>
+    <p class="outline-box--content">
       <a href="{% url 'nofos:subsection_edit' nofo.id prev_subsection_with_tag.section.id prev_subsection_with_tag.id %}" class="usa-link usa-link--external" target="blank" title="{{ prev_subsection_with_tag.name }} (Opens in a new tab)">
         {{ prev_subsection_with_tag.name }}
-        (<span class="previous-subsection--tag">{{ prev_subsection_with_tag.tag }}</span>)
+        (<span class="small-caps">{{ prev_subsection_with_tag.tag }}</span>)
       </a>
     </p>
   </div>
   {% endif %}
 
-  <h2 class="font-serif-lg margin-top-4 margin-bottom-0">Your new subsection</h2>
+  <h2 class="font-serif-lg margin-top-5 margin-bottom-0">Your new subsection</h2>
 
   <form class="form" method="post">
     {% csrf_token %}

--- a/bloom_nofos/nofos/templates/nofos/subsection_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_edit.html
@@ -32,6 +32,24 @@
   
   <p>Edit page for this subsection.</p>
 
+  {% if nofo.modifications %}
+    {% if subsection.section.name|lower == 'modifications' %}
+      {% if subsection.order == 1 %}
+        <h2 class="font-serif-md margin-top-4">Modifications date</h2>
+        <div class="previous-subsection-widget outline-box">
+          <p class="outline-box--heading text-base-dark">Last modified date: September 13, 2024</p>
+          <p class="outline-box--content">
+            <a href="#" class="usa-link usa-link--external" target="blank" title="Edit modifications date (Opens in a new tab)">
+              Edit date
+            </a>
+          </p>
+        </div>
+
+        <h2 class="font-serif-lg margin-top-5 margin-bottom-0">Edit modifications table</h2>
+      {% endif %}
+    {% endif %}
+  {% endif %}
+
   <form class="form" method="post">
     {% csrf_token %}
     <fieldset class="usa-fieldset">

--- a/bloom_nofos/nofos/tests/test_audits.py
+++ b/bloom_nofos/nofos/tests/test_audits.py
@@ -1,17 +1,18 @@
 import json
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.utils import timezone
-from django.contrib.contenttypes.models import ContentType
-
 from easyaudit.models import CRUDEvent
 from nofos.models import Nofo, Section, Subsection
+
 from ..audits import (
     deduplicate_audit_events_by_day_and_object,
     format_audit_event,
     get_audit_events_for_nofo,
 )
-from django.contrib.auth import get_user_model
 
 
 class DeduplicateAuditEventsTests(TestCase):

--- a/bloom_nofos/nofos/tests/test_audits.py
+++ b/bloom_nofos/nofos/tests/test_audits.py
@@ -1,0 +1,94 @@
+import json
+from datetime import timedelta
+from django.test import TestCase
+from django.utils import timezone
+from django.contrib.contenttypes.models import ContentType
+
+from easyaudit.models import CRUDEvent
+from nofos.models import Nofo, Section, Subsection
+from ..audits import get_audit_events_for_nofo
+from django.contrib.auth import get_user_model
+
+
+class GetAuditEventsForNofoTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.nofo = Nofo.objects.create(
+            title="Test NOFO", group="bloom", opdiv="Test OpDiv"
+        )
+        self.section = Section.objects.create(
+            nofo=self.nofo, name="Section 1", html_id="sec-1", order=1
+        )
+        self.subsection = Subsection.objects.create(
+            section=self.section, name="Subsection 1", order=1, tag="h3"
+        )
+
+        self.nofo_ct = ContentType.objects.get_for_model(Nofo)
+        self.section_ct = ContentType.objects.get_for_model(Section)
+        self.subsection_ct = ContentType.objects.get_for_model(Subsection)
+
+    def create_event(
+        self,
+        obj,
+        content_type,
+        event_type=CRUDEvent.UPDATE,
+        changed_fields=None,
+        dt_offset=0,
+    ):
+        return CRUDEvent.objects.create(
+            content_type=content_type,
+            object_id=str(obj.id),
+            object_repr=str(obj),
+            event_type=event_type,
+            user=self.user,
+            datetime=timezone.now() + timedelta(minutes=dt_offset),
+            changed_fields=json.dumps(changed_fields or {"title": ["old", "new"]}),
+        )
+
+    def test_includes_all_event_types_except_updated_only(self):
+        # Should be included
+        self.create_event(
+            self.nofo, self.nofo_ct, changed_fields={"title": ["Old", "New"]}
+        )
+        self.create_event(self.section, self.section_ct)
+        self.create_event(self.subsection, self.subsection_ct)
+
+        # Should be excluded (NOFO event with only 'updated')
+        self.create_event(
+            self.nofo, self.nofo_ct, changed_fields={"updated": ["2023", "2024"]}
+        )
+
+        results = get_audit_events_for_nofo(self.nofo)
+
+        # Should only return 3 events
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(isinstance(event, CRUDEvent) for event in results))
+        self.assertNotIn(
+            {"updated": ["2023", "2024"]},
+            [json.loads(e.changed_fields or "{}") for e in results],
+        )
+
+    def test_returns_events_in_reverse_chronological_order_by_default(self):
+        self.create_event(self.nofo, self.nofo_ct, dt_offset=2)
+        self.create_event(self.section, self.section_ct, dt_offset=1)
+        self.create_event(self.subsection, self.subsection_ct, dt_offset=0)
+
+        events = get_audit_events_for_nofo(self.nofo)
+        timestamps = [event.datetime for event in events]
+
+        self.assertEqual(timestamps, sorted(timestamps, reverse=True))
+
+    def test_returns_events_in_chronological_order_if_requested(self):
+        self.create_event(self.nofo, self.nofo_ct, dt_offset=2)
+        self.create_event(self.section, self.section_ct, dt_offset=1)
+        self.create_event(self.subsection, self.subsection_ct, dt_offset=0)
+
+        events = get_audit_events_for_nofo(self.nofo, reverse=False)
+        timestamps = [event.datetime for event in events]
+
+        self.assertEqual(timestamps, sorted(timestamps))

--- a/bloom_nofos/nofos/tests/test_subsection_edit.py
+++ b/bloom_nofos/nofos/tests/test_subsection_edit.py
@@ -1,8 +1,7 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
-from django.contrib.auth import get_user_model
-
 from nofos.models import Nofo, Section, Subsection
 
 User = get_user_model()

--- a/bloom_nofos/nofos/tests/test_subsection_edit.py
+++ b/bloom_nofos/nofos/tests/test_subsection_edit.py
@@ -1,0 +1,95 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+
+from nofos.models import Nofo, Section, Subsection
+
+User = get_user_model()
+
+
+class SubsectionEditTemplateTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(email="test@example.com", password="testpass123")
+
+        self.nofo = Nofo.objects.create(
+            title="Test NOFO", group="bloom", opdiv="HRSA", modifications=timezone.now()
+        )
+        self.modifications_section = Section.objects.create(
+            nofo=self.nofo, name="Modifications", html_id="modifications", order=1
+        )
+
+    def test_modifications_block_renders_for_first_subsection(self):
+        subsection = Subsection.objects.create(
+            section=self.modifications_section,
+            name="Test Subsection",
+            order=1,
+            tag="h3",
+        )
+
+        response = self.client.get(
+            reverse(
+                "nofos:subsection_edit",
+                args=[self.nofo.id, self.modifications_section.id, subsection.id],
+            )
+        )
+        self.assertContains(response, "Modifications date")
+        self.assertContains(response, "Edit modifications table")
+
+    def test_modifications_block_does_not_render_if_order_is_not_1(self):
+        subsection = Subsection.objects.create(
+            section=self.modifications_section,
+            name="Another Subsection",
+            order=2,
+            tag="h3",
+        )
+
+        response = self.client.get(
+            reverse(
+                "nofos:subsection_edit",
+                args=[self.nofo.id, self.modifications_section.id, subsection.id],
+            )
+        )
+        self.assertNotContains(response, "Modifications date")
+
+    def test_modifications_block_does_not_render_if_section_name_differs(self):
+        other_section = Section.objects.create(
+            nofo=self.nofo, name="Other Section", html_id="other", order=2
+        )
+        subsection = Subsection.objects.create(
+            section=other_section, name="Test Subsection", order=1, tag="h3"
+        )
+
+        response = self.client.get(
+            reverse(
+                "nofos:subsection_edit",
+                args=[self.nofo.id, other_section.id, subsection.id],
+            )
+        )
+        self.assertNotContains(response, "Modifications date")
+
+    def test_modifications_block_does_not_render_if_no_modification_date(self):
+        self.nofo.modifications = None
+        self.nofo.save()
+
+        subsection = Subsection.objects.create(
+            section=self.modifications_section,
+            name="Test Subsection",
+            order=1,
+            tag="h3",
+        )
+
+        response = self.client.get(
+            reverse(
+                "nofos:subsection_edit",
+                args=[self.nofo.id, self.modifications_section.id, subsection.id],
+            )
+        )
+
+        self.assertNotContains(response, "Modifications date")

--- a/bloom_nofos/nofos/urls.py
+++ b/bloom_nofos/nofos/urls.py
@@ -13,6 +13,11 @@ urlpatterns = [
         name="nofo_history",
     ),
     path(
+        "<int:pk>/history-modifications",
+        views.NofoModificationsHistoryView.as_view(),
+        name="nofo_history_modifications",
+    ),
+    path(
         "<int:pk>/import",
         views.NofosImportOverwriteView.as_view(),
         name="nofo_import_overwrite",

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1370,4 +1370,15 @@ class NofoModificationsHistoryView(
 
         context["modification_events"] = filtered_events
         context["modification_date"] = modifications_date
+
+        # Find the first subsection under the "Modifications" section
+        try:
+            modifications_section = self.object.sections.get(name="Modifications")
+            modifications_subsection = modifications_section.subsections.order_by(
+                "order"
+            ).first()
+        except Section.DoesNotExist:
+            modifications_subsection = None
+
+        context["modifications_subsection"] = modifications_subsection
         return context

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -2,7 +2,6 @@ import io
 import json
 from datetime import datetime
 
-
 import docraptor
 from bs4 import BeautifulSoup
 from constance import config

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1,7 +1,6 @@
 import io
 import json
 from datetime import datetime
-from collections import OrderedDict
 
 
 import docraptor
@@ -30,7 +29,10 @@ from easyaudit.models import CRUDEvent
 
 from bloom_nofos.utils import cast_to_boolean, is_docraptor_live_mode_active
 
-from .audits import get_audit_events_for_nofo
+from .audits import (
+    deduplicate_audit_events_by_day_and_object,
+    get_audit_events_for_nofo,
+)
 from .forms import (
     CheckNOFOLinkSingleForm,
     InsertOrderSpaceForm,
@@ -1341,31 +1343,6 @@ class NofoHistoryView(
         )
 
         return context
-
-
-def deduplicate_audit_events_by_day_and_object(events):
-    """
-    Deduplicate audit events so that only the most recent event
-    for a given object (type + description) on a given day is kept.
-
-    Args:
-        events (list of dict): A list of audit event dictionaries, each with
-                               'object_type', 'object_description', and 'timestamp' keys.
-
-    Returns:
-        list: Deduplicated list of events, keeping the latest per object per day.
-    """
-    deduplicated = OrderedDict()
-
-    for event in events:
-        key = (
-            event["object_type"],
-            event["object_description"],
-            event["timestamp"].date(),  # Use only the date
-        )
-        deduplicated[key] = event  # Overwrites earlier events on same object + day
-
-    return list(deduplicated.values())
 
 
 class NofoModificationsHistoryView(

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1265,7 +1265,7 @@ class CheckNOFOLinksDetailView(GroupAccessObjectMixin, DetailView):
         return context
 
 
-def get_audit_events_for_nofo(nofo):
+def get_audit_events_for_nofo(nofo, reverse=True):
     """
     Return all audit events related to the given NOFO: the NOFO object,
     its sections, and its subsections.
@@ -1313,7 +1313,7 @@ def get_audit_events_for_nofo(nofo):
     return sorted(
         list(nofo_events) + list(section_events) + list(subsection_events),
         key=lambda e: e.datetime,
-        reverse=True,
+        reverse=reverse,
     )
 
 
@@ -1429,7 +1429,7 @@ class NofoModificationsHistoryView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        all_events = get_audit_events_for_nofo(self.object)
+        all_events = get_audit_events_for_nofo(self.object, reverse=False)
         modifications_date = None
 
         for event in all_events:
@@ -1488,6 +1488,11 @@ class NofoModificationsHistoryView(
                 "event_type": event.get_event_type_display(),
                 "object_type": event.content_type.model.title(),
                 "object_description": event.object_repr,
+                "object_html_id": (
+                    json.loads(event.object_json_repr)[0]
+                    .get("fields", [])
+                    .get("html_id", "")
+                ),
                 "user": event.user,
                 "timestamp": event.datetime,
             }


### PR DESCRIPTION
## Summary

This PR is pretty large. It adds:

- a new page for audit events since "add modifications" button was clicked
  - shows the markdown table code you can use to update your modifications table subsection 
- a link to this new page from other audit events page
- a link to this new page from the "other actions" box on nofo_edit page
- shows the "last modified" date in the "other actions" box and adds a link to change it on the nofo_edit page
- shows the "last modified" date and a link to change it on the subsection edit page for the modifications table

The idea here is that people who are modifying NOFOs are making a large number of small edits across many subsections, and trying to remember them all manually is really annoying and impractical. This makes that process easier, using information we are already capturing.

### Screenshots

Here is what the new "modifications" audit events page looks like:

| updates since modifying "your nofo" |
|--------|
|   Shows a list of audit events at the top, and then at the bottom a markdown-formatted list of the same events for people to (hopefully) copy and paste into their Modifications section.     |
|   ![localhost_8000_nofos_308_history-modifications](https://github.com/user-attachments/assets/737f0142-5ec6-4c21-817e-9f465531da99)     |



Here is what the "other actions" box on the `edit_nofo.html` page now looks like

| before | after |
|--------|-------|
|   <img width="980" alt="Screenshot 2025-04-07 at 1 02 47 PM" src="https://github.com/user-attachments/assets/7d699223-8509-47c0-8cf0-526d5ef0af7e" />     |    <img width="980" alt="Screenshot 2025-04-07 at 1 02 16 PM" src="https://github.com/user-attachments/assets/b02a943c-2abc-42ae-a69c-4671a251661f" />   |



Here is what the `edit_subsection.html` page now looks like

| before | after |
|--------|-------|
|    <img width="980" alt="Screenshot 2025-04-07 at 1 03 57 PM" src="https://github.com/user-attachments/assets/873dd49e-2a7c-42a2-9cac-1e4c3d0864db" />    |   <img width="980" alt="Screenshot 2025-04-07 at 1 03 30 PM" src="https://github.com/user-attachments/assets/a30a89e5-5cd3-4dbf-bd14-05f9a495e3f7" />    |


