### PR TITLE
Upgrade 3 debian libraries after results of vuln scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,17 @@ RUN apt-get update && \
   libpq-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# Patch system libraries to address known CVEs:
+# - libcap2: CVE-2025-1390
+# - login, passwd: CVE-2023-4641, CVE-2023-29383
+RUN apt-get update && \
+  apt-get install -y --only-upgrade \
+  libcap2 \
+  login \
+  passwd && \
+  rm -rf /var/lib/apt/lists/*
+
+
 # Install Poetry
 RUN curl -sSL https://install.python-poetry.org | python3 - && \
   ln -s /root/.local/bin/poetry /usr/local/bin/poetry


### PR DESCRIPTION
## Summary

Yesterday, we turned on container vulnerability scanning, and a few os-level packages [are being flagged](https://github.com/HHS/simpler-grants-gov/actions/runs/15171314960/job/42661896649).

This PR adds an explicit "upgrade" command for all 3 of them in our Dockerfile, which brings them up to the latest, "FIXED" versions.

###  Details

This is what we are seeing in the vuln scan:

```
NAME     INSTALLED          FIXED-IN                TYPE    VULNERABILITY        SEVERITY
libcap2  1:2.66-4           1:2.66-4+deb12u1        deb     CVE-2025-1390        Medium
login    1:4.13+dfsg1-1+b1  1:4.13+dfsg1-1+deb12u1  deb     CVE-2023-4641        Medium
login    1:4.13+dfsg1-1+b1  1:4.13+dfsg1-1+deb12u1  deb     CVE-2023-29383       Low
passwd   1:4.13+dfsg1-1+b1  1:4.13+dfsg1-1+deb12u1  deb     CVE-2023-4641        Medium
passwd   1:4.13+dfsg1-1+b1  1:4.13+dfsg1-1+deb12u1  deb     CVE-2023-29383       Low
```

So I am adding an explicit upgrade for these three packages in our Dockerfile until such time as they become the latest versions.