### PR TITLE
Start tracking model changes again

### DIFF
--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -484,8 +484,6 @@ ALLOWED_HTML_ATTRIBUTES = [
 # https://github.com/soynatan/django-easy-audit
 
 DJANGO_EASY_AUDIT_READONLY_EVENTS = True
-# TODO: remove this once migration finishes
-DJANGO_EASY_AUDIT_WATCH_MODEL_EVENTS = False
 DJANGO_EASY_AUDIT_WATCH_REQUEST_EVENTS = False
 
 # If the header is set it must be available on the request or an Error will be thrown


### PR DESCRIPTION
## Summary

This was a temporary setting to stop adding events while I was importing models, but now that we are back in the swing of things, we want to start tracking events again.