### PR TITLE
Lengthen app timeout time & Turn off model updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ Versioning since version 1.0.0.
 - Add cover image for HHS-2025-ACF-OCS-EF-0177
 - Add healthcheck endpoint at /health
 - Add `db-migrate` command that can be run from built container
+- Add "import" and "export" buttons to NOFO models and audit events
 
 ### Changed
 
+- Temporarily stop logging audit events for model updates
+- Temporarily set the app timeout time for 15 minutes
 - Add the "Important: public information" subsection after _last_ matching subsection
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ COPY --chown=appuser:appuser . .
 RUN poetry run python nofos/manage.py collectstatic --noinput --verbosity 0
 
 EXPOSE ${PORT:-8000}
-CMD ["sh", "-c", "poetry run gunicorn --workers 8 --timeout 89 --chdir nofos --bind 0.0.0.0:${PORT:-8000} bloom_nofos.wsgi:application"]
+CMD ["sh", "-c", "poetry run gunicorn --workers 8 --timeout 899 --chdir nofos --bind 0.0.0.0:${PORT:-8000} bloom_nofos.wsgi:application"]

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -484,7 +484,10 @@ ALLOWED_HTML_ATTRIBUTES = [
 # https://github.com/soynatan/django-easy-audit
 
 DJANGO_EASY_AUDIT_READONLY_EVENTS = True
+# TODO: remove this once migration finishes
+DJANGO_EASY_AUDIT_WATCH_MODEL_EVENTS = False
 DJANGO_EASY_AUDIT_WATCH_REQUEST_EVENTS = False
+
 # If the header is set it must be available on the request or an Error will be thrown
 if is_prod:
     DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER = "HTTP_X_FORWARDED_FOR"


### PR DESCRIPTION
## Summary

I am trying to migrate our data into AWS.

The 2 changes here are:

- lengthen the app timeout time to 15 mins: right now we can't export because it we time out too soon
- turn off model updates: we don't want to generate audit logs temporarily while the date is being moved around
