### PR TITLE
Show deleted subsections in the audit logs table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Add the "Important: public information" subsection after _last_ matching subsection
+
 ### Fixed
+
+- Show audit events for deleted subsections on the "All updates for NOFO" page
 
 ## [3.1.0] - 2025-05-12
 
@@ -25,7 +29,6 @@ Versioning since version 1.0.0.
 - IHS not-selected top nav link borders on section pages are white
 - Tag docker images built with Makefile with latest git sha (or "latest")
 - Show sticky flash message for edits on nofo_edit page
-- Add the "Important: public information" subsection after _last_ matching subsection
 
 ### Fixed
 

--- a/nofos/nofos/audits.py
+++ b/nofos/nofos/audits.py
@@ -141,13 +141,13 @@ def get_audit_events_for_nofo(nofo, reverse=True):
         content_type__model="subsection",
     )
 
-    # Get DELETE events for Subsections (they aren't included in "subsection_ids")
+    # Get ALL events for Subsections that have been deleted
     subsection_delete_filter = Q()
     for section_id in section_ids:
         subsection_delete_filter |= Q(object_json_repr__contains=str(section_id))
 
     deleted_subsection_events = CRUDEvent.objects.filter(
-        content_type__model="subsection", event_type=CRUDEvent.DELETE
+        content_type__model="subsection"
     ).filter(subsection_delete_filter)
 
     return sorted(


### PR DESCRIPTION
## Summary

This is a small PR that fixes a bug where deleted subsections would not be shown in the list of audit events for a NOFO.

### Details 

The issue was this:

  Our logic for displaying audit events related to a Nofo involved us finding all section_ids attached to the Nofo, and then all subsection_ids related to those sections. Then we query the audit logs for those subsection ids and build our list.

  However, when a subsection is DELETED, then it is no longer _associated_ with an existing Nofo and it doesn't show up in our logic to pull subsection_ids for the Nofo. (_tant pis._)

The fix here is:

- we use our section_ids
- then we query the `easyaudit_crudevent` table directly for any subsection records that are "deleted" events and also contain a given section id in the `object_json_repr` field
  - (even though the subsection has been deleted from our database, the audit event json object for this subsection still shows the section id. Even though the subsection db object is gone, its data lives on
in the json object repr in the audit event).

So now we can show subsections that were removed.

HOWEVER, if an entire section is removed we don't see it (which is fine).

### How to test

Here's what you can do to confirm the behaviour is correct:

- Import a new nofo
- Click "Edit" on any subsection
- Scroll down to "Other actions" and open it. Select "Add subsection"
- On this page, create a new subsection. Call it anything you like. "Save"
- Find your new subsection and make an edit. Anything you do is fine. "Save"
- Find your new subsection, and click "Edit". Scroll down to "Other actions" and open it. Select "Delete subsection"
- Are you sure: "Yes"
- On the nofo_edit page again, click "See all updates to this nofo"
- Your 3 actions for your deleted subsection should all be there (Create, Update, Delete)
  - If you switch to your `main` branch and reload this page, those three events will not be there

## Screenshots

| before | after | after (closer)
|--------|-------|-------|
|  Audit table on "main", no audit events for the New subsection      | Audit table on this branch. 3 new audit events for "New subsection"      | Closeup of the 3 new audit events |
|   <img width="1385" alt="Screenshot 2025-05-13 at 12 32 00 PM" src="https://github.com/user-attachments/assets/f81e51c1-dcae-4f12-a107-4980852040d2" />     |   <img width="1385" alt="Screenshot 2025-05-13 at 12 32 16 PM" src="https://github.com/user-attachments/assets/3f27aa51-b3d8-491b-91b8-ecfa8b34bd18" />  | <img width="1031" alt="Screenshot 2025-05-13 at 12 32 27 PM" src="https://github.com/user-attachments/assets/53781bc2-389a-486d-b620-b65f3835f41d" />  |



