### PR TITLE
Find & Replace values in subsection.name if matched 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- DO find and replace subsection.name values on Find + Replace page
+- DO NOT replace URLs on Find + Replace page
 - More comprehensive error messages for section.name and subsection.name validation errors
   - Delete NOFOs with heading errors now, don't keep them
 - Use "extract content" function in all find+replace types of interfaces
@@ -18,6 +20,8 @@ Versioning since version 1.0.0.
   - It made sense to group them before, but the "matched values" logic for the title field makes the double inputs really messy.
 
 ### Fixed
+
+- Fix contextual button text for "Save" title, "Remove" page breaks, and "Replace" values
 
 ## [3.2.2] - 2025-06-16
 

--- a/nofos/bloom_nofos/static/js/nofo_edit_form.js
+++ b/nofos/bloom_nofos/static/js/nofo_edit_form.js
@@ -1,6 +1,6 @@
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener("DOMContentLoaded", function () {
   try {
-    const formId = window.nofoEditFormId || 'nofo_edit_form';
+    const formId = window.nofoEditFormId || "nofo_edit_form";
     const form = document.getElementById(formId);
 
     // No form found
@@ -9,18 +9,14 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     const buttons = form.querySelectorAll('button[type="submit"]');
-    const replaceButton = form.querySelector('#replace-button');
+    const replaceButton = form.querySelector("#replace-button");
     if (!buttons.length) {
       return;
     }
 
-    const checkboxes = form.querySelectorAll('input[name="replace_subsections"]');
-
-    // Store original text for each button
-    const buttonTexts = {};
-    buttons.forEach(btn => {
-      buttonTexts[btn.id || btn.getAttribute('name') || 'default'] = btn.dataset.baseText || btn.textContent.trim() || 'Save';
-    });
+    const checkboxes = form.querySelectorAll(
+      'input[name="replace_subsections"]'
+    );
 
     // Nothing checked
     if (checkboxes.length === 0) {
@@ -28,26 +24,26 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Initialize Select All / Deselect All button if it exists
-    const toggleButton = document.getElementById('toggle-all-checkboxes');
+    const toggleButton = document.getElementById("toggle-all-checkboxes");
     if (toggleButton) {
-      const selectAllText = toggleButton.querySelector('.select-all-text');
-      const deselectAllText = toggleButton.querySelector('.deselect-all-text');
+      const selectAllText = toggleButton.querySelector(".select-all-text");
+      const deselectAllText = toggleButton.querySelector(".deselect-all-text");
 
       // Function to update the button text based on checkbox states
       function updateToggleButtonText() {
         let allChecked = true;
-        checkboxes.forEach(checkbox => {
+        checkboxes.forEach((checkbox) => {
           if (!checkbox.checked) {
             allChecked = false;
           }
         });
 
         if (allChecked) {
-          selectAllText.style.display = 'none';
-          deselectAllText.style.display = 'inline';
+          selectAllText.style.display = "none";
+          deselectAllText.style.display = "inline";
         } else {
-          selectAllText.style.display = 'inline';
-          deselectAllText.style.display = 'none';
+          selectAllText.style.display = "inline";
+          deselectAllText.style.display = "none";
         }
       }
 
@@ -55,18 +51,18 @@ document.addEventListener('DOMContentLoaded', function () {
       updateToggleButtonText();
 
       // Toggle all checkboxes when button is clicked
-      toggleButton.addEventListener('click', function() {
+      toggleButton.addEventListener("click", function () {
         let allChecked = true;
 
         // Check if all checkboxes are currently checked
-        checkboxes.forEach(checkbox => {
+        checkboxes.forEach((checkbox) => {
           if (!checkbox.checked && !checkbox.disabled) {
             allChecked = false;
           }
         });
 
         // Toggle checkboxes based on current state
-        checkboxes.forEach(checkbox => {
+        checkboxes.forEach((checkbox) => {
           if (!checkbox.disabled) {
             checkbox.checked = !allChecked;
             updateRowHighlight(checkbox);
@@ -80,74 +76,71 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function updateButtonText() {
-      const checkedCount = form.querySelectorAll('input[name="replace_subsections"]:checked').length;
+      const checkedCount = form.querySelectorAll(
+        'input[name="replace_subsections"]:checked'
+      ).length;
 
-      buttons.forEach(button => {
-        const baseText = buttonTexts[button.id || button.getAttribute('name') || 'default'];
+      buttons.forEach((button) => {
+        const baseText =
+          button.dataset.baseText || button.textContent.trim() || "Save";
+        const preposition = button.dataset.preposition || "";
 
         // Only update replace button or buttons without explicit action
-        if (button.id === 'replace-button' || !button.getAttribute('name')) {
-          if (button.id === 'replace-button') {
-            // Special handling for replace button
-            if (checkedCount === 1) {
-              button.textContent = `${baseText} 1 subsection`;
-            } else if (checkedCount === checkboxes.length) {
-              button.textContent = `${baseText} All`;
-            } else if (checkedCount > 1) {
-              button.textContent = `${baseText} ${checkedCount} subsections`;
-            } else {
-              button.textContent = baseText;
-            }
+        if (
+          button.id === "replace-button" ||
+          button.id === "replace_button" ||
+          !button.getAttribute("name")
+        ) {
+          if (checkedCount === 1) {
+            button.textContent = `${baseText} ${preposition} 1 subsection`;
+          } else if (checkedCount === checkboxes.length) {
+            button.textContent = `${baseText}  ${preposition} all subsections`;
+          } else if (checkedCount > 1) {
+            button.textContent = `${baseText} ${preposition} ${checkedCount} subsections`;
           } else {
-            // Default handling for other buttons without explicit action
-            if (checkedCount === 0) {
-              button.textContent = baseText;
-            } else if (checkedCount === 1) {
-              button.textContent = `${baseText} + 1 subsection`;
-            } else {
-              button.textContent = `${baseText} + ${checkedCount} subsections`;
-            }
+            button.textContent = baseText;
           }
         }
       });
     }
 
     function updateRowHighlight(checkbox) {
-      const row = checkbox.closest('tr');
+      const row = checkbox.closest("tr");
       if (!row) return;
 
       // Toggle the highlight class based on checkbox state
       if (checkbox.checked) {
-        row.classList.add('subsection--selected');
+        row.classList.add("subsection--selected");
       } else {
-        row.classList.remove('subsection--selected');
+        row.classList.remove("subsection--selected");
       }
     }
 
     // Attach listener to each checkbox
     checkboxes.forEach(function (checkbox) {
-      checkbox.addEventListener('change', function () {
+      checkbox.addEventListener("change", function () {
         updateButtonText();
         updateRowHighlight(this);
 
         // Update toggle button text if it exists
         if (toggleButton) {
-          const selectAllText = toggleButton.querySelector('.select-all-text');
-          const deselectAllText = toggleButton.querySelector('.deselect-all-text');
+          const selectAllText = toggleButton.querySelector(".select-all-text");
+          const deselectAllText =
+            toggleButton.querySelector(".deselect-all-text");
 
           let allChecked = true;
-          checkboxes.forEach(checkbox => {
+          checkboxes.forEach((checkbox) => {
             if (!checkbox.checked) {
               allChecked = false;
             }
           });
 
           if (allChecked) {
-            selectAllText.style.display = 'none';
-            deselectAllText.style.display = 'inline';
+            selectAllText.style.display = "none";
+            deselectAllText.style.display = "inline";
           } else {
-            selectAllText.style.display = 'inline';
-            deselectAllText.style.display = 'none';
+            selectAllText.style.display = "inline";
+            deselectAllText.style.display = "none";
           }
         }
       });
@@ -156,25 +149,33 @@ document.addEventListener('DOMContentLoaded', function () {
     // Initialize state
     updateButtonText();
     // Initialize highlighting for all checked checkboxes
-    checkboxes.forEach(checkbox => {
+    checkboxes.forEach((checkbox) => {
       if (checkbox.checked) {
         updateRowHighlight(checkbox);
       }
     });
 
     // Add form submission handler
-    form.addEventListener('submit', function(event) {
-      const selectedCheckboxes = form.querySelectorAll('input[name="replace_subsections"]:checked');
-      const selectedSubsections = Array.from(selectedCheckboxes).map(cb => cb.value);
+    form.addEventListener("submit", function (event) {
+      const selectedCheckboxes = form.querySelectorAll(
+        'input[name="replace_subsections"]:checked'
+      );
+      const selectedSubsections = Array.from(selectedCheckboxes).map(
+        (cb) => cb.value
+      );
 
       // If no subsections selected and it's a replace action, trigger cancel button click
-      if (selectedSubsections.length === 0 && event.submitter && event.submitter.id === 'replace-button') {
+      if (
+        selectedSubsections.length === 0 &&
+        event.submitter &&
+        event.submitter.id === "replace-button"
+      ) {
         event.preventDefault();
-        form.querySelector('a.usa-button--outline').click();
+        form.querySelector("a.usa-button--outline").click();
         return;
       }
     });
   } catch (error) {
-    console.error('Error in form initialization:', error);
+    console.error("Error in form initialization:", error);
   }
 });

--- a/nofos/bloom_nofos/templates/includes/subsection_matches_table_macro.html
+++ b/nofos/bloom_nofos/templates/includes/subsection_matches_table_macro.html
@@ -45,11 +45,19 @@
         <td>{{ match.section.name }}</td>
         <td>
           <a class="usa-link usa-link--external" target="_blank" href="{% url "nofos:subsection_edit" nofo.id match.section.id match.subsection.id %}">
-            {{ match.subsection|subsection_name_or_order }}
+            {% if match.subsection_name_highlight %}
+              {{ match.subsection_name_highlight|safe }}
+            {% else %}
+              {{ match.subsection|subsection_name_or_order }}
+            {% endif %}
           </a>
         </td>
         <td>
-          {{ match.subsection_body_highlight|safe_markdown|linebreaksbr }}
+          {% if match.subsection_body_highlight %}
+            {{ match.subsection_body_highlight|safe_markdown|linebreaksbr }}
+          {% else %}
+            <i class="text-base">No matches in body text</i>
+          {% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -25,6 +25,7 @@ from .utils import (
     clean_string,
     create_subsection_html_id,
     extract_highlighted_context,
+    replace_text_not_markdown_links,
     strip_markdown_links,
     style_map_manager,
 )
@@ -2627,7 +2628,9 @@ def replace_value_in_subsections(
 
         # Update body
         if subsection.body:
-            new_body = pattern.sub(new_value, subsection.body)
+            new_body = replace_text_not_markdown_links(
+                subsection.body, old_value, new_value
+            )
             if new_body != subsection.body:
                 subsection.body = new_body
                 updated = True

--- a/nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_application_deadline.html
@@ -17,7 +17,7 @@
 
         {% include "includes/form_macro.html" with hint2='eg: "Monday, January 1, 2024"' %}
 
-        <button class="usa-button margin-top-3" type="submit">Save application deadline</button>
+        <button class="usa-button margin-top-3" type="submit" data-base-text="Save application deadline" data-preposition="+">Save application deadline</button>
 
         {% include "includes/subsection_matches_table_macro.html" with form_id=form_id subsection_matches=subsection_matches match_value=form.application_deadline.value replace_text="application deadline" checkbox_checked=True %}
       </form>

--- a/nofos/nofos/templates/nofos/nofo_edit_number.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_number.html
@@ -17,7 +17,7 @@
 
         {% include "includes/form_macro.html" with hint2='eg: "HRSA-24-019"' %}
 
-        <button class="usa-button margin-top-3" type="submit">Save number</button>
+        <button class="usa-button margin-top-3" type="submit" data-base-text="Save number" data-preposition="+">Save number</button>
 
         {% include "includes/subsection_matches_table_macro.html" with form_id=form_id subsection_matches=subsection_matches match_value=form.number.value replace_text="number" checkbox_checked=True %}
       </form>

--- a/nofos/nofos/templates/nofos/nofo_edit_title.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_title.html
@@ -17,7 +17,7 @@
 
         {% include "includes/form_macro.html" with hint2='eg: "Physician Assistant Rural Training in Mental and Behavioral Health (PCTE-PARM) Program"' hint2for="title" %}
 
-        <button class="usa-button margin-top-3" type="submit">Save title</button>
+        <button class="usa-button margin-top-3" type="submit" data-base-text="Save title" data-preposition="+">Save title</button>
 
         {% include "includes/subsection_matches_table_macro.html" with form_id=form_id subsection_matches=subsection_matches match_value=form.title.value replace_text="title" checkbox_checked=True %}
       </form>

--- a/nofos/nofos/templates/nofos/nofo_find_replace.html
+++ b/nofos/nofos/templates/nofos/nofo_find_replace.html
@@ -46,7 +46,7 @@
             <label class="usa-label" for="replace_text">Replace with</label>
             <input class="usa-input border-2px" id="replace_text" name="replace_text" type="text" {% if replace_text %}value="{{ replace_text }}"{% endif %}>
             <div class="margin-top-2">
-              <button id="replace_button" class="usa-button usa-button--accent-warm" type="submit" name="action" value="replace" data-base-text="Replace">Replace Nothing</button>
+              <button id="replace_button" class="usa-button usa-button--accent-warm" type="submit" name="action" value="replace" data-base-text="Replace" data-preposition="in">Replace</button>
               <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button usa-button--outline">Cancel</a>
             </div>
           </div>

--- a/nofos/nofos/templates/nofos/nofo_remove_page_breaks.html
+++ b/nofos/nofos/templates/nofos/nofo_remove_page_breaks.html
@@ -36,7 +36,7 @@
       </div>
 
       <div class="margin-top-3">
-        <button id="replace-button" class="usa-button" type="submit" data-base-text="Remove">Remove Page Breaks</button>
+        <button id="replace-button" class="usa-button" type="submit" data-base-text="Remove" data-preposition="from">Remove Page Breaks</button>
         <a href="{% url 'nofos:nofo_edit' nofo.id %}" class="usa-button usa-button--outline">Cancel</a>
       </div>
 

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -7200,3 +7200,95 @@ class ReplaceValueInSubsectionsTests(TestCase):
         self.assertEqual(len(updated), 0)
         self.subsection_1.refresh_from_db()
         self.assertEqual(self.subsection_1.body, original_body)
+
+    def test_replace_in_name_with_include_name(self):
+        self.subsection_1.name = "Important Dates"
+        self.subsection_1.save()
+
+        updated = replace_value_in_subsections(
+            [self.subsection_1.id],
+            "Important",
+            "Key",
+            include_name=True,
+        )
+
+        self.assertEqual(len(updated), 1)
+        self.subsection_1.refresh_from_db()
+        self.assertEqual(self.subsection_1.name, "Key Dates")
+
+    def test_replace_in_name_is_case_insensitive(self):
+        self.subsection_2.name = "REMINDER"
+        self.subsection_2.save()
+
+        updated = replace_value_in_subsections(
+            [self.subsection_2.id],
+            "reminder",
+            "Heads Up",
+            include_name=True,
+        )
+
+        self.assertEqual(len(updated), 1)
+        self.subsection_2.refresh_from_db()
+        self.assertEqual(self.subsection_2.name, "Heads Up")
+
+    def test_replace_in_name_but_include_name_false(self):
+        self.subsection_1.name = "Important Dates"
+        self.subsection_1.save()
+
+        updated = replace_value_in_subsections(
+            [self.subsection_1.id],
+            "Important",
+            "Key",
+            include_name=False,  # should skip name
+        )
+
+        self.assertEqual(len(updated), 0)
+        self.subsection_1.refresh_from_db()
+        self.assertEqual(self.subsection_1.name, "Important Dates")
+
+    def test_replace_in_name_and_body(self):
+        self.subsection_1.name = "Important Dates"
+        self.subsection_1.body = "June 1, 2025 is an important date."
+        self.subsection_1.save()
+
+        updated = replace_value_in_subsections(
+            [self.subsection_1.id],
+            "important",
+            "critical",
+            include_name=True,
+        )
+
+        self.assertEqual(len(updated), 1)
+        self.subsection_1.refresh_from_db()
+        self.assertEqual(self.subsection_1.name, "critical Dates")
+        self.assertEqual(self.subsection_1.body, "June 1, 2025 is an critical date.")
+
+    def test_replace_in_name_no_match(self):
+        self.subsection_3.name = "No Match Here"
+        self.subsection_3.save()
+
+        updated = replace_value_in_subsections(
+            [self.subsection_3.id],
+            "Something Else",
+            "Updated",
+            include_name=True,
+        )
+
+        self.assertEqual(len(updated), 0)
+        self.subsection_3.refresh_from_db()
+        self.assertEqual(self.subsection_3.name, "No Match Here")
+
+    def test_replace_name_with_multiple_matches(self):
+        self.subsection_3.name = "Important dates that are important"
+        self.subsection_3.save()
+
+        updated = replace_value_in_subsections(
+            [self.subsection_3.id],
+            "Important",
+            "Critical",
+            include_name=True,
+        )
+
+        self.assertEqual(len(updated), 1)
+        self.subsection_3.refresh_from_db()
+        self.assertEqual(self.subsection_3.name, "Critical dates that are Critical")

--- a/nofos/nofos/tests_nofos/test_utils.py
+++ b/nofos/nofos/tests_nofos/test_utils.py
@@ -17,6 +17,7 @@ from nofos.utils import (
     extract_highlighted_context,
     get_icon_path_choices,
     match_view_url,
+    strip_markdown_links
 )
 
 from ..models import Nofo, Section, Subsection
@@ -224,6 +225,35 @@ class ExtractHighlightedContextTests(TestCase):
         self.assertIn("Match", result[0])
         self.assertIn('<mark class="bg-yellow">Match</mark>', result[0])
 
+class StripMarkdownLinksTests(TestCase):
+    def test_removes_markdown_link_url(self):
+        text = "Visit [the saloon](https://the-saloon.rodeo)"
+        expected = "Visit [the saloon]"
+        self.assertEqual(strip_markdown_links(text), expected)
+
+    def test_multiple_links(self):
+        text = "Links: [one](http://a.com) and [two](http://b.com)"
+        expected = "Links: [one] and [two]"
+        self.assertEqual(strip_markdown_links(text), expected)
+
+    def test_no_links(self):
+        text = "Just plain text."
+        self.assertEqual(strip_markdown_links(text), text)
+
+    def test_incomplete_link_syntax(self):
+        text = "Here is a [link without closing"
+        self.assertEqual(strip_markdown_links(text), text)
+
+    def test_empty_string(self):
+        self.assertEqual(strip_markdown_links(""), "")
+
+    def test_none_input(self):
+        self.assertIsNone(strip_markdown_links(None))
+
+    def test_nested_like_links(self):
+        text = "Check [this [nested](http://nested.com)](http://outer.com)"
+        expected = "Check [this [nested]]"
+        self.assertEqual(strip_markdown_links(text), expected)
 
 class TestAddHtmlIdToSubsection(TestCase):
     def setUp(self):

--- a/nofos/nofos/utils.py
+++ b/nofos/nofos/utils.py
@@ -123,6 +123,15 @@ def extract_highlighted_context(body, pattern, context_chars=100, group_distance
 
     return results
 
+def strip_markdown_links(text):
+    """
+    Remove markdown links of the format ](...) from text.
+    This removes the link portion but keeps the link text.
+    """
+    if not text:
+        return text
+    # Remove link URLs: ](anything)
+    return re.sub(r'\]\([^)]*\)', ']', text)
 
 def get_icon_path_choices(theme):
     if theme == "portrait-acf-white":

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -801,7 +801,7 @@ class NofoFindReplaceView(
 
             # Use the existing replace_value_in_subsections function with only selected subsections
             updated_subsections = replace_value_in_subsections(
-                selected_subsections, find_text, replace_text
+                selected_subsections, find_text, replace_text, include_name=True
             )
 
             if updated_subsections:

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -767,7 +767,7 @@ class NofoFindReplaceView(
             # Find matches if find_text is provided and at least 3 chars
             if len(find_text.strip()) > 2:
                 context["subsection_matches"] = find_matches_with_context(
-                    self.object, find_text
+                    self.object, find_text, include_name=True
                 )
 
         return context


### PR DESCRIPTION
## Summary

The major change in this PR is to clean up the Find + Replace function. Specifically, you should be able to find and replace values that live in the `subsection.name`, so that you can change both the link text and the subsection heading if that's what you want to do.

Other changes in this PR:

- Do **not** find or replace URL strings
- Make the contextual buttons a little nicer

### Details

Find & replace has been augmented so that it will match values that are in the `name` of a subsection. The reason for this is sometimes people want to change both the link text ("link to my section") as well as the name of the section ("my section"). It should be possible to do the same at once. 

However, when doing this, we want to be careful that we are not updating urls. Both external and internal urls will break if we just start find+replacing them, so we don't.

### Screenshots

| before | after |
|--------|-------|
|   - does not highlight matches in title<br>- does highlight match in url string     |   - match on just title (3rd result)<br>- do not show or match on URL string    |
|  <img width="1349" alt="Screenshot 2025-06-20 at 16 33 58" src="https://github.com/user-attachments/assets/cf72f8e5-1304-4b60-af01-833f56537d70" />      |    <img width="1349" alt="Screenshot 2025-06-20 at 16 33 33" src="https://github.com/user-attachments/assets/56ac327d-59cd-486d-9f1a-822f7d78d046" />   |


#### Button text improvement

The find/replace buttons are trying to give you context on what is going to happen when you click them.

- On the "title" page, the button will _Save_ the title + some subsections.
- On the page breaks page, the button will _Remove_ page breaks
from some number of subsections.
- On the find/replace page, the button will _Replace_ the value in some
number of subsections.

The logic for this is probably a little too complicated, but at least it works a bit better now than before.

See below:

![Screen Recording 2025-06-20 at 16 35 22](https://github.com/user-attachments/assets/f56cdb05-640d-448f-acc8-7d1d6839d2ca)

