### PR TITLE
Fix for "edit date" link and for "Other required forms" in application table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Fix to allow unbolded "Other required forms:" string in appliction checklist
+- Fix link to edit modification date in the subsection edit page for the mods table
 - Fix for nested lists no longer importing correctly
 
 ## [2.12.0] - 2025-03-31

--- a/bloom_nofos/nofos/templates/nofos/subsection_edit.html
+++ b/bloom_nofos/nofos/templates/nofos/subsection_edit.html
@@ -39,7 +39,7 @@
         <div class="previous-subsection-widget outline-box">
           <p class="outline-box--heading text-base-dark">Last modified date: September 13, 2024</p>
           <p class="outline-box--content">
-            <a href="#" class="usa-link usa-link--external" target="blank" title="Edit modifications date (Opens in a new tab)">
+            <a href="{% url 'nofos:nofo_modifications' nofo.id %}" class="usa-link usa-link--external" target="blank" title="Edit modifications date (Opens in a new tab)">
               Edit date
             </a>
           </p>

--- a/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
+++ b/bloom_nofos/nofos/templatetags/replace_unicode_with_icon.py
@@ -55,7 +55,7 @@ def is_list_heading(td):
         return True
 
     if (
-        td.text.lower() == "other required forms"
+        td.text.lower().startswith("other required forms")
         or td.text.lower() == "attachments"
         or td.text.lower() == "narratives"
     ):


### PR DESCRIPTION
## Summary 

Very small PR here: it only makes 2 changes

1. Fix for the "Edit date" link on the subsection page with the modifications table. It was blank before, now it has a real link in it.
2. Allow the unbolded text "Other required forms:" (ends with a colon) in the application checklist table. Previously, it needed to be an exact match or the string needed to be bold.

