### PR TITLE
Add wget for docker & support `HEAD` method for /health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add healthcheck endpoint at /health
+
 ### Changed
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends \
   build-essential \
   curl \
+  wget \
   libffi-dev \
   libpq-dev \
   && rm -rf /var/lib/apt/lists/*

--- a/nofos/nofos/api/api.py
+++ b/nofos/nofos/api/api.py
@@ -20,10 +20,12 @@ class BearerAuth(HttpBearer):
 # Create a separate API instance for health check without namespace
 health_api = NinjaAPI(auth=None, urls_namespace=None)
 
-@health_api.get("/health", auth=None)
+
+@health_api.api_operation(["GET", "HEAD"], "/health", auth=None)
 def health_check(request):
     """Health check endpoint that returns 200 OK."""
     return 200, {"status": "ok"}
+
 
 # Main API instance for other endpoints
 api = NinjaAPI(

--- a/nofos/nofos/api/tests.py
+++ b/nofos/nofos/api/tests.py
@@ -7,11 +7,17 @@ from nofos.models import Nofo, Section, Subsection
 
 
 class HealthCheckAPITest(TestCase):
-    def test_health_check(self):
-        """Test that health check endpoint returns 200 OK with correct response"""
+    def test_health_check_get(self):
+        """Test that a GET request for health check endpoint returns 200 OK with correct response"""
         response = self.client.get("/health")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_health_check_head(self):
+        """Test that a HEAD request for health check endpoint returns 200 OK"""
+        response = self.client.head("/health")
+        self.assertEqual(response.status_code, 200)
+
 
 @override_settings(API_TOKEN="test-token-for-ci")
 class NofoAPITest(TestCase):


### PR DESCRIPTION
## Summary

This PR adds `wget` to our Dockerfile and also allows the `HEAD` method for the `/health` endpoint.

### Description

The "healthcheck_command" in simpler-grants-gov is running `wget` inside of the container to check that the app is up and running.

This means we need to install wget as a Docker dependency.

Here's the command ([link](https://github.com/HHS/simpler-grants-gov/blob/ea2460fd5b83763f633b6f21ef51a09e873c515b/infra/modules/service/variables.tf#L178)):
- `wget --no-verbose --tries=1 --spider http://localhost:8000/health || exit 1`

Also, it's not immediately obvious, but the "--spider" option will send a `HEAD` request instead of a `GET` request:

So this PR also enables the "HEAD" method and also adds a test to confirm.

### How to test this PR

The way to test this PR is to run the `CMD-SHELL` inside of a docker container, which is [how the `healthcheck_command` works in simpler-grants-gov](https://github.com/HHS/simpler-grants-gov/blob/ea2460fd5b83763f633b6f21ef51a09e873c515b/infra/modules/service/variables.tf#L173).

- From the repo root, build a docker container: `make build` 
- Run container in detached mode: `container_id=$(docker run -d -p 8000:8000 nofos:latest)`
- Run health check: `docker exec $container_id sh -c "wget --no-verbose --tries=1 --spider http://localhost:8000/health || exit 1"`
- Stop container: `docker stop $container_id`
- Delete container: `docker rm $container_id`
