### PR TITLE
Add `db-migrate` command that can be run from built container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning since version 1.0.0.
 ### Added
 
 - Add healthcheck endpoint at /health
+- Add `db-migrate` command that can be run from built container
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN poetry config virtualenvs.in-project true && \
 # Copy the rest of the app
 COPY . .
 
+# Make "db-migrate" a shell command in the container
+RUN echo '#!/bin/sh\nmake migrate' > /usr/local/bin/db-migrate && chmod +x /usr/local/bin/db-migrate
+
 # Collect static files
 RUN poetry run python nofos/manage.py collectstatic --noinput --verbosity 0
 


### PR DESCRIPTION
## Summary

This PR adds a `db-migrate` command that we can execute from the root of the Dockerfile.

### Details

Inside of the GitHub action to deploy the nofos app, we have a database migration step:

- https://github.com/HHS/simpler-grants-gov/commit/b703d97e753f6aad8dff5c5d335f16b4396563e4

Which triggers command "make release-run-database-migrations":

- https://github.com/HHS/simpler-grants-gov/blob/main/Makefile#L278

Which calls ./bin/run-database-migrations

- https://github.com/HHS/simpler-grants-gov/blob/main/bin/run-database-migrations#L6

Which calls "db-migrate" command inside the container.

So this PR adds a `db-migrate` command when building the Dockerfile so that we can run migrations the same way that all the other apps do.