### PR TITLE
Allow "<br>" tags in headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Allow `<br>` tags in heading strings
 - Add cover image for HHS-2025-ACF-OCS-EF-0177
 - Add healthcheck endpoint at /health
 - Add `db-migrate` command that can be run from built container

--- a/nofos/bloom_nofos/templates/includes/heading.html
+++ b/nofos/bloom_nofos/templates/includes/heading.html
@@ -1,15 +1,15 @@
-{% load static add_classes_to_headings %}
+{% load static add_classes_to_headings safe_br %}
 
 {% if tag == "h2" %}
-  <h2 {% if id %}id="{{ id }}"{% endif %}>{{ content }}</h2>
+  <h2 {% if id %}id="{{ id }}"{% endif %}>{{ content|safe_br }}</h2>
 {% elif tag == "h3" %}
-  <h3 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content }}</h3>
+  <h3 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content|safe_br }}</h3>
 {% elif tag == "h4" %}
-  <h4 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content }}</h4>
+  <h4 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content|safe_br }}</h4>
 {% elif tag == "h5" %}
-  <h5 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content }}</h5>
+  <h5 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content|safe_br }}</h5>
 {% elif tag == "h6" %}
-  <h6 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content }}</h6>
+  <h6 {% if id %}id="{{ id }}"{% endif %} {% if class %}class="{{ class }}"{% elif content|add_classes_to_headings %}class="{{ content| add_classes_to_headings }}"{% endif %}>{{ content|safe_br }}</h6>
 {% elif tag == "h7" %}
-  <div {% if id %}id="{{ id }}"{% endif %} role="heading" aria-level="7" {% if class %}class="{{ class }}"{% endif %}>{{ content }}</div>
+  <div {% if id %}id="{{ id }}"{% endif %} role="heading" aria-level="7" {% if class %}class="{{ class }}"{% endif %}>{{ content|safe_br }}</div>
 {% endif %}

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -443,9 +443,9 @@ Edit “{{ nofo|nofo_name }}”
 
 {% for section in nofo.sections.all|dictsort:"order" %}
 <table class="usa-table usa-table--borderless width-full table--hide-edit-if-published table--hide-edit-if-archived table--section">
-  <caption aria-label="{{ section.name }}">
+  <caption aria-label="{{ section.name|strip_br }}">
     <div>
-      <h2 class="margin-bottom-0" id="{{ section.html_id }}">{{ section.name }}</h2>
+      <h2 class="margin-bottom-0" id="{{ section.html_id }}">{{ section.name|safe_br }}</h2>
       <span class="section--copy-button">
         <button
           type="button"

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static tz martortags nofo_name subsection_name_or_order get_value_or_none add_classes_to_tables add_classes_to_links convert_paragraphs_to_hrs split_char_and_remove %}
+{% load static tz martortags nofo_name subsection_name_or_order get_value_or_none add_classes_to_tables add_classes_to_links convert_paragraphs_to_hrs split_char_and_remove safe_br %}
 
 {% block title %}
 Edit “{{ nofo|nofo_name }}”
@@ -484,7 +484,7 @@ Edit “{{ nofo|nofo_name }}”
             <span class="floating">
               {% if subsection.name %}
                 <span {% if subsection|has_heading_error:heading_errors %}class="usa-tooltip" data-position="bottom" title="{{ subsection|get_heading_error:heading_errors|split_char_and_remove:":" }}."{% endif %}>
-                  {{ subsection.name }}
+                  {{ subsection.name|safe_br }}
                 </span>
               {% else %}
                 <span class="text-base">(#{{ subsection.order}})</span>

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -523,7 +523,7 @@ Edit “{{ nofo|nofo_name }}”
           </td>
           <td class="nofo-edit-table--subsection--manage">
             <span class="floating">
-              <a href="{% url 'nofos:subsection_edit' nofo.id section.id subsection.id %}">Edit<span class="usa-sr-only"> subsection: {{ subsection.name }}</span></a>
+              <a href="{% url 'nofos:subsection_edit' nofo.id section.id subsection.id %}">Edit<span class="usa-sr-only"> subsection: {{ subsection.name|strip_br }}</span></a>
             </span>
           </td>
         </tr>

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -1,5 +1,5 @@
 {% extends 'base_barebones.html' %}
-{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_classes_to_lists add_classes_to_headings add_classes_to_toc add_captions_to_tables split_char_and_remove get_breadcrumb convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section %}
+{% load static martortags nofo_section_name_separator add_classes_to_tables add_footnote_ids callout_box_contents replace_unicode_with_icon add_classes_to_paragraphs add_classes_to_lists add_classes_to_headings add_classes_to_toc add_captions_to_tables split_char_and_remove get_breadcrumb convert_paragraphs_to_hrs is_floating_callout_box get_floating_callout_boxes_from_section safe_br %}
 
 {% block metadata %}
   {% if nofo.author %}
@@ -194,14 +194,14 @@
               {% include "includes/icon_macro.html" with section_name=section.name|lower icon_style=nofo.icon_style only %}
             </div>
             <div class="toc--section-name--wrapper">
-              <a href="#{{ section.html_id }}" class="toc--section-name--a">{{ section.name }}</a>
+              <a href="#{{ section.html_id }}" class="toc--section-name--a">{{ section.name|strip_br }}</a>
 
               {% if section.name|lower != "contacts & support" and section.name|lower != "contacts and support" %}
                 <ol class="usa-list usa-list--unstyled">
                   {% for subsection in section.subsections.all|dictsort:"order" %}
                     {% with tag=subsection.tag content=subsection.name id=subsection.html_id %}
                       {% if tag == 'h3' %}
-                        <li class="toc--subsection-name"><a href="#{{ subsection.html_id }}">{{ content }}</a></li>
+                        <li class="toc--subsection-name"><a href="#{{ subsection.html_id }}">{{ content|strip_br }}</a></li>
                       {% endif %}
                     {% endwith %}
                   {% endfor %}
@@ -305,7 +305,7 @@
                   <span>Step {{ section_name.number }}:</span>
                   <br>
                 {% endif %}
-                <span>{{ section_name.name }}</span>
+                <span>{{ section_name.name|safe_br }}</span>
               {% endwith %}
             </h2>
           </div>
@@ -316,7 +316,7 @@
               {% for subsection in section.subsections.all|dictsort:"order" %}
                 {% with tag=subsection.tag content=subsection.name id=subsection.html_id %}
                   {% if tag == 'h3' %}
-                    <li><a href="#{{ subsection.html_id }}">{{ content }}</a></li>
+                    <li><a href="#{{ subsection.html_id }}">{{ content|strip_br }}</a></li>
                   {% endif %}
                 {% endwith %}
               {% endfor %}

--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static nofo_name input_type whitespaceless %}
+{% load static nofo_name input_type whitespaceless safe_br %}
 
 {% block title %}
   Subsection: {% if subsection.name %}{{ subsection.name }}{% else %}(#{{ subsection.order }}){% endif %}
@@ -20,7 +20,7 @@
       <a href="{% url 'nofos:nofo_edit' nofo.id %}#{{ subsection.html_id }}">Edit “{{ nofo_name_str }}”</a>
     </div>
     <div class="subsection_edit--header">
-      <h1 class="font-heading-xl margin-y-0">Subsection: {% if subsection.name %}{{ subsection.name }}{% else %}(#{{ subsection.order }}){% endif %}</h1>
+      <h1 class="font-heading-xl margin-y-0">Subsection: {% if subsection.name %}{{ subsection.name|safe_br }}{% else %}(#{{ subsection.order }}){% endif %}</h1>
       {% if subsection.callout_box %}<h2 class="font-heading-lg margin-y-1 text-base"><span aria-hidden="true">📦</span> Callout box</h2>{% endif %}
       {% if subsection.name %}
       <div class="subsection_edit--header--view font-sans-md">

--- a/nofos/nofos/templatetags/safe_br.py
+++ b/nofos/nofos/templatetags/safe_br.py
@@ -1,0 +1,26 @@
+import re
+from django import template
+from django.utils.html import escape, mark_safe
+
+register = template.Library()
+
+# Allow <br>, <br />, <BR>, <BR />
+BR_TAG_RE = re.compile(r'<br\s*/?>', flags=re.IGNORECASE)
+
+@register.filter
+def safe_br(value):
+    if not isinstance(value, str):
+        return value
+
+    # First, temporarily replace any real <br> tags with a placeholder
+    placeholder = '___BR_TAG___'
+    br_preserved = BR_TAG_RE.sub(placeholder, value)
+
+    # Escape everything else
+    escaped = escape(br_preserved)
+
+    # Restore the <br> placeholder
+    result = escaped.replace(placeholder, '<br>')
+
+    return mark_safe(result)
+

--- a/nofos/nofos/templatetags/safe_br.py
+++ b/nofos/nofos/templatetags/safe_br.py
@@ -7,6 +7,7 @@ register = template.Library()
 # Allow <br>, <br />, <BR>, <BR />
 BR_TAG_RE = re.compile(r'<br\s*/?>', flags=re.IGNORECASE)
 
+# This filter escapes all HTML except <br> tags
 @register.filter
 def safe_br(value):
     if not isinstance(value, str):
@@ -24,3 +25,12 @@ def safe_br(value):
 
     return mark_safe(result)
 
+
+# This filter removes <br> tags from a string
+@register.filter
+def strip_br(value):
+    if not isinstance(value, str):
+        return value
+
+    # Just remove all <br>, <br/>, <br />, <BR>, etc.
+    return BR_TAG_RE.sub('', value)

--- a/nofos/nofos/tests_nofos/test_templatetags.py
+++ b/nofos/nofos/tests_nofos/test_templatetags.py
@@ -2,8 +2,10 @@ import re
 
 from bs4 import BeautifulSoup
 from django.test import TestCase
+from django.utils.safestring import SafeString
 from nofos.models import Nofo, Section, Subsection
 from nofos.templatetags.add_classes_to_links import add_classes_to_broken_links
+from nofos.templatetags.safe_br import safe_br
 from nofos.templatetags.utils import (
     _add_class_if_not_exists_to_tag,
     _add_class_if_not_exists_to_tags,
@@ -691,6 +693,37 @@ class ModifyHtmlTests(TestCase):
         convert_paragraph_to_searchable_hr(soup.p)
         self.assertEqual(str(soup), expected_html)
 
+
+class SafeBrOnlyFilterTests(TestCase):
+
+    def test_all_html_is_escaped_except_br(self):
+        input_text = 'Line 1<br>Line 2<b>bold</b><script>alert("hi")</script>'
+        expected = SafeString('Line 1<br>Line 2&lt;b&gt;bold&lt;/b&gt;&lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt;')
+        result = safe_br(input_text)
+        self.assertEqual(result, expected)
+
+    def test_br_variants_are_normalized(self):
+        input_text = 'Line 1<BR/>Line 2<Br >Line 3<br >Line 4<BR >'
+        expected = SafeString('Line 1<br>Line 2<br>Line 3<br>Line 4<br>')
+        result = safe_br(input_text)
+        self.assertEqual(result, expected)
+
+    def test_escaping_angle_brackets(self):
+        input_text = 'This is <not a tag> and should be escaped'
+        expected = SafeString('This is &lt;not a tag&gt; and should be escaped')
+        result = safe_br(input_text)
+        self.assertEqual(result, expected)
+
+    def test_plain_text_remains_unchanged(self):
+        input_text = 'Just some normal text here.'
+        expected = SafeString('Just some normal text here.')
+        result = safe_br(input_text)
+        self.assertEqual(result, expected)
+
+    def test_non_string_input_is_returned_as_is(self):
+        self.assertEqual(safe_br(None), None)
+        self.assertEqual(safe_br(42), 42)
+        self.assertEqual(safe_br(True), True)
 
 class TestFindElementsWithChar(TestCase):
     def test_single_element_with_char(self):


### PR DESCRIPTION
## Summary

This is a fairly small PR that allows `<br>` tags in headings, which has been much requested by NOFO designers!!

This should work well for Subsections and Sections, although getting at Sections is harder (you have to use the admin UI).

| before | subsection_edit_view | after
|--------|-------|-------|
|   Textual widow, which is a word on its own line     |   Adding `<br>` tags directly    |  `<br>` tags are respected by the NOFO Builder  |
|   <img width="695" alt="Screenshot 2025-06-02 at 4 20 23 PM" src="https://github.com/user-attachments/assets/e44e30b6-0e98-4c22-ba06-7fd639b6e6ae" />     |    <img width="695" alt="Screenshot 2025-06-02 at 4 21 18 PM" src="https://github.com/user-attachments/assets/c5653624-fe37-4093-8106-35f5267c8e45" />  | <img width="695" alt="Screenshot 2025-06-02 at 4 21 04 PM" src="https://github.com/user-attachments/assets/b14d8e1e-7649-4425-813b-a829118d537f" />   |


## Details

The idea is that sometimes we have text widows (one word on a line on its own) and some NOFO designers are very annoyed by this. 

Here are some examples of this happening:

| Step 4 | App submission and deadlines | Step 6 |
|--------|-------|------|
|   ![Screenshot 2025-05-23 at 3 22 06 PM](https://github.com/user-attachments/assets/d6be001a-16e8-4cf2-9bf0-658955aad0fe)     |  ![Screenshot 2025-05-23 at 3 22 37 PM](https://github.com/user-attachments/assets/7e3fd726-8355-4b65-9279-e920343bda5b)     | ![Screenshot 2025-05-23 at 3 22 54 PM](https://github.com/user-attachments/assets/d21c8d7e-b3a9-471a-8be7-a2642c2ca7e4) | 

The easy thing to do is just allow `<br>` elements, which we already do in the rest of the NOFO text, so this fits into what we already expect. However, we don't want other HTML showing up here, so `<br>` is the only HTML text that we allow.

However titles appear in other areas other than just where they live in the text, for example in the Table of Contents. For those ones, we have to fully strip the `<br>` tags so that the heading shows up as regular text.

## How to test

- Add `<br>` to a Section heading 
- Add `<br>` to a Subsection heading 
- Look for it in the NOFO body text and table of contents in the NOFO HTML view ("nofo_view" page)
- Look for it in the NOFO edit page ("nofo_edit")

The only one I am not sure about is the rendering of literal `<br>` strings in the h1 on the Subsection edit page. On the one hand, at least we are being explict. On the other hand, I don't know if this looks like something is broken.