### PR TITLE
Add Django management script to get all NOFOs in a CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add script to download all Nofos and ContentGuides to a .csv
+
 ### Changed
 
 - Makefile commands can be run from a Docker image

--- a/bloom_nofos/nofos/management/commands/get_nofos_and_guides.py
+++ b/bloom_nofos/nofos/management/commands/get_nofos_and_guides.py
@@ -1,0 +1,92 @@
+import csv
+from django.core.management.base import BaseCommand
+from nofos.models import Nofo
+from guides.models import ContentGuide
+
+
+class Command(BaseCommand):
+    help = (
+        "Export NOFOs and ContentGuides with UUIDs and future URL links to a CSV file."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output-file",
+            type=str,
+            default="nofos_and_guides.csv",
+            help="Output file name for the CSV (default: nofos_and_guides.csv)",
+        )
+
+    def handle(self, *args, **options):
+        output_file = options["output_file"]
+
+        with open(output_file, mode="w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(
+                [
+                    "type",
+                    "id",
+                    "id_url",
+                    "uuid",
+                    "uuid_url",
+                    "number",
+                    "title",
+                    "status",
+                    "created",
+                    "updated",
+                    "archived",
+                ]
+            )
+
+            # Export NOFOs
+            self.export_nofos(writer)
+            # Export ContentGuides
+            self.export_content_guides(writer)
+
+        self.stdout.write(self.style.SUCCESS(f"Data exported to {output_file}"))
+
+    def export_nofos(self, writer):
+        self.stdout.write("Exporting NOFOs...")
+        nofos = Nofo.objects.all().order_by("created")
+
+        for nofo in nofos:
+            print("NOFO: {}".format(nofo.id))
+            writer.writerow(
+                [
+                    "Nofo",
+                    nofo.id,
+                    f"https://nofo.rodeo/nofos/{nofo.id}/edit",
+                    nofo.uuid,
+                    f"https://nofo.rodeo/nofos/{nofo.uuid}/edit",
+                    nofo.number,
+                    nofo.title,
+                    nofo.status,
+                    nofo.created,
+                    nofo.updated,
+                    nofo.archived,
+                ]
+            )
+        self.stdout.write(self.style.SUCCESS("NOFOs exported."))
+
+    def export_content_guides(self, writer):
+        self.stdout.write("Exporting ContentGuides...")
+        guides = ContentGuide.objects.all().order_by("created")
+
+        for guide in guides:
+            print("ContentGuide: {}".format(guide.id))
+            writer.writerow(
+                [
+                    "ContentGuide",
+                    guide.id,
+                    f"https://nofo.rodeo/guides/{guide.id}/edit",
+                    guide.uuid,
+                    f"https://nofo.rodeo/guides/{guide.uuid}/edit",
+                    "",
+                    guide.title,
+                    guide.status,
+                    guide.created,
+                    guide.updated,
+                    guide.archived,
+                ]
+            )
+        self.stdout.write(self.style.SUCCESS("ContentGuides exported."))


### PR DESCRIPTION
## Summary

This PR adds a script to download all NOFOs and Content Guides to a CSV. 

The primary motivator here is so that we can map between an old integer id and a new uuid, once we complete [the primary key migration](https://github.com/HHS/simpler-grants-pdf-builder/issues/305).

So this script will download all NOFOs and ContentGuides, and show us their id in one column and their uuid in another column, as well as other identifying attributes.

Run it like this:

> `poetry run python manage.py get_nofos_and_guides --output-file="nofos_content_guides.csv"`

The resulting CSV file will have column headings like this:

```
type | id | id_url | uuid | uuid_url | number | title | status | created | updated | archived
```