### PR TITLE
Hide ADDs and red lines on the content guide compare page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versioning since version 1.0.0.
 
 - Editing a content guide name from the nofo_edit page works better
 - Show HTML table classnames on nofo_edit page and martor preview
+- Don't show ADDs on Content Guide compare screen
+- Don't show red lines on Content Guide compare screen
+- "nofo_compare" function accepts a list of statuses to exclude
+  - for example, we don't want to show the matches on the diff page
 
 ### Fixed
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -1240,6 +1240,10 @@ del {
   background-color: #ffebe9;
 }
 
+.nofo_compare--content-guide del {
+  text-decoration: none;
+}
+
 ins {
   background-color: #aceebb;
 }

--- a/bloom_nofos/guides/views.py
+++ b/bloom_nofos/guides/views.py
@@ -214,7 +214,9 @@ class ContentGuideCompareView(BaseNofoImportView):
             new_nofo.save()
 
             # Compare against the existing Content Guide
-            comparison = compare_nofos(guide, new_nofo, statuses_to_ignore=["MATCH"])
+            comparison = compare_nofos(
+                guide, new_nofo, statuses_to_ignore=["MATCH", "ADD"]
+            )
 
             # Number of changes
             num_changed_sections = len(comparison)


### PR DESCRIPTION
## Summary

This is a small change to the content guide comparison screen.

- Don't show `ADD`ed subsections: when comparing against a Content Guide, we expect there to be lots of ADDs, what we care about is what has changed or been removed.
- Don't show the red strikethrough effect on deleted text: they decrease readability.

### Screenshots 

| before | after |
|--------|-------|
|  - red strikethrough on deleted text <br>- ADD subsection    |  - no read strikethrough<br>- No more ADD     |
|   <img width="820" alt="Screenshot 2025-04-23 at 9 24 53 AM" src="https://github.com/user-attachments/assets/fbedf032-b082-431a-8099-d1677546fae8" />     |     <img width="820" alt="Screenshot 2025-04-23 at 9 28 41 AM" src="https://github.com/user-attachments/assets/1020db0e-a82b-46ca-acdc-211c719a6cd7" />  |

