### PR TITLE
Change all matched instances of application_deadline value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning since version 1.0.0.
 - Delete a content guide
 - Use width classes for HTML tables on nofo_edit page
 - Add cover image for HHS-2025-IHS-ALZ-0002
+- Early concept of "change this everywhere" feature for application deadline
 
 ### Changed
 

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -1000,6 +1000,26 @@ main .back-link a::before,
   width: 16px;
 }
 
+/* Nofo edit properties pages */
+
+.edit__application-deadline form table h2 {
+  margin: 0;
+}
+
+.edit__application-deadline form table tr > th:first-of-type,
+.edit__application-deadline form table tr > td:first-of-type {
+  padding-left: 0;
+}
+
+.edit__application-deadline
+  form
+  table
+  tr
+  > td:first-of-type
+  .usa-checkbox__label {
+  margin-top: 0;
+}
+
 /* Subsection edit page */
 
 .subsection_edit blockquote {

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -1008,7 +1008,8 @@ main .back-link a::before,
 
 .edit__application-deadline form table tr > th:first-of-type,
 .edit__application-deadline form table tr > td:first-of-type {
-  padding-left: 0;
+  padding-left: 0.5rem;
+  padding-right: 0;
 }
 
 .edit__application-deadline
@@ -1018,6 +1019,10 @@ main .back-link a::before,
   > td:first-of-type
   .usa-checkbox__label {
   margin-top: 0;
+}
+
+.edit__application-deadline form table tr.subsection--selected td {
+  background-color: #f2e4d4;
 }
 
 /* Subsection edit page */

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2409,10 +2409,8 @@ def find_subsections_with_nofo_field_value(nofo, field_name):
                     )
                     matches.append(
                         {
-                            "subsection_id": subsection.id,
-                            "subsection_name": subsection.name or "(No name)",
-                            "highlighted_body": highlighted,
-                            "body": subsection.body,
+                            "subsection": subsection,
+                            "subsection_body_highlight": highlighted,
                             "section": subsection.section,
                         }
                     )
@@ -2431,10 +2429,14 @@ def replace_value_in_subsections(subsection_ids, old_value, new_value):
 
     updated_subsections = []
 
-    subsections = Subsection.objects.filter(id__in=subsection_ids).select_related(
-        "section"
-    )
-    for subsection in subsections:
+    for subsection_id in subsection_ids:
+        try:
+            subsection = Subsection.objects.select_related("section").get(
+                id=subsection_id
+            )
+        except Subsection.DoesNotExist:
+            continue
+
         original_body = subsection.body
         new_body = re.sub(
             re.escape(old_value),

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2385,7 +2385,13 @@ def modifications_update_announcement_text(nofo):
 
 
 def find_subsections_with_nofo_field_value(nofo, field_name):
-    import re
+    def _is_basic_info_first_subsection(subsection):
+        return (
+            subsection.name
+            and subsection.name.lower() == "basic information"
+            and subsection.order == 1
+            and subsection.section.order == 1
+        )
 
     value = getattr(nofo, field_name, None)
     if not value:
@@ -2397,18 +2403,19 @@ def find_subsections_with_nofo_field_value(nofo, field_name):
     for section in nofo.sections.prefetch_related("subsections").all():
         for subsection in section.subsections.all():
             if pattern.search(subsection.body):
-                highlighted = pattern.sub(
-                    lambda m: f"<mark>{m.group(0)}</mark>", subsection.body
-                )
-                matches.append(
-                    {
-                        "subsection_id": subsection.id,
-                        "subsection_name": subsection.name or "(No name)",
-                        "highlighted_body": highlighted,
-                        "body": subsection.body,
-                        "section": subsection.section,
-                    }
-                )
+                if not _is_basic_info_first_subsection(subsection):
+                    highlighted = pattern.sub(
+                        lambda m: f"<mark>{m.group(0)}</mark>", subsection.body
+                    )
+                    matches.append(
+                        {
+                            "subsection_id": subsection.id,
+                            "subsection_name": subsection.name or "(No name)",
+                            "highlighted_body": highlighted,
+                            "body": subsection.body,
+                            "section": subsection.section,
+                        }
+                    )
 
     return matches
 

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2382,3 +2382,32 @@ def modifications_update_announcement_text(nofo):
             if updated_body != subsection.body:
                 subsection.body = updated_body
                 subsection.save()
+
+
+def find_subsections_with_nofo_field_value(nofo, field_name):
+    import re
+
+    value = getattr(nofo, field_name, None)
+    if not value:
+        return []
+
+    matches = []
+    pattern = re.compile(re.escape(value), re.IGNORECASE)
+
+    for section in nofo.sections.prefetch_related("subsections").all():
+        for subsection in section.subsections.all():
+            if pattern.search(subsection.body):
+                highlighted = pattern.sub(
+                    lambda m: f"<mark>{m.group(0)}</mark>", subsection.body
+                )
+                matches.append(
+                    {
+                        "subsection_id": subsection.id,
+                        "subsection_name": subsection.name or "(No name)",
+                        "highlighted_body": highlighted,
+                        "body": subsection.body,
+                        "section": subsection.section,
+                    }
+                )
+
+    return matches

--- a/bloom_nofos/nofos/nofo.py
+++ b/bloom_nofos/nofos/nofo.py
@@ -2411,3 +2411,33 @@ def find_subsections_with_nofo_field_value(nofo, field_name):
                 )
 
     return matches
+
+
+def replace_value_in_subsections(subsection_ids, old_value, new_value):
+    """
+    Replaces `old_value` with `new_value` in bodies of given subsection_ids.
+    Note that old_value uses a case-insensitive compare, so "JUNE 1" will match "June 1".
+    Returns the list of updated Subsection objects.
+    """
+    if not subsection_ids:
+        return []
+
+    updated_subsections = []
+
+    subsections = Subsection.objects.filter(id__in=subsection_ids).select_related(
+        "section"
+    )
+    for subsection in subsections:
+        original_body = subsection.body
+        new_body = re.sub(
+            re.escape(old_value),
+            new_value,
+            subsection.body,
+            flags=re.IGNORECASE,
+        )
+        if new_body != original_body:
+            subsection.body = new_body
+            subsection.save()
+            updated_subsections.append(subsection)
+
+    return updated_subsections

--- a/bloom_nofos/nofos/nofo_compare.py
+++ b/bloom_nofos/nofos/nofo_compare.py
@@ -1,7 +1,7 @@
 import re
-from difflib import SequenceMatcher
 from dataclasses import dataclass, field
-from typing import Optional, List
+from difflib import SequenceMatcher
+from typing import List, Optional
 
 from django.utils.html import escape
 

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -40,7 +40,9 @@
         <tr>
           <th scope="row">{{ match.section.name }}</th>
           <td>
+            <a class="usa-link usa-link--external" href={% url "nofos:subsection_edit" nofo.id match.section.id match.subsection_id %}>
             {{ match.subsection_name }}
+            </a>
           </td>
           <td>
             {{ match.highlighted_body|safe|linebreaksbr }}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -46,6 +46,7 @@
                 type="checkbox"
                 name="replace_subsections"
                 value="{{ match.subsection.id }}"
+                checked
               />
               <label class="usa-checkbox__label" for="replace-{{ match.subsection.id }}">
                 <span class="usa-sr-only">Replace application deadline in subsection: {{ match.subsection|subsection_name_or_order }}</span>
@@ -109,7 +110,13 @@
           updateButtonText();
           updateRowHighlight(checkbox);
         });
+
+        // run once when page loads
+        updateRowHighlight(checkbox);
       });
+
+      // run once when page loads
+      updateButtonText();
     });
   </script>
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -5,6 +5,8 @@
   NOFO Application Deadline
 {% endblock %}
 
+{% block body_class %}edit__application-deadline{% endblock %}
+
 {% block content %}
   {% with nofo|nofo_name as nofo_name_str %}
   {% with "Back to  “"|add:nofo_name_str|add:"”" as back_text %}
@@ -19,17 +21,16 @@
     {% include "includes/form_macro.html" with hint2="eg: “Monday, January 1, 2024”" %}
 
     <button class="usa-button margin-top-3" type="submit">Save application deadline</button>
-  </form>
 
   {% if subsection_matches %}
     <hr class="margin-top-4 margin-bottom-3">
-    <h2 class="h4">Application deadline found in {{ subsection_matches|length }} subsections</h2>
     <table class="usa-table usa-table--borderless">
       <caption>
-        Subsections containing: “{{ form.application_deadline.value }}”
+        <h2 class="h4">{{ subsection_matches|length }} subsection{{ subsection_matches|length|pluralize }} found with “{{ form.application_deadline.value }}”</h2>
       </caption>
       <thead>
-        <tr>
+        <tr class="usa-sr-only">
+          <th scope="col">Replace?</th>
           <th scope="col">Section</th>
           <th scope="col">Subsection</th>
           <th scope="col">Content</th>
@@ -38,10 +39,24 @@
       <tbody>
         {% for match in subsection_matches %}
         <tr>
+          <td>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="replace-{{ match.subsection_id }}"
+                type="checkbox"
+                name="replace_subsections"
+                value="{{ match.subsection_id }}"
+              />
+              <label class="usa-checkbox__label" for="replace-{{ match.subsection_id }}">
+                <span class="usa-sr-only">Replace application deadline in subsection: {{ match.subsection_name }}</span>
+              </label>
+            </div>
+          </td>
           <th scope="row">{{ match.section.name }}</th>
           <td>
-            <a class="usa-link usa-link--external" href={% url "nofos:subsection_edit" nofo.id match.section.id match.subsection_id %}>
-            {{ match.subsection_name }}
+            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection_id %}">
+              {{ match.subsection_name }}
             </a>
           </td>
           <td>
@@ -52,4 +67,5 @@
       </tbody>
     </table>
   {% endif %}
+  </form>
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -23,8 +23,7 @@
     <button class="usa-button margin-top-3" type="submit">Save application deadline</button>
 
   {% if subsection_matches %}
-    <hr class="margin-top-4 margin-bottom-3">
-    <table class="usa-table usa-table--borderless">
+    <table class="usa-table usa-table--borderless margin-top-4">
       <caption>
         <h2 class="h4">{{ subsection_matches|length }} subsection{{ subsection_matches|length|pluralize }} found with “{{ form.application_deadline.value }}”</h2>
       </caption>
@@ -53,7 +52,7 @@
               </label>
             </div>
           </td>
-          <th scope="row">{{ match.section.name }}</th>
+          <td>{{ match.section.name }}</td>
           <td>
             <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection_id %}">
               {{ match.subsection_name }}
@@ -68,4 +67,49 @@
     </table>
   {% endif %}
   </form>
+{% endblock %}
+
+{% block js_footer %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const form = document.getElementById('nofo-application-deadline--form');
+      const button = form.querySelector('button[type="submit"]');
+      const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
+      const originalButtonText = button.textContent.trim();
+
+      if (checkboxes.length === 0) {
+        // No subsection matches, nothing to do
+        return;
+      }
+
+      function updateButtonText() {
+        const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
+        if (checkedCount === 0) {
+          button.textContent = originalButtonText;
+        } else if (checkedCount === 1) {
+          button.textContent = `${originalButtonText} + 1 subsection`;
+        } else {
+          button.textContent = `${originalButtonText} + ${checkedCount} subsections`;
+        }
+      }
+
+      function updateRowHighlight(checkbox) {
+        const row = checkbox.closest('tr');
+        const className = 'subsection--selected'
+        if (checkbox.checked) {
+          row.classList.add(className);
+        } else {
+          row.classList.remove(className);
+        }
+      }
+
+      // Attach listener to each checkbox
+      checkboxes.forEach(function (checkbox) {
+        checkbox.addEventListener('change', function () {
+          updateButtonText();
+          updateRowHighlight(checkbox);
+        });
+      });
+    });
+  </script>
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -20,4 +20,34 @@
 
     <button class="usa-button margin-top-3" type="submit">Save application deadline</button>
   </form>
+
+  {% if subsection_matches %}
+    <hr class="margin-top-4 margin-bottom-3">
+    <h2 class="h4">Application deadline found in {{ subsection_matches|length }} subsections</h2>
+    <table class="usa-table usa-table--borderless">
+      <caption>
+        Subsections containing: “{{ form.application_deadline.value }}”
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">Section</th>
+          <th scope="col">Subsection</th>
+          <th scope="col">Content</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for match in subsection_matches %}
+        <tr>
+          <th scope="row">{{ match.section.name }}</th>
+          <td>
+            {{ match.subsection_name }}
+          </td>
+          <td>
+            {{ match.highlighted_body|safe|linebreaksbr }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
 {% endblock %}

--- a/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/bloom_nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load nofo_name %}
+{% load nofo_name subsection_name_or_order %}
 
 {% block title %}
   NOFO Application Deadline
@@ -42,24 +42,24 @@
             <div class="usa-checkbox">
               <input
                 class="usa-checkbox__input"
-                id="replace-{{ match.subsection_id }}"
+                id="replace-{{ match.subsection.id }}"
                 type="checkbox"
                 name="replace_subsections"
-                value="{{ match.subsection_id }}"
+                value="{{ match.subsection.id }}"
               />
-              <label class="usa-checkbox__label" for="replace-{{ match.subsection_id }}">
-                <span class="usa-sr-only">Replace application deadline in subsection: {{ match.subsection_name }}</span>
+              <label class="usa-checkbox__label" for="replace-{{ match.subsection.id }}">
+                <span class="usa-sr-only">Replace application deadline in subsection: {{ match.subsection|subsection_name_or_order }}</span>
               </label>
             </div>
           </td>
           <td>{{ match.section.name }}</td>
           <td>
-            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection_id %}">
-              {{ match.subsection_name }}
+            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
+              {{ match.subsection|subsection_name_or_order }}
             </a>
           </td>
           <td>
-            {{ match.highlighted_body|safe|linebreaksbr }}
+            {{ match.subsection_body_highlight|safe|linebreaksbr }}
           </td>
         </tr>
         {% endfor %}

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -6679,11 +6679,11 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         )
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>July 15, 2025</mark>", match["highlighted_body"])
-        self.assertIn("Deadline Details", match["subsection_name"])
+        self.assertIn("<mark>July 15, 2025</mark>", match["subsection_body_highlight"])
+        self.assertIn("Deadline Details", match["subsection"].name)
         self.assertEqual(self.section, match["section"])
-        self.assertEqual(1, match["subsection_id"])
-        self.assertEqual(match["body"], self.matching_subsection.body)
+        self.assertEqual(1, match["subsection"].id)
+        self.assertEqual(match["subsection"].body, self.matching_subsection.body)
 
     def test_ignores_match_if_basic_information(self):
         self.matching_subsection.name = "Basic information"
@@ -6703,17 +6703,17 @@ class FindSubsectionsWithFieldValueTests(TestCase):
 
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>July 15, 2025</mark>", match["highlighted_body"])
-        self.assertIn("Basic information", match["subsection_name"])
+        self.assertIn("<mark>July 15, 2025</mark>", match["subsection_body_highlight"])
+        self.assertIn("Basic information", match["subsection"].name)
         self.assertEqual(self.section, match["section"])
-        self.assertEqual(1, match["subsection_id"])
-        self.assertEqual(match["body"], self.matching_subsection.body)
+        self.assertEqual(1, match["subsection"].id)
+        self.assertEqual(match["subsection"].body, self.matching_subsection.body)
 
     def test_ignores_subsections_without_match(self):
         results = find_subsections_with_nofo_field_value(
             self.nofo, "application_deadline"
         )
-        self.assertNotIn("Other Info", [r["subsection_name"] for r in results])
+        self.assertNotIn("Other Info", [r["subsection"].name for r in results])
 
     def test_case_insensitive_matching(self):
         self.matching_subsection.body = "all applications due by JULY 15, 2025"
@@ -6723,8 +6723,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         )
         self.assertEqual(len(results), 1)
         self.assertEqual(self.section, results[0]["section"])
-        self.assertEqual(1, results[0]["subsection_id"])
-        self.assertIn("<mark>JULY 15, 2025</mark>", results[0]["highlighted_body"])
+        self.assertEqual(1, results[0]["subsection"].id)
+        self.assertIn(
+            "<mark>JULY 15, 2025</mark>", results[0]["subsection_body_highlight"]
+        )
 
     def test_returns_empty_list_when_no_value(self):
         self.nofo.application_deadline = ""

--- a/bloom_nofos/nofos/test_nofo.py
+++ b/bloom_nofos/nofos/test_nofo.py
@@ -6685,6 +6685,30 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         self.assertEqual(1, match["subsection_id"])
         self.assertEqual(match["body"], self.matching_subsection.body)
 
+    def test_ignores_match_if_basic_information(self):
+        self.matching_subsection.name = "Basic information"
+        self.matching_subsection.save()
+        results = find_subsections_with_nofo_field_value(
+            self.nofo, "application_deadline"
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_returns_match_with_basic_information_if_order_is_not_1(self):
+        self.matching_subsection.name = "Basic information"
+        self.matching_subsection.order = 3
+        self.matching_subsection.save()
+        results = find_subsections_with_nofo_field_value(
+            self.nofo, "application_deadline"
+        )
+
+        self.assertEqual(len(results), 1)
+        match = results[0]
+        self.assertIn("<mark>July 15, 2025</mark>", match["highlighted_body"])
+        self.assertIn("Basic information", match["subsection_name"])
+        self.assertEqual(self.section, match["section"])
+        self.assertEqual(1, match["subsection_id"])
+        self.assertEqual(match["body"], self.matching_subsection.body)
+
     def test_ignores_subsections_without_match(self):
         results = find_subsections_with_nofo_field_value(
             self.nofo, "application_deadline"

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -73,6 +73,7 @@ from .nofo import (
     find_h7_headers,
     find_incorrectly_nested_heading_levels,
     find_same_or_higher_heading_levels_consecutive,
+    find_subsections_with_nofo_field_value,
     get_cover_image,
     get_sections_from_soup,
     get_step_2_section,
@@ -839,6 +840,13 @@ class NofoEditGroupView(BaseNofoEditView):
 class NofoEditApplicationDeadlineView(BaseNofoEditView):
     form_class = NofoApplicationDeadlineForm
     template_name = "nofos/nofo_edit_application_deadline.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["subsection_matches"] = find_subsections_with_nofo_field_value(
+            self.object, "application_deadline"
+        )
+        return context
 
 
 class NofoEditTaglineView(BaseNofoEditView):


### PR DESCRIPTION
## Summary

This PR modifies the "Change Application Deadline" view by showing all other subsections where the current application deadline exists and offering to change them all at the same time.

## Details 

This story came out of our NOFO Builder retro with the coaches and HRSA.

We use the `application_deadline` field for the date that we have on the cover of the NOFO as well as the "Before you begin" page. However, it is also commonly in the body of the NOFO itself, usually inside of the "Key Dates" callout box.

If there is a change to the application date, writers have to hunt down all instances of this value and make sure they are all in sync.

The update here is to list them all on the edit page for the top-level `application_deadline` and offer to change them all at once.

**Note:** We don't have an understanding of which subsections the application deadline exists in, we literally just string match. If the date exists in another subsection we show it. If it doesn't exist, or if it does but it is in a different format ("June 10th, 2025" vs "June 10 2025") then we won't match it. This is a 'best-effort' type of feature. 

### Screenshots

| when you first load the page | after selecting subsections | success message | 
|--------|-------|------|
|   show the subsections with matching dates underneath the save button    |   selected subsections are highlighted and the button text is updated when you select a subsection    | success message tells you what changed |
|    <img width="1363" alt="Screenshot 2025-04-29 at 3 36 02 PM" src="https://github.com/user-attachments/assets/3894ae81-bd57-404f-8df8-4b2815d7b092" />    |    <img width="1363" alt="Screenshot 2025-04-29 at 3 36 12 PM" src="https://github.com/user-attachments/assets/3e85efeb-62de-4f08-80cd-17704d72eda8" />   | <img width="775" alt="Screenshot 2025-04-29 at 3 36 47 PM" src="https://github.com/user-attachments/assets/9b830866-ade1-46e8-a4bb-eabc910ca4bd" /> |


Here's a gif of it working:

![Screen Recording 2025-04-29 at 3 40 42 PM](https://github.com/user-attachments/assets/cd9eccaf-d53a-409d-b1f8-786834b81854)

