### PR TITLE
Rewrite Dockerfile for python:3.13-slim debian-based image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Dockerfile now uses python -slim image, not python -alpine image
+
 ### Fixed
 
 ## [2.16.0] - 2025-05-04

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.13-alpine
+FROM python:3.13-slim
 
 # set work directory
 WORKDIR /app
 
 ARG IS_PROD_ARG=0
+ARG GITHUB_SHA_ARG
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -12,28 +13,40 @@ ENV PORT=8000
 
 ENV IS_DOCKER=1
 ENV IS_PROD=${IS_PROD_ARG}
-
-ARG GITHUB_SHA_ARG
 ENV GITHUB_SHA=${GITHUB_SHA_ARG}
 
 # copy project
 COPY . .
 
-# install linux dependencies
-RUN apk update && apk upgrade && \
-  apk add gcc g++ musl-dev curl libffi-dev postgresql-dev && \
-  curl -sSL https://install.python-poetry.org | python3 -
+# Install system dependencies (Debian-based)
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  build-essential \
+  curl \
+  libffi-dev \
+  libpq-dev \
+  && rm -rf /var/lib/apt/lists/*
 
-# install python dependencies
-COPY ./pyproject.toml .
-COPY ./poetry.lock .
-RUN /root/.local/bin/poetry config virtualenvs.in-project true && \
-  /root/.local/bin/poetry install --without dev && \
+# Install Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 - && \
+  ln -s /root/.local/bin/poetry /usr/local/bin/poetry
+
+# Copy dependency files first
+COPY pyproject.toml poetry.lock ./
+
+# Configure Poetry and install dependencies
+RUN poetry config virtualenvs.in-project true && \
+  poetry install --no-root --without dev && \
   rm -rf ~/.cache/pypoetry/{cache,artifacts}
 
-# collect static files
-RUN /root/.local/bin/poetry run python bloom_nofos/manage.py collectstatic --noinput --verbosity 0
 
+# Copy the rest of the app
+COPY . .
+
+# Collect static files
+RUN poetry run python bloom_nofos/manage.py collectstatic --noinput --verbosity 0
+
+
+# Expose port and run server
 EXPOSE $PORT
-
-CMD ["sh", "-c", "/root/.local/bin/poetry run gunicorn --workers 8 --timeout 89 --chdir bloom_nofos --bind 0.0.0.0:$PORT bloom_nofos.wsgi:application"]
+CMD ["sh", "-c", "poetry run gunicorn --workers 8 --timeout 89 --chdir bloom_nofos --bind 0.0.0.0:$PORT bloom_nofos.wsgi:application"]


### PR DESCRIPTION
## Summary

This PR rewrites our Dockerfile from the `-alpine` base to the `-slim` debian-based image.

Tested locally and things seem to be working fine. Let's see if the build pipeline holds up!