### PR TITLE
Add Content Guide "edit" html template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning since version 1.0.0.
   - Add basic functionality: we can import a content guide and edit its title
 - Added a separate page for the NOFO exports
   - It is now possible to export for all users in your group
+- Added a real "edit" page for Content Guides
 
 ### Changed
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -1093,6 +1093,25 @@ main .back-link a::before,
   font-weight: 600;
 }
 
+/* Content guides */
+
+.content_guide_edit .nofo_edit--header--subheading {
+  margin-bottom: -10px;
+  z-index: 30;
+  position: relative;
+  margin-top: 15px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.subsection_edit--diff-subsection
+  .subsection_edit--comparison-table
+  .row-comparison--no
+  > *:not(:nth-of-type(2)) {
+  color: var(--color--text-grey);
+  font-style: italic;
+}
+
 /* NOFO external links page */
 
 .nofo_links .usa-table td,

--- a/bloom_nofos/guides/templates/guides/guide_edit.html
+++ b/bloom_nofos/guides/templates/guides/guide_edit.html
@@ -1,13 +1,136 @@
-{% extends "base.html" %}
+{% extends 'base.html' %}
+{% load martortags tz nofo_name get_value_or_none add_classes_to_tables convert_paragraphs_to_hrs %}
+
+
+{% block title %}
+  Configure Content Guide: “{{ guide.title }}”
+{% endblock %}
+
+{% block body_class %}content_guide_edit{% endblock %}
 
 {% block content %}
-  <h1>Edit Content Guide</h1>
 
-  <form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="usa-button">Save changes</button>
-  </form>
+  <div class="back-link font-body-md">
+    <a href="{% url 'guides:guide_index' %}">All Content Guides</a>
+  </div>
+  <div class="nofo_edit--header--subheading font-mono-sm text-base">Content Guide</div>
+  <div class="nofo_edit--header nofo_edit--header--sticky" id="nofo_edit--header--id">
+    <div class="nofo_edit--header--h1 {% if guide.title|length > 40 %}nofo_edit--header--h1--smaller{% endif %}">
+      <h1 class="font-heading- margin-0">Configure Content Guide: “{{ guide.title }}”</h1>
+    </div>
+  </div>
 
-  <p><a href="{% url 'guides:guide_index' %}">Back to all content guides</a></p>
+  {% timezone "America/New_York" %}
+    <p>
+      This Content Guide was created on {{ guide.updated|date:'F j' }} at {{ guide.updated|date:'g:i A' }}.
+    </p>
+  {% endtimezone %}
+
+  <div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
+    <div class="usa-summary-box__body">
+      <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
+        Other actions
+      </h2>
+      <div class="usa-summary-box__text">
+        <p>Content Guides can be compared to existing NOFOs or new NOFO Word documents.</p>
+        <p>You can define what to compare, but you can’t directly edit the text of the Content Guide.</p>
+        <a class="usa-button usa-button--accent-warm" href="#">TODO: Compare to a NOFO</a>
+           — Check for differences between a NOFO document and this Content Guide.
+          </p>
+      </div>
+    </div>
+  </div>
+
+  <table class="usa-table usa-table--borderless width-full table--hide-edit-if-published table--hide-edit-if-archived">
+    <caption>
+      <div>
+        <h2 class="margin-bottom-0">Basic information</h2>
+      </div>
+    </caption>
+    <thead class="usa-sr-only">
+      <tr>
+        <th scope="col">Key</th>
+        <th scope="col">Value</th>
+        <th scope="col">Manage</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row" class="w-15">Name</th>
+        <td>{{ guide.title }}</td>
+        <td class="w-5 text-right"><a href="{% url 'guides:guide_edit_title' guide.id %}">Edit<span class="usa-sr-only"> name</span></a></td>
+      </tr>
+      <tr>
+        <th scope="row">Filename</th>
+        <td>{{ guide.filename }}</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+
+
+    {% for section in guide.sections.all|dictsort:"order" %}
+      <table class="usa-table usa-table--borderless width-full table--section">
+        <caption>
+          <div>
+            <h2 class="margin-bottom-0" id="{{ section.html_id }}">{{ section.name }}</h2>
+          </div>
+        </caption>
+        <thead>
+          <tr>
+            <!-- <th scope="col">Order</th> -->
+            <th scope="col">Comparison type</th>
+            <th scope="col">Heading</th>
+            <th scope="col">Content</th>
+            <th scope="col">Manage</th>
+          </tr>
+        </thead>
+        <tbody>
+
+          {% for subsection in section.subsections.all|dictsort:"order" %}
+            {% if subsection.name != 'Basic information' %}
+            <tr class="row--comparison-type--{{ subsection.comparison_type }}">
+              <!-- <th scope="row"
+                class="w-5 nofo-edit-table--subsection--index"
+                id="{{ subsection.html_id }}">
+                <span class="floating">
+                  <span class="text-base">#{{subsection.order }}</span>
+                </span>
+              </th> -->
+              <td class="w-20 nofo-edit-table--subsection--comparison_type">
+                {{ subsection.get_comparison_type_display }}
+              </td>
+              <th scope="row"
+                class="w-20 nofo-edit-table--subsection--name{% if subsection.html_class %} {{ subsection.html_class }}{% endif %}">
+                <span class="floating">
+                  {% if subsection.name %}
+                    <span {% if subsection.comparison_type == 'none' %}class="text-base text-italic"{% endif %}>
+                      {{ subsection.name }}
+                    </span>
+                  {% else %}
+                    <span class="text-base">—</span>
+                  {% endif %}
+                </span>
+              </th>
+              <td class="nofo-edit-table--subsection--body">
+                {% if subsection.comparison_type == 'body' %}
+                  {{ subsection.body|safe_markdown|add_classes_to_tables|convert_paragraphs_to_hrs|get_value_or_none:"content" }}
+                {% elif subsection.comparison_type == 'diff_strings' %}
+                  {{ subsection.diff_strings }}
+                {% else %}
+                  <span class="text-base text-italic">N/A</span>
+                {% endif %}
+              </td>
+              <td class="w-5 text-right nofo-edit-table--subsection--manage ">
+                <span class="floating">
+                  <a href="#">TODO: Edit<span class="usa-sr-only"> subsection: {{ subsection.name }}</span></a>
+                </span>
+              </td>
+            </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endfor %}
+
 {% endblock %}


### PR DESCRIPTION
## Summary

This PR builds the "edit" page for a content guide. 

This is the page where we will configure the subsections of a content guide, as well as change the name or do comparisons or whatever else we want, really. It's not really functional yet, as we still have to add the subsection edit page as well as update the compare function to work with non-Nofo objects, but that's all good.

At least this gives us something to work with. 😄 

### Screenshots

| before | after |
|--------|-------|
|   basic page where you could only edit the title     |  more normal looking page where you can see all your subsections      |
|     <img width="1193" alt="Screenshot 2025-04-11 at 12 05 08 PM" src="https://github.com/user-attachments/assets/c3923792-79e8-4ca4-8b86-76e5b119ab86" />   |   <img width="1193" alt="Screenshot 2025-04-11 at 12 04 55 PM" src="https://github.com/user-attachments/assets/4a21b011-bd3c-49c8-9d95-1bf18732fcf0" />    |



