### PR TITLE
Compare refactor: introduce `SubsectionDiff`

### DIFF
--- a/bloom_nofos/nofos/tests_nofos/test_compare.py
+++ b/bloom_nofos/nofos/tests_nofos/test_compare.py
@@ -654,9 +654,10 @@ class TestCompareNofosMetadata(TestCase):
 
         # Ensure 8 attributes changes are detected
         self.assertEqual(len(nofo_comparison_metadata), 8)
+
         # 3 attributes are not matched (update, add, or delete)
         non_matches_results = [
-            item for item in nofo_comparison_metadata if item["status"] != "MATCH"
+            item for item in nofo_comparison_metadata if item.status != "MATCH"
         ]
         self.assertEqual(len(non_matches_results), 3)
 
@@ -669,40 +670,40 @@ class TestCompareNofosMetadata(TestCase):
             "Tagline",
         ]
         for item in nofo_comparison_metadata:
-            if item["name"] in matched_names:
-                self.assertEqual(item["status"], "MATCH")
-                self.assertNotIn("diff", item)
+            if item.name in matched_names:
+                self.assertEqual(item.status, "MATCH")
+                self.assertFalse(item.diff)  # None or ""
 
         # Update test (subagency changed)
         subagency_update = nofo_comparison_metadata[4]
-        self.assertEqual(subagency_update["status"], "UPDATE")
+        self.assertEqual(subagency_update.status, "UPDATE")
         self.assertEqual(
-            subagency_update["old_value"], "Department of Guessing Groundhogs (DGG)"
+            subagency_update.old_value, "Department of Guessing Groundhogs (DGG)"
         )
         self.assertEqual(
-            subagency_update["new_value"], "Department of Groundhog Excellence (DOGE)"
+            subagency_update.new_value, "Department of Groundhog Excellence (DOGE)"
         )
         self.assertIn(
             "Department of <del>Guessing</del><ins>Groundhog</ins> <del>Groundhogs</del><ins>Excellence</ins> (<del>DGG</del><ins>DOGE</ins>)",
-            subagency_update["diff"],
+            subagency_update.diff,
         )
 
         # Delete test (subagency2 removed)
         subagency2_delete = nofo_comparison_metadata[5]
-        self.assertEqual(subagency2_delete["status"], "DELETE")
+        self.assertEqual(subagency2_delete.status, "DELETE")
         self.assertEqual(
-            subagency2_delete["old_value"],
+            subagency2_delete.old_value,
             "Action Group for Diverse Prognosticators (AGDP)",
         )
-        self.assertEqual(subagency2_delete["new_value"], "")
+        self.assertEqual(subagency2_delete.new_value, "")
         self.assertIn(
             "<del>Action Group for Diverse Prognosticators (AGDP)</del>",
-            subagency2_delete["diff"],
+            subagency2_delete.diff,
         )
 
         # Addition test (application deadline added)
         application_deadline_add = nofo_comparison_metadata[6]
-        self.assertEqual(application_deadline_add["status"], "ADD")
-        self.assertEqual(application_deadline_add["old_value"], "")
-        self.assertEqual(application_deadline_add["new_value"], "February 2, 2026")
-        self.assertIn("<ins>February 2, 2026</ins>", application_deadline_add["diff"])
+        self.assertEqual(application_deadline_add.status, "ADD")
+        self.assertEqual(application_deadline_add.old_value, "")
+        self.assertEqual(application_deadline_add.new_value, "February 2, 2026")
+        self.assertIn("<ins>February 2, 2026</ins>", application_deadline_add.diff)


### PR DESCRIPTION
## Summary

This PR does not change any logic or user-visible behaviour, instead it is an internal refactor to keep our codebase maintainable.

Previously, we were using `dicts` for our subsection comparisons, which have the benefit of being flexible (easier to build, easier to work with), but have the drawback of being unstructured (anything can be assinged to any key, new keys can be created on the fly, no guarantee of anything).

Now that we have a strong opinion about what subsection diffs should look like, it was time to introduce more of a strict data type around subsections, so voila.

This refactor sets us up for a more maintainable diff feature.