### PR TITLE
Added simple /health API endpoint

### DIFF
--- a/nofos/bloom_nofos/urls.py
+++ b/nofos/bloom_nofos/urls.py
@@ -19,7 +19,7 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
-from nofos.api.api import api
+from nofos.api.api import api, health_api
 
 from . import views
 
@@ -49,5 +49,6 @@ urlpatterns = [
     path("test-mode", views.TestModeView.as_view(), name="test_mode"),
     path("", views.index, name="index"),
     path("404/", views.page_not_found),
-    path("api/", api.urls),
+    path("", health_api.urls),  # Mount health check at root
+    path("api/", api.urls),     # Mount main API under /api/
 ]

--- a/nofos/nofos/api/api.py
+++ b/nofos/nofos/api/api.py
@@ -17,16 +17,20 @@ class BearerAuth(HttpBearer):
         return None
 
 
+# Create a separate API instance for health check without namespace
+health_api = NinjaAPI(auth=None, urls_namespace=None)
+
+@health_api.get("/health", auth=None)
+def health_check(request):
+    """Health check endpoint that returns 200 OK."""
+    return 200, {"status": "ok"}
+
+# Main API instance for other endpoints
 api = NinjaAPI(
     auth=BearerAuth(),
     urls_namespace="api",
     docs_url="/docs",
 )
-
-@api.get("/health", auth=None)
-def health_check(request):
-    """Health check endpoint that returns 200 OK."""
-    return 200, {"status": "ok"}
 
 
 @api.post("/nofos", response={201: SuccessSchema, 400: ErrorSchema})

--- a/nofos/nofos/api/api.py
+++ b/nofos/nofos/api/api.py
@@ -23,6 +23,11 @@ api = NinjaAPI(
     docs_url="/docs",
 )
 
+@api.get("/health", auth=None)
+def health_check(request):
+    """Health check endpoint that returns 200 OK."""
+    return 200, {"status": "ok"}
+
 
 @api.post("/nofos", response={201: SuccessSchema, 400: ErrorSchema})
 def create_nofo(request, payload: NofoSchema):

--- a/nofos/nofos/api/tests.py
+++ b/nofos/nofos/api/tests.py
@@ -9,7 +9,7 @@ from nofos.models import Nofo, Section, Subsection
 class HealthCheckAPITest(TestCase):
     def test_health_check(self):
         """Test that health check endpoint returns 200 OK with correct response"""
-        response = self.client.get("/api/health")
+        response = self.client.get("/health")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"status": "ok"})
 

--- a/nofos/nofos/api/tests.py
+++ b/nofos/nofos/api/tests.py
@@ -6,6 +6,13 @@ from django.test import TestCase, override_settings
 from nofos.models import Nofo, Section, Subsection
 
 
+class HealthCheckAPITest(TestCase):
+    def test_health_check(self):
+        """Test that health check endpoint returns 200 OK with correct response"""
+        response = self.client.get("/api/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
 @override_settings(API_TOKEN="test-token-for-ci")
 class NofoAPITest(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
Add a health check endpoint at `/api/health` that doesn't require auth.

## More Info
We've decided to add this such that when the app is running, we can quickly check the status. This is in anticipation of running this within AWS.

Please note that this is _very_ simple and could be expanded to include checking the Database Connection too.

## Screenshots
<img width="358" alt="Screenshot 2025-05-14 at 1 19 31 PM" src="https://github.com/user-attachments/assets/ed7ea178-a1a0-4f55-9c10-bf29452423ee" />
