### PR TITLE
Fix 2 bugs with tables on nofo_edit page

### DIFF
--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -663,8 +663,8 @@ label.usa-label {
   font-weight: 400;
 }
 
-.nofo-edit-table--subsection--body table > thead > tr > th::after,
-.subsection_edit div.martor-preview table > thead > tr > th::after {
+.nofo-edit-table--subsection--body table > thead > tr > th[class]::after,
+.subsection_edit div.martor-preview table > thead > tr > th[class]::after {
   content: "." attr(class);
   display: block;
   font-size: 0.85em;
@@ -847,7 +847,7 @@ _:future,
   padding: 0;
 }
 
-.nofo_edit main table tbody tr:first-of-type td:last-of-type {
+.nofo_edit main table.usa-table > tbody > tr:first-of-type > td:last-of-type {
   width: 5%;
   text-align: right;
 }


### PR DESCRIPTION
## Summary

I pushed some fixes back in https://github.com/HHS/simpler-grants-pdf-builder/pull/298, but it looks like it introduced 2 layout bugs:

1. The dot from the classname was always showing up. Now it only shows up if there _is_ a class on the th element.
2. Some overly general table CSS was forcing the last column of inline tables to be a 5% width, which was messing up my layouts.

Here are some screenshots:

### Screenshots

#### `nofo_edit` page

| before | after |
|--------|-------|
|  dot `.` exists, and 5% width for last column       |   no dot, and last column looks normal    |
|    <img width="1021" alt="Screenshot 2025-04-30 at 1 44 47 PM" src="https://github.com/user-attachments/assets/a221a54b-6e1c-408c-aba8-62063f525b55" />    |  <img width="1021" alt="Screenshot 2025-04-30 at 1 44 06 PM" src="https://github.com/user-attachments/assets/a05c9beb-a734-4ab3-9cf9-88899237217c" />     |


#### `subsection_edit` page (preview tab)

| before | after |
|--------|-------|
|  dot `.` exists even if no classname      |  dot is gone     |
|   <img width="594" alt="Screenshot 2025-04-30 at 1 45 32 PM" src="https://github.com/user-attachments/assets/1e48ad6e-ac54-4113-ae33-e36f99c13425" />     |    <img width="594" alt="Screenshot 2025-04-30 at 1 46 25 PM" src="https://github.com/user-attachments/assets/7dbd236b-59b9-44f8-8687-67b02312dfcd" />   |

