### PR TITLE
Remove CONN_MAX_AGE and CONN_HEALTH_CHECKS in aws database config

### DIFF
--- a/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
+++ b/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
@@ -11,9 +11,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_connection_params(self):
         params = super().get_connection_params()
 
-        print("--- GET PARAMS")
         if self.generate_iam_auth_token:
-            print("--- GET PARAMS: generate_iam_auth_token")
             params["password"] = self.generate_iam_auth_token()
 
         return params

--- a/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
+++ b/nofos/bloom_nofos/db/backends/postgresql_iam/base.py
@@ -11,7 +11,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_connection_params(self):
         params = super().get_connection_params()
 
+        print("--- GET PARAMS")
         if self.generate_iam_auth_token:
+            print("--- GET PARAMS: generate_iam_auth_token")
             params["password"] = self.generate_iam_auth_token()
 
         return params

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -220,8 +220,6 @@ if is_aws_db(env):
                 "sslmode": "require",
                 "generate_iam_auth_token": generate_iam_auth_token_func(env),
             },
-            "CONN_MAX_AGE": 600,  # 10 minutes
-            "CONN_HEALTH_CHECKS": True,
         }
     }
 


### PR DESCRIPTION
## Summary

Remove `CONN_MAX_AGE` and `CONN_HEALTH_CHECKS` settings in the database config.  I suspect this may be caching our password for too long.

### Details

I noticed that our deployed nofo app was failing after a while because of the database connection, so my supposition is that the CONN_MAX_AGE variable holds onto the wrong password for too long and at some point they go out of sync.

Not totally sure this is a solution but I notice that the django-iam-dbauth library isn't recommending CONN_MAX_AGE or doing anything around this in general:

- https://github.com/labd/django-iam-dbauth

Note that I added a print statement to the DatabaseWrapper to prove that that code actually runs when we make requests.

<img width="492" alt="Screenshot 2025-05-22 at 1 11 56 PM" src="https://github.com/user-attachments/assets/47041e7e-c52e-4e77-8066-5ea5cde8b0ff" />

That worked, so we know that code is running, and now I have removed those print statements.