### PR TITLE
Update ALLOWED_HOSTS for AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning since version 1.0.0.
 ### Fixed
 
 - Show audit events for deleted subsections on the "All updates for NOFO" page
+- Add AWS Load Balancer domain to ALLOWED_HOSTS
 - Add current hostname to ALLOWED_HOSTS if using a private IP range starting with "10."
 
 ## [3.1.0] - 2025-05-12

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 import sys
-from socket import gethostbyname, gethostname
 
 import warnings
 from datetime import datetime
@@ -23,7 +22,7 @@ import tomli
 from django.utils.timezone import now
 
 from .aws import is_aws_db, generate_iam_auth_token
-from .utils import cast_to_boolean, get_login_gov_keys
+from .utils import cast_to_boolean, get_login_gov_keys, get_internal_ip
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -86,7 +85,7 @@ if allowed_domain_string:
     ALLOWED_HOSTS.extend(allowed_domain_string.split(","))
 
 # Automatically add internal IP if it starts with "10." (private IP range)
-internal_ip = gethostbyname(gethostname())
+internal_ip = get_internal_ip()
 if internal_ip.startswith("10."):
     ALLOWED_HOSTS.append(internal_ip)
 

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -89,6 +89,10 @@ internal_ip = get_internal_ip()
 if internal_ip.startswith("10."):
     ALLOWED_HOSTS.append(internal_ip)
 
+aws_dns_name = env.get_value("LOAD_BALANCER_DNS_NAME", default="")
+if aws_dns_name:
+    ALLOWED_HOSTS.append(aws_dns_name)
+
 # SECURITY HEADERS
 SECURE_SSL_REDIRECT = is_prod
 SESSION_COOKIE_SECURE = is_prod

--- a/nofos/bloom_nofos/utils.py
+++ b/nofos/bloom_nofos/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+from socket import gethostbyname, gethostname, gaierror
 
 from django.conf import settings
 from django.utils.timezone import now, timedelta
@@ -42,6 +43,13 @@ def is_docraptor_live_mode_active(last_updated):
 
 def get_timedelta_for_docraptor_live_mode():
     return timedelta(minutes=5)
+
+
+def get_internal_ip():
+    try:
+        return gethostbyname(gethostname())
+    except gaierror:
+        return ""
 
 
 def parse_docraptor_ip_addresses(ip_string: str):


### PR DESCRIPTION
## Summary

This PR makes 2 changes:

1. Adds error checking to our `gethostbyname(gethostname())` call. 
2. Adds the Load Balancer DNS name to `ALLOWED_HOSTS` if it exists

These 2 changes will allow the container to run in non-Debug mode in AWS without using an "allow-everything" ALLOWED_HOSTS value of "*". 

They will also allow the app to run on Cory's laptop.

## Details

1. Adds error checking to our `gethostbyname(gethostname())` call.

Some people see an error when calling `gethostbyname(gethostname())`:

- https://stackoverflow.com/questions/39970606/gaierror-errno-8-nodename-nor-servname-provided-or-not-known-with-macos-sie
- https://github.com/zauberzeug/nicegui/issues/1178

We don't actually need to solve this error, we just need it to not crash. The point of this code is so that we can get our internal IP when we are running in a docker container in AWS. Locally, this condition will be skipped.

2. Adds the Load Balancer DNS name to `ALLOWED_HOSTS` if it exists

The DNS name is the semi-randomized web url that the load balancer accepts traffic at. If you visit it, you will see the app, but then Django will be mad if it doesn't know about the domain. 

This env var will exist in our environment if we are running in AWS, since this PR went in:  https://github.com/HHS/simpler-grants-gov/pull/5101


