### PR TITLE
Small change to docker tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ help:
 	@echo "  make makemigrations  Create new migrations"
 
 build:
-	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
+	docker build -t  $(IMAGE_NAME):latest .
+	docker image tag $(IMAGE_NAME):latest $(IMAGE_NAME):$(IMAGE_TAG) .
 	@echo "Built image: $(IMAGE_NAME):$(IMAGE_TAG)"
 
 test:


### PR DESCRIPTION
## Summary

The CI/CD on the SGG end expects an image tagged `latest` to run tests against and image tagged `{{ commit hash }}` to deploy

## Testing

```
make build test
docker build -t  bloom_nofos:latest .
[+] Building 27.8s (14/14) FINISHED                                                                                                                                docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                               0.0s
 => => transferring dockerfile: 1.24kB                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/python:3.13-slim                                                                                                                0.5s
 => [internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 449B                                                                                                                                                  0.0s
 => [1/9] FROM docker.io/library/python:3.13-slim@sha256:914bf5c12ea40a97a78b2bff97fbdb766cc36ec903bfb4358faf2b74d73b555b                                                          0.0s
 => [internal] load build context                                                                                                                                                  0.0s
 => => transferring context: 116.30kB                                                                                                                                              0.0s
 => CACHED [2/9] WORKDIR /app                                                                                                                                                      0.0s
 => [3/9] COPY . .                                                                                                                                                                 0.2s
 => [4/9] RUN apt-get update &&   apt-get install -y --no-install-recommends   build-essential   curl   libffi-dev   libpq-dev   && rm -rf /var/lib/apt/lists/*                    6.7s
 => [5/9] RUN curl -sSL https://install.python-poetry.org | python3 - &&   ln -s /root/.local/bin/poetry /usr/local/bin/poetry                                                     8.8s 
 => [6/9] COPY pyproject.toml poetry.lock ./                                                                                                                                       0.0s 
 => [7/9] RUN poetry config virtualenvs.in-project true &&   poetry install --no-root &&   rm -rf ~/.cache/pypoetry/{cache,artifacts}                                              8.6s 
 => [8/9] COPY . .                                                                                                                                                                 0.2s 
 => [9/9] RUN poetry run python bloom_nofos/manage.py collectstatic --noinput --verbosity 0                                                                                        2.1s 
 => exporting to image                                                                                                                                                             0.7s 
 => => exporting layers                                                                                                                                                            0.7s 
 => => writing image sha256:0574630c0e789d5b4fd03abdaca504f23396d3179325657c0bbe79374ed57cfb                                                                                       0.0s 
 => => naming to docker.io/library/bloom_nofos:latest                                                                                                                              0.0s 
                                                                                                                                                                                        
What's next:                                                                                                                                                                            
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
docker image tag bloom_nofos:latest bloom_nofos:7798e26c34f836dd0ba17453b91b32d5b1df25e6
Built image: bloom_nofos:7798e26c34f836dd0ba17453b91b32d5b1df25e6
cd bloom_nofos && poetry run python manage.py test
=====
DEBUG: True
=====
No .env file found at /Users/kai/projects/simpler-grants-pdf-builder/bloom_nofos/bloom_nofos/.env
=====
Found 816 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......./Users/kai/projects/simpler-grants-pdf-builder/.venv/lib/python3.13/site-packages/django/core/handlers/base.py:61: UserWarning: No directory at: /Users/kai/projects/simpler-grants-pdf-builder/bloom_nofos/static/
  mw_instance = middleware(adapted_handler)
............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................/Users/kai/projects/simpler-grants-pdf-builder/.venv/lib/python3.13/site-packages/django/core/handlers/base.py:61: UserWarning: No directory at: /Users/kai/projects/simpler-grants-pdf-builder/bloom_nofos/static/
  mw_instance = middleware(adapted_handler)
.............................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 816 tests in 17.983s

OK
Destroying test database for alias 'default'...
```