### PR TITLE
Upgrade 2 more debian libraries after vuln scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,15 @@ RUN apt-get update && \
 
 # Patch system libraries to address known CVEs
 # - libcap2: CVE-2025-1390
-# - login, passwd: CVE-2023-4641, CVE-2023-29383
+# - login, passwd: CVE-2023-4641, CVE-2023-29383, 
+# - libsystemd0, libudev1: CVE-2025-4598
 RUN apt-get update && \
   apt-get install -y --only-upgrade \
   libcap2 \
   login \
-  passwd && \
+  passwd \
+  libsystemd0 \
+  libudev1 && \
   rm -rf /var/lib/apt/lists/*
 
 # Install Poetry and create user


### PR DESCRIPTION
## Summary

We had a failing vuln report to do with 2 more debian libraries in our container.

```
NAME         INSTALLED         FIXED-IN          TYPE    VULNERABILITY  SEVERITY
libsystemd0  252.36-1~deb12u1  252.38-1~deb12u1  deb     CVE-2025-4598  Medium
libudev1     252.36-1~deb12u1  252.38-1~deb12u1  deb     CVE-2025-4598  Medium
```

Like before, we have a couple of libraries to upgrade.