### PR TITLE
Show agency name on front cover for HHS-2025-ACF-OCS-EF-0177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning since version 1.0.0.
 - Temporarily stop logging audit events for model updates
 - Temporarily set the app timeout time for 15 minutes
 - Add the "Important: public information" subsection after _last_ matching subsection
+- Show agency name (instead of subagency) on front cover for HHS-2025-ACF-OCS-EF-0177
 
 ### Fixed
 

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -96,7 +96,11 @@
             <p>{{ nofo.agency }}</p>
             <p>{% if nofo.subagency %}{{ nofo.subagency }}{% endif %}</p>
           {% else %}
-            <p>{% if nofo.subagency and nofo_opdiv != 'hrsa' %}{{ nofo.subagency }}{% else %}{{ nofo.agency }}{% endif %}</p>
+            {% if nofo.number == 'HHS-2025-ACF-OCS-EF-0177' %}
+              <p>{{ nofo.agency }}</p>
+            {% else %}
+              <p>{% if nofo.subagency and nofo_opdiv != 'hrsa' %}{{ nofo.subagency }}{% else %}{{ nofo.agency }}{% endif %}</p>
+            {% endif %}
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Summary

This is a small PR to override our template logic for one specific NOFO.

The idea is that we will show the "agency" name on the front cover instead of the "subagency" name for this one NOFO.

We can solve this with a real fix next week, but for now we just need to make this change.