### PR TITLE
Update match_view_url function to filter out non-uuid urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@ Versioning since version 1.0.0.
 
 ### Added
 
-- Add script to download all Nofos and ContentGuides to a .csv
-
 ### Changed
 
-- Makefile commands can be run from a Docker image
-
 ### Fixed
+
+- match_view_url needed to be updated to look for uuid vals in urls
 
 ## [3.0.0] - 2025-05-07
 

--- a/bloom_nofos/nofos/tests_nofos/test_utils.py
+++ b/bloom_nofos/nofos/tests_nofos/test_utils.py
@@ -361,18 +361,27 @@ class StyleMapManagerTests(TestCase):
 
 
 class MatchUrlTests(TestCase):
-    def test_match_valid_urls(self):
+    def test_match_valid_uuid_urls(self):
         """
-        Test the match_url function with valid URLs.
+        Test the match_view_url function with valid UUID URLs.
         """
-        self.assertTrue(match_view_url("/nofos/123"))
-        self.assertTrue(match_view_url("/nofos/1"))
-        self.assertTrue(match_view_url("/nofos/0"))
+        self.assertTrue(match_view_url("/nofos/8713ea6d-335a-409f-90c0-f75162aecf0e"))
+        self.assertTrue(match_view_url("/nofos/123e4567-e89b-12d3-a456-426614174000"))
+        self.assertTrue(match_view_url("/nofos/abcdef12-1234-5678-1234-abcdefabcdef"))
 
     def test_match_invalid_urls(self):
         """
-        Test the match_url function with invalid URLs.
+        Test the match_view_url function with invalid URLs.
         """
+        # Invalid UUIDs
+        self.assertFalse(match_view_url("/nofos/123"))
+        self.assertFalse(match_view_url("/nofos/1"))
+        self.assertFalse(match_view_url("/nofos/0"))
+        self.assertFalse(match_view_url("/nofos/12345"))
+        self.assertFalse(match_view_url("/nofos/not-a-uuid"))
+        self.assertFalse(match_view_url("/nofos/1234-5678"))
+
+        # Invalid paths
         self.assertFalse(match_view_url("/nofos"))
         self.assertFalse(match_view_url("/nofos/"))
         self.assertFalse(match_view_url("/nofos/abc"))

--- a/bloom_nofos/nofos/utils.py
+++ b/bloom_nofos/nofos/utils.py
@@ -1,5 +1,6 @@
 import json
 import re
+import uuid
 
 from constance import config
 from django.contrib.contenttypes.models import ContentType
@@ -101,7 +102,7 @@ def get_icon_path_choices(theme):
 
 def match_view_url(url):
     """
-    Check if the given URL matches the pattern "/nofos/{integer}".
+    Check if the given URL matches the pattern "/nofos/{uuid}".
 
     Args:
     url (str): The URL to be checked.
@@ -109,10 +110,17 @@ def match_view_url(url):
     Returns:
     bool: True if the URL matches the pattern, False otherwise.
     """
-    # Regular expression to match the specified pattern
-    pattern = r"^/nofos/\d+$"
+    # Extract the UUID part from the URL
+    if not url.startswith("/nofos/"):
+        return False
 
-    return bool(re.match(pattern, url))
+    uuid_part = url[len("/nofos/") :]
+
+    try:
+        uuid.UUID(uuid_part)
+        return True
+    except ValueError:
+        return False
 
 
 class StyleMapManager:


### PR DESCRIPTION
## Summary

This breaks the ability of the app to get PDFs, so not good.

The problem is that we changed the url pattern, so we started not allowing uuids to be permitted.

Previously, we were assuming integers but no longer.