### PR TITLE
Require ssl mode when connecting to AWS database

### DIFF
--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -220,6 +220,7 @@ if is_aws_db(env):
             "HOST": env.get_value("DB_HOST"),
             "PORT": int(env.get_value("DB_PORT", default=5432)),
             "OPTIONS": {
+                "sslmode": "require",
                 "connect_timeout": 10,
             },
         }


### PR DESCRIPTION
## Summary

There was a server error running the app in prod, and the root cause was this set of messages:

```
message:psycopg2.OperationalError: connection to server at "***" (***), port **** failed: 
FATAL: PAM authentication failed for user "***"
FATAL: pg rejects connection for host "***" user "***", database "***", no encryption
```

I've changed the database options to require `sslmode`, which seems to have done the trick.
