### PR TITLE
Update Django to 5.0.14

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -461,13 +461,13 @@ test = ["cssselect", "importlib-resources", "jaraco.test (>=5.1)", "lxml", "pyte
 
 [[package]]
 name = "django"
-version = "5.0.13"
+version = "5.0.14"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "Django-5.0.13-py3-none-any.whl", hash = "sha256:b983238dfa2eb2e6b27ebb815e14f0741cf186606eb7bcd857e740174017c50e"},
-    {file = "Django-5.0.13.tar.gz", hash = "sha256:f9d4b7b87a9dae248d5f20cec940cf7290e07d508d6d8432e3c2cabf09b3b0ff"},
+    {file = "Django-5.0.14-py3-none-any.whl", hash = "sha256:e762bef8629ee704de215ebbd32062b84f4e56327eed412e5544f6f6eb1dfd74"},
+    {file = "Django-5.0.14.tar.gz", hash = "sha256:29019a5763dbd48da1720d687c3522ef40d1c61be6fb2fad27ed79e9f655bc11"},
 ]
 
 [package.dependencies]
@@ -1478,4 +1478,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.13"
-content-hash = "38c447e13916413c815e7ca11f41d887289ba3a6fe7c98f7a0b9620107ab5f81"
+content-hash = "d1f12b2d50748354f9531eaa45f8f9ee0e6d0490d0f2de6ff1c9b2b057f9b586"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "~3.13"
-django = "5.0.13"
+django = "5.0.14"
 beautifulsoup4 = "^4.12.2"
 markdownify = "1.1.0"
 django-easy-audit = "^1.3.5"


### PR DESCRIPTION
Doing this because there is a `Medium` vulnerability in 5.0.13 that is fixed in 5.0.14.

https://github.com/HHS/simpler-grants-gov/actions/runs/15147743231/job/42587548429?pr=5113

Note that we are not able to update to Django 5.1* or 5.2* yet because one of our libraries ([django-project-version](https://pypi.org/project/django-project-version/)), relies on < Django 5.1. Issue here: 

This PR does update Django to a new version but it doesn't get us onto the LTS version, so that's why I created this issue: https://github.com/HHS/simpler-grants-pdf-builder/issues/343
