### PR TITLE
Add current hostname IP to ALLOWED_HOSTS if inside private IP range (for ECR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning since version 1.0.0.
 ### Fixed
 
 - Show audit events for deleted subsections on the "All updates for NOFO" page
+- Add current hostname to ALLOWED_HOSTS if using a private IP range starting with "10."
 
 ## [3.1.0] - 2025-05-12
 

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 import sys
+from socket import gethostbyname, gethostname
+
 from datetime import datetime
 from pathlib import Path
 
@@ -71,6 +73,7 @@ SECRET_KEY = env("SECRET_KEY", default="bad-secret-key-please-change")
 
 API_TOKEN = env("API_TOKEN", default=None)
 
+# ALLOWED HOSTS
 ALLOWED_HOSTS = [
     "0.0.0.0",
     "127.0.0.1",
@@ -81,6 +84,10 @@ allowed_domain_string = env.get_value("DJANGO_ALLOWED_HOSTS", default="")
 if allowed_domain_string:
     ALLOWED_HOSTS.extend(allowed_domain_string.split(","))
 
+# Automatically add internal IP if it starts with "10." (private IP range)
+internal_ip = gethostbyname(gethostname())
+if internal_ip.startswith("10."):
+    ALLOWED_HOSTS.append(internal_ip)
 
 # SECURITY HEADERS
 SECURE_SSL_REDIRECT = is_prod


### PR DESCRIPTION
## Summary

When we are deploying the app inside of ECS, the containers use a dynamic private IP range starting with "10".

These can't be set in advance in env vars because they change, so we will now set them at runtime contingent on them being in a private IP range.

 This is apparently how we can check our local ip inside of a docker container so that we can add it to `ALLOWED_HOSTS`.

Sources:

- https://stackoverflow.com/questions/37031749/django-allowed-hosts-ips-range
- https://code.djangoproject.com/ticket/27485
- https://medium.com/django-unleashed/djangos-allowed-hosts-in-aws-ecs-369959f2c2ab

