### PR TITLE
Makefile can now run as a docker container, not as a python app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,6 @@ coverage.xml
 .mypy_cache
 .pytest_cache
 .hypothesis
+
+# virtualenvs
+.venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Makefile commands can be run from a Docker image
+
 ### Fixed
 
 ## [2.17.0] - 2025-05-05

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY pyproject.toml poetry.lock ./
 
 # Configure Poetry and install dependencies
 RUN poetry config virtualenvs.in-project true && \
-  poetry install --no-root --without dev && \
+  poetry install --no-root && \
   rm -rf ~/.cache/pypoetry/{cache,artifacts}
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test lint format collectstatic migrate makemigrations
+.PHONY: help build test lint format collectstatic migrate makemigrations
 
 WORKDIR = bloom_nofos
 USE_DOCKER ?= 0
@@ -15,12 +15,16 @@ MANAGE = $(PY_RUN_CMD) python manage.py
 
 help:
 	@echo "Available commands:"
+	@echo "  make build           Build a docker image"
 	@echo "  make test            Run all tests"
 	@echo "  make lint            Run isort and black --check"
 	@echo "  make format          Auto-format using isort and black"
 	@echo "  make collectstatic   Run collectstatic"
 	@echo "  make migrate         Run database migrations"
 	@echo "  make makemigrations  Create new migrations"
+
+build:
+	docker build -t $(IMAGE_NAME) .
 
 test:
 	cd $(WORKDIR) && $(MANAGE) test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
-.PHONY: help test lint format migrate makemigrations
+.PHONY: help test lint format collectstatic migrate makemigrations
 
-PYTHON=poetry run python
-MANAGE=poetry run python manage.py
-WORKDIR=bloom_nofos
+WORKDIR = bloom_nofos
+USE_DOCKER ?= 0
+IMAGE_NAME ?= bloom_nofos
+
+ifeq ($(USE_DOCKER),1)
+	PY_RUN_CMD = docker run --rm -w /app/$(WORKDIR) $(IMAGE_NAME) poetry run
+else
+	PY_RUN_CMD = poetry run
+endif
+
+
+MANAGE = $(PY_RUN_CMD) python manage.py
 
 help:
 	@echo "Available commands:"


### PR DESCRIPTION
## Summary

This PR makes it possible to run our `make` commands with a docker image instead just natively. 

For example, we can build the image first and then call a command passing in our image name:

```
docker build -t pcraig3/bloom-nofos:dev .
make test USE_DOCKER=1 IMAGE_NAME=pcraig3/bloom-nofos:dev
```

Or we can use the `build` command if we want to use the default image name:

```
make build
make test USE_DOCKER=1
```