### PR TITLE
Fix for insufficient nested lists markdown indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Fix for nested lists no longer importing correctly
+
 ## [2.12.0] - 2025-03-31
 
 ### Added

--- a/bloom_nofos/nofos/tests/test_nofo_markdown.py
+++ b/bloom_nofos/nofos/tests/test_nofo_markdown.py
@@ -476,6 +476,98 @@ class NofoMarkdownConverterULTest(TestCase):
         self.assertEqual(md_body.strip(), expected_markdown.strip())
 
 
+class NofoMarkdownConverterLITest(TestCase):
+    def test_five_level_nested_ul(self):
+        html = """
+        <ul>
+            <li>Level 1
+                <ul>
+                    <li>Level 2
+                        <ul>
+                            <li>Level 3
+                                <ul>
+                                    <li>Level 4
+                                        <ul>
+                                            <li>Level 5</li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+        """
+        expected = """* Level 1
+    + Level 2
+        - Level 3
+            * Level 4
+                + Level 5"""
+        self.assertEqual(md(html).strip(), expected.strip())
+
+    def test_five_level_nested_ol(self):
+        html = """
+        <ol>
+            <li>Step 1
+                <ol>
+                    <li>Step 2
+                        <ol>
+                            <li>Step 3
+                                <ol>
+                                    <li>Step 4
+                                        <ol>
+                                            <li>Step 5</li>
+                                        </ol>
+                                    </li>
+                                </ol>
+                            </li>
+                        </ol>
+                    </li>
+                </ol>
+            </li>
+        </ol>
+        """
+        expected = """1. Step 1
+    1. Step 2
+        1. Step 3
+            1. Step 4
+                1. Step 5"""
+        self.assertEqual(md(html).strip(), expected.strip())
+
+    def test_mixed_ul_inside_ol(self):
+        html = """
+        <ol>
+            <li>Do this
+                <ul>
+                    <li>First</li>
+                    <li>Second</li>
+                </ul>
+            </li>
+        </ol>
+        """
+        expected = """1. Do this
+    * First
+    * Second"""
+        self.assertEqual(md(html).strip(), expected.strip())
+
+    def test_mixed_ol_inside_ul(self):
+        html = """
+        <ul>
+            <li>Start here
+                <ol>
+                    <li>Step A</li>
+                    <li>Step B</li>
+                </ol>
+            </li>
+        </ul>
+        """
+        expected = """* Start here
+    1. Step A
+    2. Step B"""
+        self.assertEqual(md(html).strip(), expected.strip())
+
+
 class NofoMarkdownConverterATest(TestCase):
     maxDiff = None
 


### PR DESCRIPTION
Starting since [I last updated markdownify](https://github.com/HHS/simpler-grants-pdf-builder/pull/267), we have seen problems with our nested lists being interpreted correctly in markdown.

The issue appears to be that instead of using tabs as the indentation for nested lists, the new update has been using  2 or 3 spaces, depending on whether the list was a UL or an OL.

So for this UL as HTML:

```
<ul>
  <li>
    Unordered list level 1
    <ul>
      <li>
        Unordered list level 2
        <ul>
          <li>
            Unordered list level 3
            <ul>
              <li>Unordered list level 4</li>
            </ul>
          </li>
          <li>Unordered list level 3</li>
        </ul>
      </li>
      <li>Unordered list level 2</li>
    </ul>
  </li>
  <li>Unordered list level 1</li>
</ul>
```

this is what we would get as the markdown string:

```
* Unordered list level 1
  + Unordered list level 2
    - Unordered list level 3
      * Unordered list level 4
    - Unordered list level 3
  + Unordered list level 2
* Unordered list level 1
```

Looks basically right, except when we re-interpreted this using the Markdown library, it would only recognize 4 spaces as a nested list, not 2 spaces as we have here.

So once we re-converted this to HTML, it would look like this:

```
* Unordered list level 1
* Unordered list level 2
    - Unordered list level 3
    - Unordered list level 4
    - Unordered list level 3
* Unordered list level 2
* Unordered list level 1
```

That is, the first and second levels were both root level lists, and the 3rd and 4th levels were demoted to level 1.

Similarly, for our ordered lists, we would see something similar.

```
<ol>
  <li>
    Ordered list level 1
    <ol>
      <li>
        Ordered list level 2
        <ol>
          <li>
            Ordered list level 3
            <ol>
              <li>Ordered list level 4</li>
            </ol>
          </li>
          <li>Ordered list level 3</li>
        </ol>
      </li>
      <li>Ordered list level 2</li>
    </ol>
  </li>
  <li>Ordered list level 1</li>
</ol>
```

as markdown:

```
1. Ordered list level 1
   1. Ordered list level 2
      1. Ordered list level 3
         1. Ordered list level 4
      2. Ordered list level 3
   2. Ordered list level 2
2. Ordered list level 1
```

Once re-interpreted to markdown, we were getting a result like this:

```
1. Ordered list level 1
2. Ordered list level 2
     1. Ordered list level 3
         1. Ordered list level 4
     2. Ordered list level 3
3. Ordered list level 2
4. Ordered list level 1
```

Again, not what we want.

So this update forces all the indents to be 4 spaces, not 2 or 3 as it was previously.

Here is the commit that changed this behaviour (which we are partially undoing here): https://github.com/matthewwithanm/python-markdownify/commit/c13bdd5c1426c5bbfd3d340096bc6c1fb2f508bf


### Screenshots 

This is what it looked like to import a Document with the following HTML before and after this change:

#### example as unstyled HTML

<img width="371" alt="Screenshot 2025-04-08 at 6 27 47 PM" src="https://github.com/user-attachments/assets/82f251f9-8fdd-4f74-a3e7-4b3e5c84ca1c" />



#### rendered in the app 


| UL before  | UL after |
|--------|-------|
|   <img width="249" alt="Screenshot 2025-04-08 at 6 25 17 PM" src="https://github.com/user-attachments/assets/881f9ed1-04c2-4f56-ac86-db8c36ada9f8" />     |  <img width="285" alt="Screenshot 2025-04-08 at 6 26 17 PM" src="https://github.com/user-attachments/assets/cb432b5d-38fe-484f-a2cd-014dbc1ea826" />     |



| OL before  | OL after |
|--------|-------|
|     <img width="249" alt="Screenshot 2025-04-08 at 6 25 31 PM" src="https://github.com/user-attachments/assets/04b7359f-e5e4-4a5d-9e7e-c7052128d90b" />   |   <img width="285" alt="Screenshot 2025-04-08 at 6 26 29 PM" src="https://github.com/user-attachments/assets/a61ccc39-075a-4f81-bb8a-d8613f889708" />    |


Note that the first OL has 3 levels because the indent was 3 spaces, and 3 * 3 is 9. Since nested lists are only recognized at intervals of 4, 9 is > 8.

