### PR TITLE
Filter compare dict items by status before displaying them

### DIFF
--- a/bloom_nofos/guides/templates/guides/guide_compare.html
+++ b/bloom_nofos/guides/templates/guides/guide_compare.html
@@ -11,7 +11,7 @@
     <div class="usa-alert__body bg-base-lightest">
       <p class="usa-alert__text">
         <span class="usa-tag bg-gold text-ink">Beta</span>
-        <span class="margin-left-1">Comparing a Content Guide to a NOFO is an experimental feature and will change as we improve it. {% include "includes/feedback_link.html" %}.</span>
+        <span class="margin-left-1">Comparing a Content Guide to a NOFO is an experimental feature and will change as we improve it. <br />{% include "includes/feedback_link.html" %}.</span>
       </p>
     </div>
   </div>
@@ -23,7 +23,7 @@
     {% if num_changed_sections == 0 %}
       <h2>No changes</h2>
       <p>
-        This document is <strong>identical</strong> to your Content Guide: “{{ guide.title }}”.
+        This document (<span class="font-mono-sm">{{ new_nofo.filename }}</span>) matches your Content Guide: “{{ guide.title }}”.
       </p>
 
       <h3 class="margin-top-4" id="follow-up-actions">Follow-up actions</h3>
@@ -55,37 +55,35 @@
             <tbody>
               {% for subsection in section.subsections %}
               {% if subsection.name|lower != 'basic information' %}
-                {% if subsection.status != 'MATCH' %}
-                  <tr>
-                    <th scope="row">
-                      {# if the subsection.name value starts with "(#" #}
-                      {% if subsection.name|slice:":2" == "(#" %}
-                          <span class="text-base">{{ subsection.name }}</span>
-                      {% else %}
-                          {{ subsection.name|safe }}
+                <tr>
+                  <th scope="row">
+                    {# if the subsection.name value starts with "(#" #}
+                    {% if subsection.name|slice:":2" == "(#" %}
+                        <span class="text-base">{{ subsection.name }}</span>
+                    {% else %}
+                        {{ subsection.name|safe }}
+                    {% endif %}
+                  </th>
+                  <td>
+                    {{ subsection.status }}
+                  </td>
+                  <td>
+                    {{ subsection.comparison_type }}
+                  </td>
+                  <td>
+                    <div class="diff">
+                      {% if not subsection.diff %}
+                        <span class="text-base text-italic">No change</span>
+                      {% elif subsection.status == 'ADD' %}
+                        <ins>{{ subsection.diff|safe|linebreaksbr }}</ins>
+                      {% elif  subsection.status == 'DELETE' %}
+                        <del>{{ subsection.diff|safe|linebreaksbr }}</del>
+                      {% elif subsection.status == 'UPDATE' %}
+                        {{ subsection.diff|safe|linebreaks }}
                       {% endif %}
-                    </th>
-                    <td>
-                      {{ subsection.status }}
-                    </td>
-                    <td>
-                      {{ subsection.comparison_type }}
-                    </td>
-                    <td>
-                      <div class="diff">
-                        {% if not subsection.diff %}
-                          <span class="text-base text-italic">No change</span>
-                        {% elif subsection.status == 'ADD' %}
-                          <ins>{{ subsection.diff|safe|linebreaksbr }}</ins>
-                        {% elif  subsection.status == 'DELETE' %}
-                          <del>{{ subsection.diff|safe|linebreaksbr }}</del>
-                        {% elif subsection.status == 'UPDATE' %}
-                          {{ subsection.diff|safe|linebreaks }}
-                        {% endif %}
-                      </div>
-                    </td>
-                  </tr>
-                {% endif %}
+                    </div>
+                  </td>
+                </tr>
               {% endif %}
               {% endfor %}
             </tbody>

--- a/bloom_nofos/guides/views.py
+++ b/bloom_nofos/guides/views.py
@@ -175,7 +175,7 @@ class ContentGuideSubsectionEditView(GroupAccessObjectMixin, UpdateView):
 
 class ContentGuideCompareView(BaseNofoImportView):
     template_name = "guides/guide_import_compare.html"
-    redirect_url_name = "guides:guide_import_compare"
+    redirect_url_name = "guides:guide_compare"
 
     def dispatch(self, request, *args, **kwargs):
         self.guide = get_object_or_404(ContentGuide, pk=kwargs.get("pk"))
@@ -214,11 +214,9 @@ class ContentGuideCompareView(BaseNofoImportView):
             new_nofo.save()
 
             # Compare against the existing Content Guide
-            comparison = compare_nofos(guide, new_nofo)
+            comparison = compare_nofos(guide, new_nofo, statuses_to_ignore=["MATCH"])
 
-            # Optional: remove "MATCH" results and collapse renamed sections
-
-            # Tally changes
+            # Number of changes
             num_changed_sections = len(comparison)
             num_changed_subsections = sum(len(s["subsections"]) for s in comparison)
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_compare.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_compare.html
@@ -25,25 +25,36 @@
   {% endwith %}
 
 
-    {% if num_changed_sections == 0 %}
-      <h2>No changes</h2>
-      <p>
-        This document is <strong>identical</strong> to your original NOFO: “{{ nofo.title }}”.
-      </p>
+  {% if num_changed_sections == 0 and not nofo_comparison_metadata %}
+    <h2>No changes</h2>
+    <p>
+      
+      This document (<span class="font-mono-sm">{{ new_nofo.filename }}</span>) is <strong>identical</strong> to your original NOFO: “{{ nofo.title }}”.
+    </p>
 
-      <h3 class="margin-top-4" id="follow-up-actions">Follow-up actions</h3>
-      <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button">
-        Back to “{{ nofo|nofo_name }}”
-      </a>
-
-    {% else %}
-      <p>
+    <h3 class="margin-top-4" id="follow-up-actions">Follow-up actions</h3>
+    <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button">
+      Back to “{{ nofo|nofo_name }}”
+    </a>
+  {% else %}
+    
+    <p><strong>Overview</strong></p>
+    <ul class="usa-list">
+    {% if num_changed_sections %}
+      <li>
         There are <strong>{{ num_changed_subsections }}</strong> subsection{{ num_changed_subsections|pluralize }} with changes across {{ num_changed_sections }} section{{ num_changed_sections|pluralize }}.
-      </p>
+      </li>
+    {% endif %}
+    {% if nofo_comparison_metadata %}
+      <li>
+        <strong>{{ nofo_comparison_metadata|length }}</strong> metadata field{{ nofo_comparison_metadata|pluralize:' has,s have' }} changed.
+      </li>
+    {% endif %}
+    </ul>
 
-        <p>After comparing this NOFO, you can <a href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">continue with re-importing</a> or <a href="{% url 'nofos:nofo_edit' nofo.id %}">return to the edit page</a>.</p>
+    <p>After comparing this NOFO, you can <a href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">continue with re-importing</a> or <a href="{% url 'nofos:nofo_edit' nofo.id %}">return to the edit page</a>.</p>
 
-      {% if nofo_comparison_metadata %}
+    {% if nofo_comparison_metadata %}
       <table class="usa-table usa-table--borderless w-100">
         <caption>
           <div>
@@ -59,7 +70,6 @@
         </thead>
         <tbody>
           {% for attribute in nofo_comparison_metadata %}
-          {% if attribute.status != 'MATCH' %}
             <tr>
               <th scope="row">
                 {{ attribute.name }}
@@ -69,64 +79,61 @@
               </td>
               <td><div class="diff">{{ attribute.diff|safe }}</div></td>
             </tr>
-          {% endif %}
           {% endfor %}
         </tbody>
       </table>
-      {% endif %}
+    {% endif %}
 
-      {% if nofo_comparison %}
-        {% for section in nofo_comparison %}
-          <table class="usa-table usa-table--borderless">
-            <caption>
-              <div>
-                <h2>{{ section.name }}</h2>
-              </div>
-            </caption>
-            <thead class="usa-sr-only">
+    {% if nofo_comparison %}
+      {% for section in nofo_comparison %}
+        <table class="usa-table usa-table--borderless w-100">
+          <caption>
+            <div>
+              <h2>{{ section.name }}</h2>
+            </div>
+          </caption>
+          <thead class="usa-sr-only">
+            <tr>
+              <th scope="col" class="w-15">Subsection</th>
+              <th scope="col" class="w-10">Status</th>
+              <th scope="col" class="w-75">Content</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for subsection in section.subsections %}
+            {% if subsection.name|lower != 'basic information' %}
               <tr>
-                <th scope="col" class="w-15">Subsection</th>
-                <th scope="col" class="w-10">Status</th>
-                <th scope="col" class="w-75">Content</th>
+                <th scope="row">
+                  {# if the subsection.name value starts with "(#" #}
+                  {% if subsection.name|slice:":2" == "(#" %}
+                      <span class="text-base">{{ subsection.name }}</span>
+                  {% else %}
+                      {{ subsection.name|safe }}
+                  {% endif %}
+                </th>
+                <td>
+                  {{ subsection.status }}
+                </td>
+                <td>
+                  <div class="diff">
+                    {% if not subsection.diff %}
+                      <span class="text-base text-italic">No change</span>
+                    {% elif subsection.status == 'ADD' %}
+                      <ins>{{ subsection.diff|safe|linebreaksbr }}</ins>
+                    {% elif  subsection.status == 'DELETE' %}
+                      <del>{{ subsection.diff|safe|linebreaksbr }}</del>
+                    {% elif subsection.status == 'UPDATE' %}
+                      {{ subsection.diff|safe|linebreaks }}
+                    {% endif %}
+                  </div>
+                </td>
               </tr>
-            </thead>
-            <tbody>
-              {% for subsection in section.subsections %}
-              {% if subsection.name|lower != 'basic information' %}
-                {% if subsection.status != 'MATCH' %}
-                  <tr>
-                    <th scope="row">
-                      {# if the subsection.name value starts with "(#" #}
-                      {% if subsection.name|slice:":2" == "(#" %}
-                          <span class="text-base">{{ subsection.name }}</span>
-                      {% else %}
-                          {{ subsection.name|safe }}
-                      {% endif %}
-                    </th>
-                    <td>
-                      {{ subsection.status }}
-                    </td>
-                    <td>
-                      <div class="diff">
-                        {% if not subsection.diff %}
-                          <span class="text-base text-italic">No change</span>
-                        {% elif subsection.status == 'ADD' %}
-                          <ins>{{ subsection.diff|safe|linebreaksbr }}</ins>
-                        {% elif  subsection.status == 'DELETE' %}
-                          <del>{{ subsection.diff|safe|linebreaksbr }}</del>
-                        {% elif subsection.status == 'UPDATE' %}
-                          {{ subsection.diff|safe|linebreaks }}
-                        {% endif %}
-                      </div>
-                    </td>
-                  </tr>
-                {% endif %}
-              {% endif %}
-              {% endfor %}
-            </tbody>
-          </table>
-        {% endfor %}
-      {% endif %}
+            {% endif %}
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endfor %}
+    {% endif %}
 
     <h3 class="margin-top-4" id="follow-up-actions">Follow-up actions</h3>
     <ul class="usa-button-group margin-top-3">

--- a/bloom_nofos/nofos/tests_nofos/test_compare.py
+++ b/bloom_nofos/nofos/tests_nofos/test_compare.py
@@ -405,7 +405,10 @@ class TestCompareNofosMetadata(TestCase):
         subagency_update = nofo_comparison_metadata[4]
         self.assertEqual(subagency_update["status"], "UPDATE")
         self.assertEqual(
-            subagency_update["value"], "Department of Groundhog Excellence (DOGE)"
+            subagency_update["old_value"], "Department of Guessing Groundhogs (DGG)"
+        )
+        self.assertEqual(
+            subagency_update["new_value"], "Department of Groundhog Excellence (DOGE)"
         )
         self.assertIn(
             "Department of <del>Guessing</del><ins>Groundhog</ins> <del>Groundhogs</del><ins>Excellence</ins> (<del>DGG</del><ins>DOGE</ins>)",
@@ -415,7 +418,11 @@ class TestCompareNofosMetadata(TestCase):
         # Delete test (subagency2 removed)
         subagency2_delete = nofo_comparison_metadata[5]
         self.assertEqual(subagency2_delete["status"], "DELETE")
-        self.assertEqual(subagency2_delete["value"], "")
+        self.assertEqual(
+            subagency2_delete["old_value"],
+            "Action Group for Diverse Prognosticators (AGDP)",
+        )
+        self.assertEqual(subagency2_delete["new_value"], "")
         self.assertIn(
             "<del>Action Group for Diverse Prognosticators (AGDP)</del>",
             subagency2_delete["diff"],
@@ -424,7 +431,8 @@ class TestCompareNofosMetadata(TestCase):
         # Addition test (application deadline added)
         application_deadline_add = nofo_comparison_metadata[6]
         self.assertEqual(application_deadline_add["status"], "ADD")
-        self.assertEqual(application_deadline_add["value"], "February 2, 2026")
+        self.assertEqual(application_deadline_add["old_value"], "")
+        self.assertEqual(application_deadline_add["new_value"], "February 2, 2026")
         self.assertIn("<ins>February 2, 2026</ins>", application_deadline_add["diff"])
 
 


### PR DESCRIPTION
## Summary

This PR improves how we handle which values to display on the `*_compare` pages. 

Previously, we added code to the template and/or the view itself that would remove, say, all `MATCH` results from the array of diffs. Since this was being done in 2 places, we were duplicating code in some places and adding inconsistencies in others. 

This has now been rewritten so that we have a much greater control over which subsections we want to show. By default we will exclude all `MATCH` results from all comparisons, but I think we will expand this in the near future to remove all `ADD` results when we are comparing a content guide to a NOFO (we expect there to be additions, we don't care about those).

No screenshots here because the logic has been moved but there is no user-visible change.