### PR TITLE
Show table widths explicitly on "nofo_edit" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Compare content guides
+- Delete a content guide
+- Use width classes for HTML tables on nofo_edit page
+
 ### Changed
+
+- Editing a content guide name from the nofo_edit page works better
+- Show HTML table classnames on nofo_edit page and martor preview
 
 ### Fixed
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -663,6 +663,16 @@ label.usa-label {
   font-weight: 400;
 }
 
+.nofo-edit-table--subsection--body table > thead > tr > th::after,
+.subsection_edit div.martor-preview table > thead > tr > th::after {
+  content: "." attr(class);
+  display: block;
+  font-size: 0.85em;
+  font-weight: 400;
+  font-family: monospace;
+  color: var(--color--med-grey);
+}
+
 /* broken link error + tooltip */
 .nofo_edit .nofo-edit-table--subsection--body a.nofo_edit--broken-link,
 .nofo_edit
@@ -735,10 +745,6 @@ label.usa-label {
 .nofo_edit main table.table--section th,
 .nofo_edit main table.table--section td {
   padding: calc(0.75rem - 5px) 1rem 0.75rem 1rem;
-}
-
-.nofo_edit main table.table--section th,
-.nofo_edit main table.table--section td {
   border-top: none;
 }
 
@@ -781,22 +787,27 @@ label.usa-label {
   top: 139px;
 }
 
-.nofo_edit main table tbody tr:first-of-type th {
+.nofo_edit main table.usa-table > tbody > tr:first-of-type > th {
   width: 15%;
 }
 
-.nofo_edit table th.nofo-edit-table--subsection--name {
+.nofo_edit table.usa-table th.nofo-edit-table--subsection--name {
   scroll-margin-top: 115px;
 }
 
-.nofo_edit table th.nofo-edit-table--subsection--name.page-break-before,
-.nofo_edit table th.nofo-edit-table--subsection--name.page-break-before ~ td {
+.nofo_edit
+  table.usa-table
+  th.nofo-edit-table--subsection--name.page-break-before,
+.nofo_edit
+  table.usa-table
+  th.nofo-edit-table--subsection--name.page-break-before
+  ~ td {
   border-top: 2px dashed #5c5c5c;
 }
 
 .nofo_edit .page-break--hr--container .page-break--hr--text,
 .nofo_edit
-  table
+  table.usa-table
   th.nofo-edit-table--subsection--name.page-break-before::before {
   content: "[ ↓ page-break ↓ ]";
   position: absolute;


### PR DESCRIPTION
## Summary

This is a relatively small PR but hopefully one that has a big impact. 

This PR is aimed at helping NOFO designers when they apply table widths. The problem to be solved here is that writers/designers adding table widths didn't know if they were being applied correctly.

Given that, there are 3 changes in this PR regarding table widths:

1. Actually implement the widths in the nofo_edit page
    - Previously, applied widths would have no effect on the nofo_edit layout
2. Show the classnames on the nofo_edit page, in the th elements
3. Show the classnames in the martor preview, in the th elements

### Screenshots

#### nofo_edit page

| before | after |
|--------|-------|
|  equal-width columns. no indication that widths had been explicitly applied.      |  columns are 25%, 25%, 50%. width classnames have been added to the `th` element.     |
|    <img width="1015" alt="Screenshot 2025-04-21 at 11 12 35 AM" src="https://github.com/user-attachments/assets/ea28cac2-ea2a-4162-9561-9c8039ed78f5" />    |    <img width="1015" alt="Screenshot 2025-04-21 at 11 11 28 AM" src="https://github.com/user-attachments/assets/c81920ea-5548-43e5-a8d2-acd7a1a48dc6" />   |



#### martor preview

| before | after |
|--------|-------|
|   widths were applied correctly, but no explicit indicator.     |   added width classnames to `th` elements.    |
|  <img width="1015" alt="Screenshot 2025-04-21 at 11 11 03 AM" src="https://github.com/user-attachments/assets/40f9a15f-9619-4a67-bf6b-427bc819a4cc" />      |     <img width="1015" alt="Screenshot 2025-04-21 at 11 10 23 AM" src="https://github.com/user-attachments/assets/d74378e7-1667-4b12-bbbf-10962a4e364d" />  |

