### PR TITLE
IHS top nav section links are white now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- IHS not-selected top nav link borders on section pages are white
 - Tag docker images built with Makefile with latest git sha (or "latest")
 
 ### Fixed

--- a/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs-white.css
+++ b/bloom_nofos/bloom_nofos/static/theme-opdiv-ihs-white.css
@@ -96,8 +96,12 @@ section.before-you-begin h2 {
 }
 
 .section--title-page--header-nav li a {
-  border-top: 4px solid var(--color--ihs-blue);
+  border-top: 4px solid var(--color--white);
   color: var(--color--ihs-blue);
+}
+
+.section--title-page--header-nav li a[aria-current] {
+  border-top: 4px solid var(--color--ihs-blue);
 }
 
 .section--title-page--name,


### PR DESCRIPTION
## Summary

This is a very simple PR. It changes our IHS link borders in the top nav to be white if they are not the current section. 

| before | after |
|--------|-------|
|    all link borders are blue, so it is hard to see the current one    |  now link borders are white, and only the current one is blue     |
|   <img width="1431" alt="Screenshot 2025-05-09 at 10 18 09 AM" src="https://github.com/user-attachments/assets/2400df3c-284f-4297-a2d9-ec072711681a" />     |    <img width="1431" alt="Screenshot 2025-05-09 at 10 17 36 AM" src="https://github.com/user-attachments/assets/922b1c75-f63d-4603-b2cb-115cfbdc3b1b" />   |

