### PR TITLE
Use same logic to extract highlighted text everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Use "extract content" function in all find+replace types of interfaces
 - Nofo title and short name are separated now
   - It made sense to group them before, but the "matched values" logic for the title field makes the double inputs really messy.
 

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -6680,7 +6680,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         )
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>July 15, 2025</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">July 15, 2025</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertIn("Deadline Details", match["subsection"].name)
         self.assertEqual(self.section, match["section"])
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
@@ -6703,7 +6706,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         )
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>July 15, 2025</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">July 15, 2025</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertIn("Basic information", match["subsection"].name)
         self.assertEqual(self.section, match["section"])
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
@@ -6725,7 +6731,8 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         self.assertEqual(self.section, results[0]["section"])
         self.assertEqual(self.matching_subsection.id, results[0]["subsection"].id)
         self.assertIn(
-            "<mark>JULY 15, 2025</mark>", results[0]["subsection_body_highlight"]
+            '<strong><mark class="bg-yellow">JULY 15, 2025</mark></strong>',
+            results[0]["subsection_body_highlight"],
         )
 
     def test_returns_empty_list_when_no_value(self):
@@ -6750,7 +6757,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         results = find_subsections_with_nofo_field_value(self.nofo, "title")
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>Test NOFO</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">Test NOFO</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertEqual(self.section, match["section"])
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
 
@@ -6768,7 +6778,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         results = find_subsections_with_nofo_field_value(self.nofo, "number")
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>HRSA-24-019</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">HRSA-24-019</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertEqual(self.section, match["section"])
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
 
@@ -6789,7 +6802,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         results = find_subsections_with_nofo_field_value(self.nofo, "title")
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>TEST NOFO</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">TEST NOFO</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
 
     def test_ignores_title_match_if_basic_information(self):
@@ -6807,7 +6823,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         results = find_subsections_with_nofo_field_value(self.nofo, "title")
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>Test NOFO</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">Test NOFO</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
 
     # Additional tests for number field
@@ -6819,7 +6838,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         results = find_subsections_with_nofo_field_value(self.nofo, "number")
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>hrsa-24-019</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">hrsa-24-019</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
 
     def test_ignores_number_match_if_basic_information(self):
@@ -6841,7 +6863,10 @@ class FindSubsectionsWithFieldValueTests(TestCase):
         results = find_subsections_with_nofo_field_value(self.nofo, "number")
         self.assertEqual(len(results), 1)
         match = results[0]
-        self.assertIn("<mark>HRSA-24-019</mark>", match["subsection_body_highlight"])
+        self.assertIn(
+            '<strong><mark class="bg-yellow">HRSA-24-019</mark></strong>',
+            match["subsection_body_highlight"],
+        )
         self.assertEqual(self.matching_subsection.id, match["subsection"].id)
 
     def test_returns_multiple_matches_for_same_field(self):

--- a/nofos/nofos/tests_nofos/test_page_breaks.py
+++ b/nofos/nofos/tests_nofos/test_page_breaks.py
@@ -376,7 +376,6 @@ class NofoRemovePagebreaksViewTest(TestCase):
         result = extract_page_break_context(
             "This has page-break once and page-break twice"
         )
-        self.assertIn("2 page breaks found in this section", result)
 
     def test_add_page_breaks_to_headings(self):
         """Test that add_page_breaks_to_headings adds page breaks to specific headings"""


### PR DESCRIPTION
## Summary

This PR standardizes our highlighted text for our various 'search the nofo' functions. 

We search for things throughout the NOFO in 3 places now:

1. Find `nofo.title`, `nofo.number`, `nofo.application_deadline`
2. Find and replace button
3. Find page breaks

Previously, we would show you the _whole_ subsection with the highlighted text for (1) and (2), but the page_break view would show snippets of text only. 

It seemed like a good way to do things, so we are using that same logic around only showing the match and 100 characters before and after it. 

Now we have much smaller and cleaner looking find results!

### Screenshots

Here is an example before and after of the title matching logic. 

- Before:
- After: 

| before | after |
|--------|-------|
|  all content in the subsection body is shown, given there is matching text in the subsection       |   only 100 characters before and after the match is shown     |
|    ![localhost_8000_nofos_0d30739a-accc-4075-a7c0-30087c232843_edit_title (1)](https://github.com/user-attachments/assets/5865fc6f-fbcd-42b7-9d45-a67fcc8da084)    |    ![localhost_8000_nofos_0d30739a-accc-4075-a7c0-30087c232843_edit_title](https://github.com/user-attachments/assets/db184878-70de-461e-a3e2-ed456fed3e6f)   |

