### PR TITLE
Bugfix - Remove Hyperlink for net-new subsection

### DIFF
--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1234,8 +1234,7 @@ class NofoSubsectionCreateView(
 
         messages.success(
             self.request,
-            "Created new subsection: “<a href='#{}'>{}</a>” in ‘{}’".format(
-                form.instance.html_id,
+            "Created new subsection: “{}” in ‘{}’".format(
                 form.instance.name or "(#{})".format(form.instance.order),
                 section.name,
             ),


### PR DESCRIPTION
## Summary
Per [convo here](https://github.com/HHS/simpler-grants-pdf-builder/issues/331#issuecomment-2894435148), we are simply removing the <a> tag that was being rendered since we auto-scroll to the destination.

## Screenshot of Fix

<img width="1675" alt="Screenshot 2025-05-20 at 8 37 17 PM" src="https://github.com/user-attachments/assets/fec81dd9-5939-4461-ac88-0236e90e6211" />
