### PR TITLE
Subclass Django's DatabaseWrapper backend for RDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning since version 1.0.0.
 - Show audit events for deleted subsections on the "All updates for NOFO" page
 - Add AWS Load Balancer domain to ALLOWED_HOSTS
 - Add current hostname to ALLOWED_HOSTS if using a private IP range starting with "10."
+- Refresh AWS DB connection password periodically
 
 ## [3.1.0] - 2025-05-12
 

--- a/nofos/bloom_nofos/aws.py
+++ b/nofos/bloom_nofos/aws.py
@@ -13,13 +13,23 @@ def is_aws_db(env):
     )
 
 
-def generate_iam_auth_token(env):
+def generate_iam_auth_token_func(env):
+    """
+    Creates a function that returns a fresh IAM token on each call.
+    """
     db_host = env.get_value("DB_HOST")
     db_user = env.get_value("DB_USER")
     db_port = int(env.get_value("DB_PORT", default=5432))
     aws_region = env.get_value("AWS_REGION")
 
     client = boto3.client("rds", region_name=aws_region)
-    return client.generate_db_auth_token(
-        DBHostname=db_host, Port=db_port, DBUsername=db_user, Region=aws_region
-    )
+
+    def _generate_token():
+        return client.generate_db_auth_token(
+            DBHostname=db_host,
+            Port=db_port,
+            DBUsername=db_user,
+            Region=aws_region,
+        )
+
+    return _generate_token

--- a/nofos/bloom_nofos/db/backends/postgresql_iam/__init__.py
+++ b/nofos/bloom_nofos/db/backends/postgresql_iam/__init__.py
@@ -1,0 +1,1 @@
+from .base import DatabaseWrapper

--- a/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
+++ b/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
@@ -1,0 +1,17 @@
+from django.db.backends.postgresql.base import DatabaseWrapper as BaseDatabaseWrapper
+
+
+class DatabaseWrapper(BaseDatabaseWrapper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        options = self.settings_dict.get("OPTIONS", {})
+        self.generate_iam_auth_token = options.get("generate_iam_auth_token", False)
+
+    def get_connection_params(self):
+        params = super().get_connection_params()
+
+        if self.generate_iam_auth_token:
+            params["password"] = self.generate_iam_auth_token()
+
+        return params

--- a/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
+++ b/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
@@ -6,7 +6,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         super().__init__(*args, **kwargs)
 
         options = self.settings_dict.get("OPTIONS", {})
-        self.generate_iam_auth_token = options.get("generate_iam_auth_token", False)
+        self.generate_iam_auth_token = options.pop("generate_iam_auth_token", None)
 
     def get_connection_params(self):
         params = super().get_connection_params()

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -210,7 +210,7 @@ database_url = (
 if is_aws_db(env):
     DATABASES = {
         "default": {
-            "ENGINE": "bloom_nofos.aws",  # points to your custom backend
+            "ENGINE": "bloom_nofos.db.backends.postgresql_iam",
             "NAME": env.get_value("DB_NAME"),
             "USER": env.get_value("DB_USER"),
             "HOST": env.get_value("DB_HOST"),
@@ -219,6 +219,8 @@ if is_aws_db(env):
                 "sslmode": "require",
                 "generate_iam_auth_token": generate_iam_auth_token_func(env),
             },
+            "CONN_MAX_AGE": 600,  # 10 minutes
+            "CONN_HEALTH_CHECKS": True,
         }
     }
 


### PR DESCRIPTION
## Summary

This PR updates our database wrapper to account for AWS' periodic token refreshing. The problem with the previous Database wrappers is that the password is set at the beginning and then never changed. AWS refreshes their password token every 15 minutes, so we need to be continually requesting new tokens when we reconnect.

## Description 

Generally, when you set your database password, the value you set for "password" is static for the lifetime of the app that is running. Django has some settings around this (eg, [`CONN_MAX_AGE`](https://docs.djangoproject.com/en/5.2/ref/settings/#conn-max-age)), but they assume they will get a new connection with the same static variables. 

What we need to do when we connect to RDS is refresh the password periodically so that we are getting _new_ tokens, rather then trying to refresh the connection with the old token.

So this custom backend does that. Essentially, we are overriding the `get_connection_params` method to call our custom function `generate_iam_auth_token()` to set the password.

Useful sources in case you want to learn more!

- https://github.com/labd/django-iam-dbauth/tree/main
- https://stackoverflow.com/questions/57865837/how-to-do-rds-iam-authentication-with-django

### How to test this

Unfortunately, we can't test this locally. 

What you can do is visit : http://nofos-dev-1402022759.us-east-1.elb.amazonaws.com/ 

If you can see the website more than 15 minutes after our last deploy, this is working!
