### PR TITLE
Fixed flash message after editing

### DIFF
--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -520,6 +520,36 @@ label.usa-label {
   z-index: 1;
 }
 
+.usa-alert__close {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  text-align: center;
+  opacity: 0.7;
+  color: inherit;
+  border-radius: 4px;
+}
+
+.usa-alert__close:hover,
+.usa-alert__close:focus {
+  opacity: 1;
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.usa-alert__close:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .nofo_edit caption {
   top: 46px;
 }

--- a/bloom_nofos/bloom_nofos/static/styles.css
+++ b/bloom_nofos/bloom_nofos/static/styles.css
@@ -483,6 +483,43 @@ label.usa-label {
   z-index: 10;
 }
 
+/* Alert styles */
+.usa-alert {
+  position: sticky;
+  top: 0;
+  z-index: 9999;
+  transition: opacity 0.3s ease-out;
+  margin-bottom: 1rem !important;
+  background: white;
+  isolation: isolate;
+}
+
+.usa-alert__body {
+  position: relative;
+}
+
+.usa-alert__heading {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.usa-alert__text {
+  margin: 0;
+}
+
+/* Ensure warning messages stay on top */
+.usa-site-alert--broken-links .usa-alert,
+.usa-site-alert--heading-errors .usa-alert,
+.usa-site-alert--h7-headers .usa-alert {
+  z-index: inherit;
+}
+
+/* Summary box should be below alerts */
+.usa-summary-box {
+  position: relative;
+  z-index: 1;
+}
+
 .nofo_edit caption {
   top: 46px;
 }

--- a/bloom_nofos/bloom_nofos/templates/includes/alerts.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/alerts.html
@@ -1,6 +1,6 @@
 {% for message in messages %}
   {% if "success" in message.tags and success_heading %}
-    <div class="usa-alert usa-alert--success margin-bottom-3" role="alert" aria-live="polite">
+    <div id="nofo-editor-success-alert" class="usa-alert usa-alert--success margin-bottom-3" role="alert" aria-live="polite">
       <div class="usa-alert__body">
         <button type="button" class="usa-alert__close" aria-label="Dismiss success message" tabindex="0">
           <span aria-hidden="true">×</span>
@@ -12,7 +12,7 @@
       </div>
     </div>
   {% elif "error" in message.tags and error_heading %}
-    <div class="usa-alert usa-alert--error margin-bottom-3" role="alert" aria-live="assertive">
+    <div id="nofo-editor-error-alert" class="usa-alert usa-alert--error margin-bottom-3" role="alert" aria-live="assertive">
       <div class="usa-alert__body">
         <button type="button" class="usa-alert__close" aria-label="Dismiss error message" tabindex="0">
           <span aria-hidden="true">×</span>
@@ -29,33 +29,36 @@
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     // Handle close button clicks and keyboard events
-    document.querySelectorAll('.usa-alert__close').forEach(button => {
-      button.addEventListener('click', dismissAlert);
-      button.addEventListener('keydown', function(e) {
-        // Handle Enter or Space key
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          dismissAlert.call(this);
-        }
-      });
-    });
-
-    // Auto-dismiss alerts after 4 seconds
-    document.querySelectorAll('.usa-alert').forEach(alert => {
-      setTimeout(() => {
-        if (alert && alert.parentNode) {
-          dismissAlert.call(alert.querySelector('.usa-alert__close'));
-        }
-      }, 4000);
+    const alerts = document.querySelectorAll('#nofo-editor-success-alert, #nofo-editor-error-alert');
+    alerts.forEach(alert => {
+      const closeButton = alert.querySelector('.usa-alert__close');
+      if (closeButton) {
+        closeButton.addEventListener('click', () => dismissAlert(alert));
+        closeButton.addEventListener('keydown', function(e) {
+          // Handle Enter or Space key
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            dismissAlert(alert);
+          }
+        });
+      }
     });
 
     // Helper function to dismiss alert
-    function dismissAlert() {
-      const alert = this.closest('.usa-alert');
-      if (alert) {
+    function dismissAlert(alert) {
+      if (alert && alert.parentNode) {
         alert.style.opacity = '0';
         setTimeout(() => alert.remove(), 300); // Remove after fade animation
       }
     }
+
+    // Auto-dismiss alerts after 4 seconds
+    alerts.forEach(alert => {
+      setTimeout(() => {
+        if (alert && alert.parentNode) {
+          dismissAlert(alert);
+        }
+      }, 4000);
+    });
   });
 </script>

--- a/bloom_nofos/bloom_nofos/templates/includes/alerts.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/alerts.html
@@ -2,6 +2,9 @@
   {% if "success" in message.tags and success_heading %}
     <div class="usa-alert usa-alert--success margin-bottom-3" role="alert" aria-live="polite">
       <div class="usa-alert__body">
+        <button type="button" class="usa-alert__close" aria-label="Dismiss success message" tabindex="0">
+          <span aria-hidden="true">×</span>
+        </button>
         <h4 class="usa-alert__heading">{{ success_heading }}</h4>
         <p class="usa-alert__text">
           {{ message | safe }}
@@ -11,6 +14,9 @@
   {% elif "error" in message.tags and error_heading %}
     <div class="usa-alert usa-alert--error margin-bottom-3" role="alert" aria-live="assertive">
       <div class="usa-alert__body">
+        <button type="button" class="usa-alert__close" aria-label="Dismiss error message" tabindex="0">
+          <span aria-hidden="true">×</span>
+        </button>
         <h4 class="usa-alert__heading">{{ error_heading }}</h4>
         <p class="usa-alert__text">
           {{ message | safe }}
@@ -19,3 +25,37 @@
     </div>
   {% endif %}
 {% endfor %}
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    // Handle close button clicks and keyboard events
+    document.querySelectorAll('.usa-alert__close').forEach(button => {
+      button.addEventListener('click', dismissAlert);
+      button.addEventListener('keydown', function(e) {
+        // Handle Enter or Space key
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          dismissAlert.call(this);
+        }
+      });
+    });
+
+    // Auto-dismiss alerts after 4 seconds
+    document.querySelectorAll('.usa-alert').forEach(alert => {
+      setTimeout(() => {
+        if (alert && alert.parentNode) {
+          dismissAlert.call(alert.querySelector('.usa-alert__close'));
+        }
+      }, 4000);
+    });
+
+    // Helper function to dismiss alert
+    function dismissAlert() {
+      const alert = this.closest('.usa-alert');
+      if (alert) {
+        alert.style.opacity = '0';
+        setTimeout(() => alert.remove(), 300); // Remove after fade animation
+      }
+    }
+  });
+</script>

--- a/bloom_nofos/bloom_nofos/templates/includes/alerts.html
+++ b/bloom_nofos/bloom_nofos/templates/includes/alerts.html
@@ -1,6 +1,6 @@
 {% for message in messages %}
   {% if "success" in message.tags and success_heading %}
-    <div class="usa-alert usa-alert--success margin-bottom-3">
+    <div class="usa-alert usa-alert--success margin-bottom-3" role="alert" aria-live="polite">
       <div class="usa-alert__body">
         <h4 class="usa-alert__heading">{{ success_heading }}</h4>
         <p class="usa-alert__text">
@@ -9,7 +9,7 @@
       </div>
     </div>
   {% elif "error" in message.tags and error_heading %}
-    <div class="usa-alert usa-alert--error margin-bottom-3" role="alert">
+    <div class="usa-alert usa-alert--error margin-bottom-3" role="alert" aria-live="assertive">
       <div class="usa-alert__body">
         <h4 class="usa-alert__heading">{{ error_heading }}</h4>
         <p class="usa-alert__text">

--- a/bloom_nofos/nofos/views.py
+++ b/bloom_nofos/nofos/views.py
@@ -1203,8 +1203,7 @@ class NofoSubsectionEditView(
         messages.add_message(
             self.request,
             messages.SUCCESS,
-            "Updated subsection: “<a href='#{}'>{}</a>” in ‘{}’".format(
-                self.object.html_id,
+            "Updated subsection: “<strong>{}</strong>” in ‘<strong>{}</strong>’".format(
                 self.object.name or "(#{})".format(self.object.order),
                 self.object.section.name,
             ),


### PR DESCRIPTION
## Summary
This PR adds sticky alert functionality to the NOFO Builder, with auto-dismiss behavior and proper accessibility features. The alerts will stay at the top of the page while scrolling, auto-dismiss after 4 seconds, and can be manually dismissed. The implementation ensures proper keyboard navigation and screen reader support.

## Details
This update came from the need to keep alerts visible while users scroll through long NOFO documents, particularly when making edits or reviewing changes. The alerts now:

- Stay fixed at the top of the page while scrolling / auto-scrolling
- Auto-dismiss after 4 seconds with a fade animation
- Can be manually dismissed via a close button
- Support keyboard navigation and screen reader announcements
- Properly layer with other page elements through z-index management

### Accessibility Features
- Success messages use `aria-live="polite"` to announce changes when the user is idle
- Error messages use `aria-live="assertive"` to announce changes immediately
- Close button is keyboard accessible with proper focus states
- Proper ARIA labels for screen readers
- Focus management for keyboard users

## Screenshots
<img width="1013" alt="Screenshot 2025-05-11 at 11 09 19 PM" src="https://github.com/user-attachments/assets/ad01a100-0532-4679-9b5f-12723a72ed7d" />

This addresses issue #322.