### PR TITLE
Updated id selector CSS + added animations for alert/success

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -484,14 +484,28 @@ label.usa-label {
 }
 
 /* Alert styles */
-.usa-alert {
-  position: sticky;
-  top: 0;
-  z-index: 9999;
-  transition: opacity 0.3s ease-out;
-  margin-bottom: 1rem !important;
+#nofo-editor-success-alert,
+#nofo-editor-error-alert {
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  z-index: 99999;
+  margin: 0 !important;
   background: white;
-  isolation: isolate;
+  opacity: 0;
+  transition: opacity 0.3s ease-out;
+}
+
+#nofo-editor-success-alert.fade-out,
+#nofo-editor-error-alert.fade-out {
+  opacity: 0;
+}
+
+#nofo-editor-success-alert .usa-alert__body,
+#nofo-editor-error-alert .usa-alert__body {
+  max-width: none;
 }
 
 .usa-alert__body {

--- a/nofos/bloom_nofos/templates/includes/alerts.html
+++ b/nofos/bloom_nofos/templates/includes/alerts.html
@@ -28,8 +28,15 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
+    const ALERT_SELECTORS = '#nofo-editor-success-alert, #nofo-editor-error-alert';
+    const ANIMATION_DURATION = 300; // Duration of fade animation in ms
+    const AUTO_DISMISS_DELAY = 4000; // Time before auto-dismissal in ms
+
     // Handle close button clicks and keyboard events
-    const alerts = document.querySelectorAll('#nofo-editor-success-alert, #nofo-editor-error-alert');
+    const alerts = document.querySelectorAll(ALERT_SELECTORS);
+    requestAnimationFrame(() => {
+      alerts.forEach(alert => alert.style.opacity = '1');
+    });
     alerts.forEach(alert => {
       const closeButton = alert.querySelector('.usa-alert__close');
       if (closeButton) {
@@ -44,21 +51,20 @@
       }
     });
 
-    // Helper function to dismiss alert
     function dismissAlert(alert) {
       if (alert && alert.parentNode) {
         alert.style.opacity = '0';
-        setTimeout(() => alert.remove(), 300); // Remove after fade animation
+        setTimeout(() => alert.remove(), ANIMATION_DURATION);
       }
     }
 
-    // Auto-dismiss alerts after 4 seconds
+    // Auto-dismiss alerts
     alerts.forEach(alert => {
       setTimeout(() => {
         if (alert && alert.parentNode) {
           dismissAlert(alert);
         }
-      }, 4000);
+      }, AUTO_DISMISS_DELAY);
     });
   });
 </script>


### PR DESCRIPTION
## Summary
[This PR addresses the comment to move the alert/success to the bottom of the NOFO Builder](https://github.com/HHS/simpler-grants-pdf-builder/issues/322#issuecomment-2880610918). It still has with auto-dismiss behavior and proper accessibility features. The alerts will stay at the **bottom** of the page while scrolling, auto-dismiss after 4 seconds, and can be manually dismissed. The implementation ensures proper keyboard navigation and screen reader support.

## GIF Demo
![NOFO-fade](https://github.com/user-attachments/assets/5f3f4b2c-a143-4506-9b23-ebc9983c698a)

## Screenshot
![Screenshot 2025-05-15 at 2 00 48 PM](https://github.com/user-attachments/assets/04e846a1-4a99-49c8-a5fd-78fa14a53bad)
