### PR TITLE
Suppress 'static directory' warnings while running tests

### DIFF
--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 import sys
+import warnings
 from datetime import datetime
 from pathlib import Path
 
@@ -249,6 +250,18 @@ STATIC_URL = "static/"
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "bloom_nofos", "static"),
 ]
+
+if "test" in sys.argv:
+    # Suppress 'static directory' warnings while running tests
+    # > UserWarning: No directory at: /**/**/simpler-nofos-pdf-builder/nofos/static/
+    #
+    # Before running the 'collectstatic' command, the static directory doesn't exist
+    # None of our test rely on this but the warning is distracting, so let's hide it
+    warnings.filterwarnings(
+        "ignore",
+        message=r"No directory at: .*/nofos/static/",
+        category=UserWarning,
+    )
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Summary

This is a small PR that suppresses an irrelevant warning we see when running tests in a new repo.

It doesn't add any logic or new tests.

###  Description

When running tests from a brand new install of the repo, we were seeing this annoying warning message:

> `UserWarning: No directory at: /**/**/simpler-nofos-pdf-builder/nofos/static/`

Essentially, it is saying that before we run the `collectstatic` command, here is no "nofos/static" directory, which is a true fact.

However, it's not relevant for the tests and none of them rely on this so this commit hides this warning when running tests.

Previously, the test output looked like this:

```
Found 841 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......./**/pypoetry/virtualenvs/nofos-ztRUj9S3-py3.13/lib/python3.13/site-packages/django/core/handlers/base.py:61: UserWarning: No directory at: /**/simpler-nofos-pdf-builder/nofos/static/
  mw_instance = middleware(adapted_handler)
...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................../**/pypoetry/virtualenvs/nofos-ztRUj9S3-py3.13/lib/python3.13/site-packages/django/core/handlers/base.py:61: UserWarning: No directory at: /**/simpler-nofos-pdf-builder/nofos/static/
  mw_instance = middleware(adapted_handler)
.............................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 841 tests in 21.172s

OK
```

Now they look like this:

```
Found 841 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 841 tests in 22.009s

OK
```

Much better!

### How to test

- `cd` into `nofos`
- Run `poetry run test`

