### PR TITLE
Refactor for Edit View, Update Empty String Logic, & other Small Bugfixes

### DIFF
--- a/nofos/bloom_nofos/static/js/nofo_edit_form.js
+++ b/nofos/bloom_nofos/static/js/nofo_edit_form.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded', function () {
+  try {
+    const formId = window.nofoEditFormId || 'nofo_edit_form';
+    const form = document.getElementById(formId);
+    
+    if (!form) {
+      console.error('Form not found:', formId);
+      return;
+    }
+
+    const button = form.querySelector('button[type="submit"]');
+    if (!button) {
+      console.error('Submit button not found');
+      return;
+    }
+
+    const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
+    const originalButtonText = button.textContent.trim() || 'Save';
+
+    if (checkboxes.length === 0) {
+      // No subsection matches, nothing to do
+      return;
+    }
+
+    function updateButtonText() {
+      const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
+      const baseText = originalButtonText || 'Save';
+      if (checkedCount === 0) {
+        button.textContent = baseText;
+      } else if (checkedCount === 1) {
+        button.textContent = `${baseText} + 1 subsection`;
+      } else {
+        button.textContent = `${baseText} + ${checkedCount} subsections`;
+      }
+    }
+
+    function updateRowHighlight(checkbox) {
+      const row = checkbox.closest('tr');
+      if (!row) return;
+      
+      // Toggle the highlight class based on checkbox state
+      if (checkbox.checked) {
+        row.classList.add('subsection--selected');
+      } else {
+        row.classList.remove('subsection--selected');
+      }
+    }
+
+    // Attach listener to each checkbox
+    checkboxes.forEach(function (checkbox) {
+      checkbox.addEventListener('change', function () {
+        updateButtonText();
+        updateRowHighlight(this);
+      });
+    });
+
+    // Initialize state
+    updateButtonText();
+    // Initialize highlighting for all checked checkboxes
+    checkboxes.forEach(checkbox => {
+      if (checkbox.checked) {
+        updateRowHighlight(checkbox);
+      }
+    });
+  } catch (error) {
+    console.error('Error in form initialization:', error);
+  }
+});

--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -33,15 +33,47 @@ def create_object_model_form(model_class):
 create_nofo_form_class = create_object_model_form(Nofo)
 
 
-# Creating form classes
-NofoNameForm = create_nofo_form_class(
-    ["title", "short_name"], not_required_labels=["Short name"]
-)
+# Creating form classes with validation
+class NofoNameForm(forms.ModelForm):
+    class Meta:
+        model = Nofo
+        fields = ["title", "short_name"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["short_name"].required = False
+
+    def clean_title(self):
+        title = self.cleaned_data.get("title")
+        if title is None or not title.strip():
+            raise forms.ValidationError("Title cannot be empty.")
+        return title.strip()
+
+class NofoNumberForm(forms.ModelForm):
+    class Meta:
+        model = Nofo
+        fields = ["number"]
+
+    def clean_number(self):
+        number = self.cleaned_data.get("number")
+        if number is None or not number.strip():
+            raise forms.ValidationError("Number cannot be empty.")
+        return number.strip()
+
+class NofoApplicationDeadlineForm(forms.ModelForm):
+    class Meta:
+        model = Nofo
+        fields = ["application_deadline"]
+
+    def clean_application_deadline(self):
+        deadline = self.cleaned_data.get("application_deadline")
+        if deadline is None or not deadline.strip():
+            raise forms.ValidationError("Application deadline cannot be empty.")
+        return deadline.strip()
+
 NofoAgencyForm = create_nofo_form_class(["agency"])
-NofoApplicationDeadlineForm = create_nofo_form_class(["application_deadline"])
 NofoCoverForm = create_nofo_form_class(["cover"])
 NofoGroupForm = create_nofo_form_class(["group"])
-NofoNumberForm = create_nofo_form_class(["number"])
 NofoOpDivForm = create_nofo_form_class(["opdiv"])
 NofoSubagencyForm = create_nofo_form_class(
     ["subagency"], not_required_labels=["Subagency"]

--- a/nofos/nofos/models.py
+++ b/nofos/nofos/models.py
@@ -378,10 +378,14 @@ class Nofo(BaseNofo):
         super().clean()
         errors = {}
 
-        # Validate title or number is present
-        if not self.title and not self.number:
-            errors["title"] = "Either title or number must be provided"
-            errors["number"] = "Either title or number must be provided"
+        # Validate title or number is present and not just whitespace
+        title_empty = not self.title or not self.title.strip()
+        number_empty = not self.number or not self.number.strip()
+        
+        if title_empty and number_empty:
+            errors["title"] = "Either title or number must be provided and cannot be empty"
+            errors["number"] = "Either title or number must be provided and cannot be empty"
+
 
         if errors:
             raise ValidationError(errors)

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -2427,7 +2427,7 @@ def replace_value_in_subsections(subsection_ids, old_value, new_value):
     
     If new_value is empty, no replacements will be made and an empty list will be returned.
     """
-    if not subsection_ids or not new_value:
+    if not subsection_ids or not new_value or not old_value:
         return []
 
     updated_subsections = []

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -2424,8 +2424,10 @@ def replace_value_in_subsections(subsection_ids, old_value, new_value):
     Replaces `old_value` with `new_value` in bodies of given subsection_ids.
     Note that old_value uses a case-insensitive compare, so "JUNE 1" will match "June 1".
     Returns the list of updated Subsection objects.
+    
+    If new_value is empty, no replacements will be made and an empty list will be returned.
     """
-    if not subsection_ids:
+    if not subsection_ids or not new_value:
         return []
 
     updated_subsections = []

--- a/nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -1,122 +1,31 @@
-{% extends 'base.html' %}
-{% load nofo_name subsection_name_or_order %}
-
-{% block title %}
-  NOFO Application Deadline
-{% endblock %}
+{% extends 'nofos/nofo_edit_base.html' %}
 
 {% block body_class %}edit__application-deadline{% endblock %}
 
-{% block content %}
-  {% with nofo|nofo_name as nofo_name_str %}
-  {% with "Back to  “"|add:nofo_name_str|add:"”" as back_text %}
-    {% url 'nofos:nofo_edit' nofo.id as back_href %}
-    {% include "includes/page_heading.html" with title="NOFO Application Deadline" back_text=back_text back_href=back_href only %}
-  {% endwith %}
-  {% endwith %}
+{% block title %}NOFO Application Deadline{% endblock %}
 
-  <form id="nofo-application-deadline--form" method="post">
-    {% csrf_token %}
+{% with page_title="NOFO Application Deadline" %}
+{% with form_id="nofo_application_deadline_form" %}
+{% with button_text="Save application deadline" %}
+{% with match_value=form.application_deadline.value %}
+{% with replace_text="application deadline" %}
+{% with checkbox_checked=True %}
 
-    {% include "includes/form_macro.html" with hint2="eg: “Monday, January 1, 2024”" %}
-
-    <button class="usa-button margin-top-3" type="submit">Save application deadline</button>
-
-  {% if subsection_matches %}
-    <table class="usa-table usa-table--borderless margin-top-4">
-      <caption>
-        <h2 class="h4">{{ subsection_matches|length }} subsection{{ subsection_matches|length|pluralize }} found with “{{ form.application_deadline.value }}”</h2>
-      </caption>
-      <thead>
-        <tr class="usa-sr-only">
-          <th scope="col">Replace?</th>
-          <th scope="col">Section</th>
-          <th scope="col">Subsection</th>
-          <th scope="col">Content</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for match in subsection_matches %}
-        <tr>
-          <td>
-            <div class="usa-checkbox">
-              <input
-                class="usa-checkbox__input"
-                id="replace-{{ match.subsection.id }}"
-                type="checkbox"
-                name="replace_subsections"
-                value="{{ match.subsection.id }}"
-                checked
-              />
-              <label class="usa-checkbox__label" for="replace-{{ match.subsection.id }}">
-                <span class="usa-sr-only">Replace application deadline in subsection: {{ match.subsection|subsection_name_or_order }}</span>
-              </label>
-            </div>
-          </td>
-          <td>{{ match.section.name }}</td>
-          <td>
-            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
-              {{ match.subsection|subsection_name_or_order }}
-            </a>
-          </td>
-          <td>
-            {{ match.subsection_body_highlight|safe|linebreaksbr }}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% endif %}
-  </form>
+{% block form_content %}
+  {% include "includes/form_macro.html" with hint2='eg: "Monday, January 1, 2024"' %}
 {% endblock %}
 
-{% block js_footer %}
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const form = document.getElementById('nofo-application-deadline--form');
-      const button = form.querySelector('button[type="submit"]');
-      const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
-      const originalButtonText = button.textContent.trim();
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
 
-      if (checkboxes.length === 0) {
-        // No subsection matches, nothing to do
-        return;
-      }
-
-      function updateButtonText() {
-        const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
-        if (checkedCount === 0) {
-          button.textContent = originalButtonText;
-        } else if (checkedCount === 1) {
-          button.textContent = `${originalButtonText} + 1 subsection`;
-        } else {
-          button.textContent = `${originalButtonText} + ${checkedCount} subsections`;
-        }
-      }
-
-      function updateRowHighlight(checkbox) {
-        const row = checkbox.closest('tr');
-        const className = 'subsection--selected'
-        if (checkbox.checked) {
-          row.classList.add(className);
-        } else {
-          row.classList.remove(className);
-        }
-      }
-
-      // Attach listener to each checkbox
-      checkboxes.forEach(function (checkbox) {
-        checkbox.addEventListener('change', function () {
-          updateButtonText();
-          updateRowHighlight(checkbox);
-        });
-
-        // run once when page loads
-        updateRowHighlight(checkbox);
-      });
-
-      // run once when page loads
-      updateButtonText();
-    });
-  </script>
+{% block content %}
+{% with match_value=form.application_deadline.value %}
+{% with button_text="Save application deadline" %}
+{{ block.super }}
+{% endwith %}
+{% endwith %}
 {% endblock %}

--- a/nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -5,7 +5,7 @@
 {% block title %}NOFO Application Deadline{% endblock %}
 
 {% with page_title="NOFO Application Deadline" %}
-{% with form_id="nofo_application_deadline_form" %}
+{% with form_id="nofo_edit_application_deadline_form" %}
 {% with button_text="Save application deadline" %}
 {% with match_value=form.application_deadline.value %}
 {% with replace_text="application deadline" %}

--- a/nofos/nofos/templates/nofos/nofo_edit_base.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_base.html
@@ -1,0 +1,152 @@
+{% extends 'base.html' %}
+{% load nofo_name subsection_name_or_order %}
+
+{% block body_class %}{% endblock %}
+
+{% block title %}{% endblock %}
+
+{% block content %}
+  {% with nofo|nofo_name as nofo_name_str %}
+  {% with "Back to “"|add:nofo_name_str|add:"”" as back_text %}
+    {% url 'nofos:nofo_edit' nofo.id as back_href %}
+    {% include "includes/page_heading.html" with title=page_title back_text=back_text back_href=back_href only %}
+  {% endwith %}
+  {% endwith %}
+
+  <form id="{{ form_id|default:'nofo-edit-form' }}" method="post">
+    {% csrf_token %}
+
+    {% block form_content %}{% endblock %}
+
+    <button class="usa-button margin-top-3" type="submit">{{ button_text }}</button>
+
+  {% if subsection_matches %}
+    <table class="usa-table usa-table--borderless margin-top-4">
+      <caption>
+        <h2 class="h4">
+          {{ subsection_matches|length }} subsection{{ subsection_matches|length|pluralize }} found with 
+          "{% firstof match_value form.title.value form.number.value form.application_deadline.value '(no value)' %}"
+        </h2>
+      </caption>
+      <thead>
+        <tr class="usa-sr-only">
+          <th scope="col">Replace?</th>
+          <th scope="col">Section</th>
+          <th scope="col">Subsection</th>
+          <th scope="col">Content</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for match in subsection_matches %}
+        <tr class="{% if checkbox_checked|default:"True" %}subsection--selected{% endif %}">
+          <td>
+            <div class="usa-checkbox">
+              <input
+                class="usa-checkbox__input"
+                id="replace-{{ match.subsection.id }}"
+                type="checkbox"
+                name="replace_subsections"
+                value="{{ match.subsection.id }}"
+                {% if checkbox_checked|default:"True" %}checked{% endif %}
+              />
+              <label class="usa-checkbox__label" for="replace-{{ match.subsection.id }}">
+                <span class="usa-sr-only">Replace {{ replace_text }} in subsection: {{ match.subsection|subsection_name_or_order }}</span>
+              </label>
+            </div>
+          </td>
+          <td>{{ match.section.name }}</td>
+          <td>
+            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
+              {{ match.subsection|subsection_name_or_order }}
+            </a>
+          </td>
+          <td>
+            {{ match.subsection_body_highlight|safe|linebreaksbr }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+  </form>
+{% endblock %}
+
+{% block js_footer %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      try {
+        const formId = '{{ form_id|default:"nofo-edit-form" }}';
+        const form = document.getElementById(formId);
+        
+        if (!form) {
+          console.error('Form not found:', formId);
+          return;
+        }
+
+        const button = form.querySelector('button[type="submit"]');
+        if (!button) {
+          console.error('Submit button not found');
+          return;
+        }
+
+        const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
+        const originalButtonText = button.textContent.trim() || '{{ button_text|default:"Save" }}';
+
+        if (checkboxes.length === 0) {
+          // No subsection matches, nothing to do
+          return;
+        }
+
+        function updateButtonText() {
+          const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
+          const baseText = originalButtonText || 'Save';
+          if (checkedCount === 0) {
+            button.textContent = baseText;
+          } else if (checkedCount === 1) {
+            button.textContent = `${baseText} + 1 subsection`;
+          } else {
+            button.textContent = `${baseText} + ${checkedCount} subsections`;
+          }
+          
+        }
+
+        function updateRowHighlight(checkbox) {
+          const row = checkbox.closest('tr');
+          if (!row) return;
+          
+          // Remove highlight from all rows first
+          form.querySelectorAll('tr').forEach(tr => {
+            tr.classList.remove('subsection--selected');
+          });
+          
+          // Add highlight to checked rows
+          form.querySelectorAll('input[name="replace_subsections"]:checked').forEach(cb => {
+            const checkedRow = cb.closest('tr');
+            if (checkedRow) {
+              checkedRow.classList.add('subsection--selected');
+            }
+          });
+        }
+
+        // Attach listener to each checkbox
+        checkboxes.forEach(function (checkbox) {
+          checkbox.addEventListener('change', function () {
+            updateButtonText();
+            updateRowHighlight(this);
+          });
+        });
+
+        // Initialize state
+        updateButtonText();
+        // Initialize highlighting for all checked checkboxes
+        checkboxes.forEach(checkbox => {
+          if (checkbox.checked) {
+            updateRowHighlight(checkbox);
+          }
+        });
+      } catch (error) {
+        console.error('Error in form initialization:', error);
+      }
+    });
+  </script>
+{% endblock %}

--- a/nofos/nofos/templates/nofos/nofo_edit_base.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_base.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load nofo_name subsection_name_or_order %}
 
-{% block body_class %}{% endblock %}
+{% block body_class %}nofo_edit{% endblock %}
 
 {% block title %}{% endblock %}
 
@@ -13,7 +13,7 @@
   {% endwith %}
   {% endwith %}
 
-  <form id="{{ form_id|default:'nofo-edit-form' }}" method="post">
+  <form id="{{ form_id|default:'nofo_edit_form' }}" class="nofo_edit_form" method="post">
     {% csrf_token %}
 
     {% block form_content %}{% endblock %}
@@ -73,80 +73,7 @@
 
 {% block js_footer %}
   <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      try {
-        const formId = '{{ form_id|default:"nofo-edit-form" }}';
-        const form = document.getElementById(formId);
-        
-        if (!form) {
-          console.error('Form not found:', formId);
-          return;
-        }
-
-        const button = form.querySelector('button[type="submit"]');
-        if (!button) {
-          console.error('Submit button not found');
-          return;
-        }
-
-        const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
-        const originalButtonText = button.textContent.trim() || '{{ button_text|default:"Save" }}';
-
-        if (checkboxes.length === 0) {
-          // No subsection matches, nothing to do
-          return;
-        }
-
-        function updateButtonText() {
-          const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
-          const baseText = originalButtonText || 'Save';
-          if (checkedCount === 0) {
-            button.textContent = baseText;
-          } else if (checkedCount === 1) {
-            button.textContent = `${baseText} + 1 subsection`;
-          } else {
-            button.textContent = `${baseText} + ${checkedCount} subsections`;
-          }
-          
-        }
-
-        function updateRowHighlight(checkbox) {
-          const row = checkbox.closest('tr');
-          if (!row) return;
-          
-          // Remove highlight from all rows first
-          form.querySelectorAll('tr').forEach(tr => {
-            tr.classList.remove('subsection--selected');
-          });
-          
-          // Add highlight to checked rows
-          form.querySelectorAll('input[name="replace_subsections"]:checked').forEach(cb => {
-            const checkedRow = cb.closest('tr');
-            if (checkedRow) {
-              checkedRow.classList.add('subsection--selected');
-            }
-          });
-        }
-
-        // Attach listener to each checkbox
-        checkboxes.forEach(function (checkbox) {
-          checkbox.addEventListener('change', function () {
-            updateButtonText();
-            updateRowHighlight(this);
-          });
-        });
-
-        // Initialize state
-        updateButtonText();
-        // Initialize highlighting for all checked checkboxes
-        checkboxes.forEach(checkbox => {
-          if (checkbox.checked) {
-            updateRowHighlight(checkbox);
-          }
-        });
-      } catch (error) {
-        console.error('Error in form initialization:', error);
-      }
-    });
+    window.nofoEditFormId = '{{ form_id|default:"nofo_edit_form" }}';
   </script>
+  <script src="/static/js/nofo_edit_form.js"></script>
 {% endblock %}

--- a/nofos/nofos/templates/nofos/nofo_edit_base.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_base.html
@@ -56,7 +56,7 @@
           </td>
           <td>{{ match.section.name }}</td>
           <td>
-            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
+            <a class="usa-link usa-link--external" target="_blank" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
               {{ match.subsection|subsection_name_or_order }}
             </a>
           </td>

--- a/nofos/nofos/templates/nofos/nofo_edit_number.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_number.html
@@ -1,121 +1,31 @@
-{% extends 'base.html' %}
-{% load nofo_name subsection_name_or_order %}
+{% extends 'nofos/nofo_edit_base.html' %}
 
 {% block body_class %}edit__nofo-number{% endblock %}
 
-{% block title %}
-  NOFO Opportunity number
+{% block title %}NOFO Opportunity number{% endblock %}
+
+{% with page_title="NOFO Opportunity number" %}
+{% with form_id="nofo-number--form" %}
+{% with button_text="Save number" %}
+{% with match_value=form.number.value %}
+{% with replace_text="number" %}
+{% with checkbox_checked=True %}
+
+{% block form_content %}
+  {% include "includes/form_macro.html" with hint2='eg: "HRSA-24-019"' %}
 {% endblock %}
+
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
 
 {% block content %}
-  {% with nofo|nofo_name as nofo_name_str %}
-  {% with "Back to  “"|add:nofo_name_str|add:"”" as back_text %}
-    {% url 'nofos:nofo_edit' nofo.id as back_href %}
-    {% include "includes/page_heading.html" with title="NOFO Opportunity number" back_text=back_text back_href=back_href only %}
-  {% endwith %}
-  {% endwith %}
-
-  <form id="nofo-number--form" method="post">
-    {% csrf_token %}
-
-    {% include "includes/form_macro.html" with hint2="eg: “HRSA-24-019”" %}
-
-    <button class="usa-button margin-top-3" type="submit">Save number</button>
-
-  {% if subsection_matches %}
-    <table class="usa-table usa-table--borderless margin-top-4">
-      <caption>
-        <h2 class="h4">{{ subsection_matches|length }} subsection{{ subsection_matches|length|pluralize }} found with "{{ form.number.value }}"</h2>
-      </caption>
-      <thead>
-        <tr class="usa-sr-only">
-          <th scope="col">Replace?</th>
-          <th scope="col">Section</th>
-          <th scope="col">Subsection</th>
-          <th scope="col">Content</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for match in subsection_matches %}
-        <tr>
-          <td>
-            <div class="usa-checkbox">
-              <input
-                class="usa-checkbox__input"
-                id="replace-{{ match.subsection.id }}"
-                type="checkbox"
-                name="replace_subsections"
-                value="{{ match.subsection.id }}"
-              />
-              <label class="usa-checkbox__label" for="replace-{{ match.subsection.id }}">
-                <span class="usa-sr-only">Replace number in subsection: {{ match.subsection|subsection_name_or_order }}</span>
-              </label>
-            </div>
-          </td>
-          <td>{{ match.section.name }}</td>
-          <td>
-            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
-              {{ match.subsection|subsection_name_or_order }}
-            </a>
-          </td>
-          <td>
-            {{ match.subsection_body_highlight|safe|linebreaksbr }}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% endif %}
-  </form>
-{% endblock %}
-
-{% block js_footer %}
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const form = document.getElementById('nofo-number--form');
-      const button = form.querySelector('button[type="submit"]');
-      const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
-      const originalButtonText = button.textContent.trim();
-
-      if (checkboxes.length === 0) {
-        // No subsection matches, nothing to do
-        return;
-      }
-
-      function updateButtonText() {
-        const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
-        if (checkedCount === 0) {
-          button.textContent = originalButtonText;
-        } else if (checkedCount === 1) {
-          button.textContent = `${originalButtonText} + 1 subsection`;
-        } else {
-          button.textContent = `${originalButtonText} + ${checkedCount} subsections`;
-        }
-      }
-
-      function updateRowHighlight(checkbox) {
-        const row = checkbox.closest('tr');
-        const className = 'subsection--selected'
-        if (checkbox.checked) {
-          row.classList.add(className);
-        } else {
-          row.classList.remove(className);
-        }
-      }
-
-      // Attach listener to each checkbox
-      checkboxes.forEach(function (checkbox) {
-        checkbox.addEventListener('change', function () {
-          updateButtonText();
-          updateRowHighlight(checkbox);
-        });
-
-        // run once when page loads
-        updateRowHighlight(checkbox);
-      });
-
-      // run once when page loads
-      updateButtonText();
-    });
-  </script>
+{% with match_value=form.number.value %}
+{% with button_text="Save number" %}
+{{ block.super }}
+{% endwith %}
+{% endwith %}
 {% endblock %}

--- a/nofos/nofos/templates/nofos/nofo_edit_number.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_number.html
@@ -5,7 +5,7 @@
 {% block title %}NOFO Opportunity number{% endblock %}
 
 {% with page_title="NOFO Opportunity number" %}
-{% with form_id="nofo-number--form" %}
+{% with form_id="nofo_edit_number_form" %}
 {% with button_text="Save number" %}
 {% with match_value=form.number.value %}
 {% with replace_text="number" %}

--- a/nofos/nofos/templates/nofos/nofo_edit_title.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_title.html
@@ -1,125 +1,34 @@
-{% extends 'base.html' %}
-{% load nofo_name subsection_name_or_order %}
+{% extends 'nofos/nofo_edit_base.html' %}
 
 {% block body_class %}edit__nofo-title{% endblock %}
 
-{% block title %}
-  NOFO title and short name
+{% block title %}NOFO title and short name{% endblock %}
+
+{% with page_title="NOFO title and short name" %}
+{% with form_id="nofo-title--form" %}
+{% with button_text="Save name" %}
+{% with match_value=form.title.value %}
+{% with replace_text="title" %}
+{% with checkbox_checked=True %}
+
+{% block form_content %}
+  {% include "includes/form_macro.html" with hint2='eg: "Physician Assistant Rural Training in Mental and Behavioral Health (PCTE-PARM) Program"' hint2for="title" %}
+  <div class="usa-hint margin-top-05" id="short_name--hint-2">
+    Opportunity number for this NOFO: {{ nofo.number }}
+  </div>
 {% endblock %}
+
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
 
 {% block content %}
-  {% with nofo|nofo_name as nofo_name_str %}
-  {% with "Back to  “"|add:nofo_name_str|add:"”" as back_text %}
-    {% url 'nofos:nofo_edit' nofo.id as back_href %}
-    {% include "includes/page_heading.html" with title="NOFO title and short name" back_text=back_text back_href=back_href only %}
-  {% endwith %}
-  {% endwith %}
-
-  <form id="nofo-title--form" method="post">
-    {% csrf_token %}
-
-    {% include "includes/form_macro.html" with hint2="eg: “Physician Assistant Rural Training in Mental and Behavioral Health (PCTE-PARM) Program”" hint2for="title" %}
-
-    <div class="usa-hint margin-top-05" id="short_name--hint-2">
-      Opportunity number for this NOFO: {{ nofo.number }}
-    </div>
-
-    <button class="usa-button margin-top-3" type="submit">Save name</button>
-
-  {% if subsection_matches %}
-    <table class="usa-table usa-table--borderless margin-top-4">
-      <caption>
-        <h2 class="h4">{{ subsection_matches|length }} subsection{{ subsection_matches|length|pluralize }} found with "{{ form.title.value }}"</h2>
-      </caption>
-      <thead>
-        <tr class="usa-sr-only">
-          <th scope="col">Replace?</th>
-          <th scope="col">Section</th>
-          <th scope="col">Subsection</th>
-          <th scope="col">Content</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for match in subsection_matches %}
-        <tr>
-          <td>
-            <div class="usa-checkbox">
-              <input
-                class="usa-checkbox__input"
-                id="replace-{{ match.subsection.id }}"
-                type="checkbox"
-                name="replace_subsections"
-                value="{{ match.subsection.id }}"
-              />
-              <label class="usa-checkbox__label" for="replace-{{ match.subsection.id }}">
-                <span class="usa-sr-only">Replace title in subsection: {{ match.subsection|subsection_name_or_order }}</span>
-              </label>
-            </div>
-          </td>
-          <td>{{ match.section.name }}</td>
-          <td>
-            <a class="usa-link usa-link--external" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
-              {{ match.subsection|subsection_name_or_order }}
-            </a>
-          </td>
-          <td>
-            {{ match.subsection_body_highlight|safe|linebreaksbr }}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% endif %}
-  </form>
-{% endblock %}
-
-{% block js_footer %}
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const form = document.getElementById('nofo-title--form');
-      const button = form.querySelector('button[type="submit"]');
-      const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
-      const originalButtonText = button.textContent.trim();
-
-      if (checkboxes.length === 0) {
-        // No subsection matches, nothing to do
-        return;
-      }
-
-      function updateButtonText() {
-        const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
-        if (checkedCount === 0) {
-          button.textContent = originalButtonText;
-        } else if (checkedCount === 1) {
-          button.textContent = `${originalButtonText} + 1 subsection`;
-        } else {
-          button.textContent = `${originalButtonText} + ${checkedCount} subsections`;
-        }
-      }
-
-      function updateRowHighlight(checkbox) {
-        const row = checkbox.closest('tr');
-        const className = 'subsection--selected'
-        if (checkbox.checked) {
-          row.classList.add(className);
-        } else {
-          row.classList.remove(className);
-        }
-      }
-
-      // Attach listener to each checkbox
-      checkboxes.forEach(function (checkbox) {
-        checkbox.addEventListener('change', function () {
-          updateButtonText();
-          updateRowHighlight(checkbox);
-        });
-
-        // run once when page loads
-        updateRowHighlight(checkbox);
-      });
-
-      // run once when page loads
-      updateButtonText();
-    });
-  </script>
+{% with match_value=form.title.value %}
+{% with button_text="Save title" %}
+{{ block.super }}
+{% endwith %}
+{% endwith %}
 {% endblock %}

--- a/nofos/nofos/templates/nofos/nofo_edit_title.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_title.html
@@ -5,7 +5,7 @@
 {% block title %}NOFO title and short name{% endblock %}
 
 {% with page_title="NOFO title and short name" %}
-{% with form_id="nofo-title--form" %}
+{% with form_id="nofo_edit_title_form" %}
 {% with button_text="Save name" %}
 {% with match_value=form.title.value %}
 {% with replace_text="title" %}

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -1015,17 +1015,16 @@ class CreateNOFOTests(TestCase):
             tag="h3",
             body="The deadline is June 1, 2025"
         )
-        
+
         # Attempt to replace with empty value
         updated = replace_value_in_subsections(
             [subsection.id],
             "June 1, 2025",
             ""
         )
-        
-        # No updates should occur
+
         self.assertEqual(len(updated), 0)
-        
+
         # Verify subsection was not changed
         subsection.refresh_from_db()
         self.assertEqual(subsection.body, "The deadline is June 1, 2025")
@@ -7070,29 +7069,25 @@ class ReplaceValueInSubsectionsTests(TestCase):
         self.assertNotIn("Test NOFO", self.subsection_1.body)
 
     def test_replace_with_empty_value(self):
-        self.subsection_1.body = "The title is Test NOFO"
+        original_body = "The title is Test NOFO"
+        self.subsection_1.body = original_body
         self.subsection_1.save()
         updated = replace_value_in_subsections(
             [self.subsection_1.id],
             "Test NOFO",
             "",
         )
-        self.assertEqual(len(updated), 1)
+        self.assertEqual(len(updated), 0)
         self.subsection_1.refresh_from_db()
-        self.assertIn("The title is ", self.subsection_1.body)
-        self.assertNotIn("Test NOFO", self.subsection_1.body)
+        self.assertEqual(self.subsection_1.body, original_body)
 
-    # NOTE - Commenting our for the time being. This feels like we should
-    # conditionally check this in the function behavior.
     def test_replace_empty_old_value_behavior(self):
-        # Since the function appears to process empty strings (based on the test failure),
-        # we should test the actual behavior rather than what we initially expected
         original_body = self.subsection_1.body
         updated = replace_value_in_subsections(
             [self.subsection_1.id],
             "",
             "New Value",
         )
-        self.assertEqual(len(updated), 1)
+        self.assertEqual(len(updated), 0)
         self.subsection_1.refresh_from_db()
-        self.assertNotEqual(self.subsection_1.body, original_body)
+        self.assertEqual(self.subsection_1.body, original_body)

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -1004,6 +1004,32 @@ class CreateNOFOTests(TestCase):
         self.assertEqual(nofo.title, "")
         self.assertEqual(len(nofo.sections.all()), 0)
 
+    def test_replace_value_in_subsections_empty_value(self):
+        """Test that empty values are not allowed as replacement values"""
+        nofo = Nofo.objects.create(title="Test NOFO", opdiv="Test OpDiv")
+        section = Section.objects.create(nofo=nofo, name="Test Section", order=1)
+        subsection = Subsection.objects.create(
+            section=section,
+            name="Test Subsection",
+            order=1,
+            tag="h3",
+            body="The deadline is June 1, 2025"
+        )
+        
+        # Attempt to replace with empty value
+        updated = replace_value_in_subsections(
+            [subsection.id],
+            "June 1, 2025",
+            ""
+        )
+        
+        # No updates should occur
+        self.assertEqual(len(updated), 0)
+        
+        # Verify subsection was not changed
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.body, "The deadline is June 1, 2025")
+
     def test_create_nofo_subsection_body_is_markdown(self):
         """
         Test creating a nofo object with markdown strings (not HTML) as body
@@ -7058,15 +7084,15 @@ class ReplaceValueInSubsectionsTests(TestCase):
 
     # NOTE - Commenting our for the time being. This feels like we should
     # conditionally check this in the function behavior.
-    # def test_replace_empty_old_value_behavior(self):
-    #     # Since the function appears to process empty strings (based on the test failure),
-    #     # we should test the actual behavior rather than what we initially expected
-    #     original_body = self.subsection_1.body
-    #     updated = replace_value_in_subsections(
-    #         [self.subsection_1.id],
-    #         "",
-    #         "New Value",
-    #     )
-    #     self.assertEqual(len(updated), 1)
-    #     self.subsection_1.refresh_from_db()
-    #     self.assertNotEqual(self.subsection_1.body, original_body)
+    def test_replace_empty_old_value_behavior(self):
+        # Since the function appears to process empty strings (based on the test failure),
+        # we should test the actual behavior rather than what we initially expected
+        original_body = self.subsection_1.body
+        updated = replace_value_in_subsections(
+            [self.subsection_1.id],
+            "",
+            "New Value",
+        )
+        self.assertEqual(len(updated), 1)
+        self.subsection_1.refresh_from_db()
+        self.assertNotEqual(self.subsection_1.body, original_body)


### PR DESCRIPTION
## Summary
The fixes in the PR here primary address concerns from [this comment](https://github.com/HHS/simpler-grants-pdf-builder/pull/323).

## Details
This is a bit of a refactor in order to de-duplicate logic / templating being shared across multiple edit screens.

In no particular order:
- Pulled out shared Javascript into the `static` folder as `nofo_edit_form.js`
- Pulled out shared templating logic into `nofo_edit_base.html`
- Updated logic in `forms.py` to check for empty strings
- Updated logic in `models.py` to check for empty strings
- Added/Fixed some tests

## Screenshots

| Empty String for Title | Empty String for App Deadline | Empty String for NOFO Number |
| -------- | -------- | -------- |
| <img width="763" alt="Screenshot 2025-05-14 at 10 48 36 AM" src="https://github.com/user-attachments/assets/6f5e72b6-5226-47b6-97fd-d6dadc38b2bc" /> | <img width="594" alt="Screenshot 2025-05-14 at 10 48 55 AM" src="https://github.com/user-attachments/assets/3d3a09ae-710b-4863-a808-27b3ac71a816" /> | <img width="590" alt="Screenshot 2025-05-14 at 10 48 22 AM" src="https://github.com/user-attachments/assets/23c4e7b2-d6d6-466f-a61c-b20c719011ca" /> |