### PR TITLE
Add the "Important: public information" section after LAST matching subsection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning since version 1.0.0.
 - IHS not-selected top nav link borders on section pages are white
 - Tag docker images built with Makefile with latest git sha (or "latest")
 - Show sticky flash message for edits on nofo_edit page
+- Add the "Important: public information" subsection after _last_ matching subsection
 
 ### Fixed
 

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -2263,6 +2263,7 @@ def add_final_subsection_to_step_3(sections):
     or "Step 3: Write Your Application" (case-insensitive).
 
     If found, then looks for a subsection called "Other required forms", "Standard forms", or "Application components".
+    It looks in reverse order for a matching subsection name, so it matches the one closest to the end of the section.
 
         If either of those are found, then a new subsection is added immediately afterwards.
         If none are found, then the new subsection is added as the final subsection.
@@ -2331,13 +2332,13 @@ def add_final_subsection_to_step_3(sections):
 
             order_number = None
 
-            # find the new subsection to insert after
-            for subsection in subsections:
+            # find the new subsection to insert after (starting from the last match)
+            for subsection in reversed(subsections):
                 if subsection.get("name", "").lower() in [
                     name.lower() for name in subsection_names
                 ]:
                     order_number = subsection.get("order") + 1
-                    break  # Stop loop once a matching subsection name is found
+                    break  # Stop loop once the LAST matching subsection name is found
 
             if not order_number:
                 # set as last order if not yet set

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -1300,9 +1300,9 @@ class AddFinalSubsectionTests(TestCase):
                     sections[2]["subsections"][2]["name"], "Subsection 3.1"
                 )
 
-    def test_add_public_information_section_after_first_specific_subsection_title(self):
+    def test_add_public_information_section_after_LAST_specific_subsection_title(self):
         """
-        Test that the public information subsection is added _after_ the first subsection title matched.
+        Test that the public information subsection is added _after_ the last subsection title matched.
         """
         sections = self._get_sections_1_2_3()
 
@@ -1358,20 +1358,21 @@ class AddFinalSubsectionTests(TestCase):
 
         # first subsection is "Standard forms"
         self.assertEqual(sections[2]["subsections"][0]["name"], "Standard forms")
-        # second subsection is public information one
+
+        # second subsection is "Other required forms"
+        self.assertEqual(sections[2]["subsections"][1]["name"], "Other required forms")
+        # third subsection is "Application components"
         self.assertEqual(
-            sections[2]["subsections"][1]["name"],
+            sections[2]["subsections"][2]["name"], "Application components"
+        )
+        # fourth subsection is public information one
+        self.assertEqual(
+            sections[2]["subsections"][3]["name"],
             PUBLIC_INFORMATION_SUBSECTION["name"],
         )
         self.assertEqual(
-            sections[2]["subsections"][1]["body"],
+            sections[2]["subsections"][3]["body"],
             PUBLIC_INFORMATION_SUBSECTION["body"],
-        )
-        # third subsection is "Other required forms"
-        self.assertEqual(sections[2]["subsections"][2]["name"], "Other required forms")
-        # fourth subsection is "Application components"
-        self.assertEqual(
-            sections[2]["subsections"][3]["name"], "Application components"
         )
         # last subsection is the initial one
         self.assertEqual(sections[2]["subsections"][4]["name"], "Subsection 3.1")


### PR DESCRIPTION
## Summary

This is a small PR that changes how we insert the `Important: public information` subsection. Instead of inserting it after the _first_ matching heading in Section 3, now we insert it into the _last_ matching heading. Essentially, we are just looping through subsections in reverse to find a match.

### Details

Since February, we have been injecting a new subsection (`Important: public information`) into step 3 of all Nofos: https://github.com/HHS/simpler-grants-pdf-builder/pull/96

It's generally been working as expected, until last week when we had a few ACF NOFOs come through where the "Public info" subsection was inserted right at the beginning of the section (it was 3rd in the list of subsections) and this confused everyone. This subsection is intended to come towards the end of Section 3, not at the beginning.

The reason for this is that `add_final_subsection_to_step_3` looks to match on several different of subsection headings and then adds the "Public info" subsection after the _first_ match. Based on the amount of confusion it created, this is not actually what we expect this function to do. We expect the "Public info" subsection to be closer to the end of section 3.

The cleanest way to solve this seemed like we can just looking for matching subsection headings _in reverse order_ and then add the "Public info" subsection after the matching subsection that is _closest to the end_ of the section.