### PR TITLE
Create Dockerfile non-root user ("appuser") for container runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,12 @@ RUN echo '#!/bin/sh\nmake migrate' > /usr/local/bin/db-migrate && chmod +x /usr/
 # Collect static files
 RUN poetry run python nofos/manage.py collectstatic --noinput --verbosity 0
 
+# Create non-root user and give ownership of app directory
+RUN useradd --create-home appuser && \
+  chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port and run server
 EXPOSE $PORT
 CMD ["sh", "-c", "poetry run gunicorn --workers 8 --timeout 89 --chdir nofos --bind 0.0.0.0:$PORT bloom_nofos.wsgi:application"]


### PR DESCRIPTION
## Summary

This commit adds a dedicated 'appuser' to the Docker image and switches to it before the application is started. 

### Details

This resolves the CIS-DI-0001 warning flagged by Dockle, which requires containers to avoid running as root.

Example here: https://github.com/HHS/simpler-grants-gov/actions/runs/15195040903/job/42737014418

By running as a non-root user:

- The container is less likely to be used as a pivot point in an attack
- Accidental or malicious writes to system paths are prevented
- Compliance scanners (e.g., Dockle, Trivy, etc.) pass with fewer flags