### PR TITLE
Add warning message for ".rodeo" domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+## [3.2.2] - 2025-06-16
+
+### Added
+
+- Add a warning message to ".rodeo" domain and ".dev" domain
+  - Now that we have multiple versions of the NOFO Builder up, we want to prevent people from using the wrong one
+
 ## [3.2.1] - 2025-06-10
 
 ### Changed

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -5,6 +5,33 @@
 {% endblock %}
 
 {% block content %}
+  {% if ".rodeo" in request.get_host %}
+    <div class="usa-alert usa-alert--error margin-bottom-4"" role="alert">
+      <div class="usa-alert__body">
+        <h4 class="usa-alert__heading">YOU ARE ON THE WRONG WEBSITE</h4>
+        <p class="usa-alert__text">
+          The NOFO Builder has moved.
+        </p>
+        <p class="usa-alert__text">
+          To log in, go to
+          <a class="usa-link" href="http://nofos.simpler.grants.gov">nofos.simpler.grants.gov</a>.
+        </p>
+      </div>
+    </div>
+  {% elif ".dev" in request.get_host %}
+    <div class="usa-alert usa-alert--warning margin-bottom-4">
+      <div class="usa-alert__body">
+        <h4 class="usa-alert__heading">YOU ARE ON THE DEVELOPMENT SITE</h4>
+        <p class="usa-alert__text">
+          This is a <strong>test</strong> version of the NOFO Builder.
+        </p>
+        <p class="usa-alert__text">
+          Go to the live site at <a class="usa-link" href="http://nofos.simpler.grants.gov">nofos.simpler.grants.gov</a>.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+
   <h1 class="font-heading-xl margin-y-0">Generate NOFOs from Word Documents</h1>
   <p class="usa-intro">
     Simplify the process of publishing Notices of Financial Opportunity (NOFOs).

--- a/nofos/users/templates/users/login.html
+++ b/nofos/users/templates/users/login.html
@@ -5,67 +5,94 @@
 {% endblock %}
 
 {% block content %}
-{% include "includes/page_heading.html" with title="Login" only %}
-
-{% if messages %}
-<div class="messages margin-top-4">
-    {% for message in messages %}
-    <div class="usa-alert usa-alert--{{ message.tags }}">
-        <div class="usa-alert__body">
-            <p class="usa-alert__text">{{ message }}</p>
-        </div>
+  {% if ".rodeo" in request.get_host %}
+    <div class="usa-alert usa-alert--error margin-bottom-4"" role="alert">
+      <div class="usa-alert__body">
+        <h4 class="usa-alert__heading">YOU ARE ON THE WRONG WEBSITE</h4>
+        <p class="usa-alert__text">
+          The NOFO Builder has moved.
+        </p>
+        <p class="usa-alert__text">
+          To log in, go to
+          <a class="usa-link" href="http://nofos.simpler.grants.gov">nofos.simpler.grants.gov</a>.
+        </p>
+      </div>
     </div>
-    {% endfor %}
-</div>
-{% endif %}
-
-{% if next %}
-  {% if user.is_authenticated %}
-    <p>
-        Your account doesn't have access to this page. To proceed, please login with an account that has access.
-    </p>
-  {% else %}
-    <p>Please login to see this page.</p>
+  {% elif ".dev" in request.get_host %}
+    <div class="usa-alert usa-alert--warning margin-bottom-4">
+      <div class="usa-alert__body">
+        <h4 class="usa-alert__heading">YOU ARE ON THE DEVELOPMENT SITE</h4>
+        <p class="usa-alert__text">
+          This is a <strong>test</strong> version of the NOFO Builder.
+        </p>
+        <p class="usa-alert__text">
+          Go to the live site at <a class="usa-link" href="http://nofos.simpler.grants.gov">nofos.simpler.grants.gov</a>.
+        </p>
+      </div>
+    </div>
   {% endif %}
-{% endif %}
 
-<!-- Email/password login form -->
-<form method="post" action="{% url 'users:login' %}">
-    {% csrf_token %}
-    <fieldset class="usa-fieldset">
+  {% include "includes/page_heading.html" with title="Login" only %}
 
-        {% if form.non_field_errors %}
-        <legend>
-            <div class="usa-error-message">
-                Error: {{ form.non_field_errors.0 }}
-            </div>
-        </legend>
-        {% endif %}
+  {% if messages %}
+  <div class="messages margin-top-4">
+      {% for message in messages %}
+      <div class="usa-alert usa-alert--{{ message.tags }}">
+          <div class="usa-alert__body">
+              <p class="usa-alert__text">{{ message }}</p>
+          </div>
+      </div>
+      {% endfor %}
+  </div>
+  {% endif %}
 
-        {% include "includes/form_macro.html" %}
+  {% if next %}
+    {% if user.is_authenticated %}
+      <p>
+          Your account doesn't have access to this page. To proceed, please login with an account that has access.
+      </p>
+    {% else %}
+      <p>Please login to see this page.</p>
+    {% endif %}
+  {% endif %}
 
-    </fieldset>
-    <input type="hidden" name="next" value="{{ next }}">
+  <!-- Email/password login form -->
+  <form method="post" action="{% url 'users:login' %}">
+      {% csrf_token %}
+      <fieldset class="usa-fieldset">
 
-    <button class="usa-button margin-top-3" type="submit">Login</button>
-</form>
+          {% if form.non_field_errors %}
+          <legend>
+              <div class="usa-error-message">
+                  Error: {{ form.non_field_errors.0 }}
+              </div>
+          </legend>
+          {% endif %}
 
-{% if LOGIN_GOV_ENABLED %}
-    <!-- Login.gov login button -->
-    <div class="margin-top-4 login-gov-container">
-        <p class="text-center">- or -</p>
-        <a href="{% url 'users:login_gov' %}" class="usa-button usa-button--outline width-full">
-            Sign in with Login.gov
-        </a>
+          {% include "includes/form_macro.html" %}
 
-        <div class="margin-top-2 text-center">
-            <small class="text-base-dark">
-                Don't have a Login.gov account?
-                <a href="https://idp.int.identitysandbox.gov/sign_up/enter_email" target="_blank" rel="noopener noreferrer">
-                    Create one here
-                </a>
-            </small>
-        </div>
-    </div>
-{% endif %}
+      </fieldset>
+      <input type="hidden" name="next" value="{{ next }}">
+
+      <button class="usa-button margin-top-3" type="submit">Login</button>
+  </form>
+
+  {% if LOGIN_GOV_ENABLED %}
+      <!-- Login.gov login button -->
+      <div class="margin-top-4 login-gov-container">
+          <p class="text-center">- or -</p>
+          <a href="{% url 'users:login_gov' %}" class="usa-button usa-button--outline width-full">
+              Sign in with Login.gov
+          </a>
+
+          <div class="margin-top-2 text-center">
+              <small class="text-base-dark">
+                  Don't have a Login.gov account?
+                  <a href="https://idp.int.identitysandbox.gov/sign_up/enter_email" target="_blank" rel="noopener noreferrer">
+                      Create one here
+                  </a>
+              </small>
+          </div>
+      </div>
+  {% endif %}
 {% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nofos"
-version = "3.2.1"
+version = "3.2.2"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Add warning messages to the index page and the login page.

Now that we have different versions of the NOFO Builder, we want to prevent people from accidentally logging into the wrong one and doing a bunch of work in it. 

If people end up on ".dev" or ".rodeo" by accident, we want them to be able to figure out what is wrong and where to go.

### Screenshots

| .rodeo | .dev |
|--------|-------|
|  YOU ARE ON THE WRONG WEBSITE<br>The NOFO Builder has moved.<br>To log in, go to nofos.simpler.grants.gov.      |  YOU ARE ON THE DEVELOPMENT SITE<br>This is a <strong>test</strong> version of the NOFO Builder.</br>Go to the live site at nofos.simpler.grants.gov.    |
|  <img width="1490" alt="Screenshot 2025-06-16 at 01 33 47" src="https://github.com/user-attachments/assets/88888796-979f-4d07-9c87-ef4b2409cfe6" />      |   <img width="1490" alt="Screenshot 2025-06-16 at 01 32 46" src="https://github.com/user-attachments/assets/fdffd146-d83a-4d89-8112-f4aa16297253" />    |




