### PR TITLE
Don't log requests to "/health"

### DIFF
--- a/nofos/bloom_nofos/middleware.py
+++ b/nofos/bloom_nofos/middleware.py
@@ -43,6 +43,7 @@ class JSONRequestLoggingMiddleware(MiddlewareMixin):
         r"/media/",
         r"/\.well-known/",
         r"/admin/jsi18n/",
+        r"^/health$",
     ]
 
     def __init__(self, get_response):


### PR DESCRIPTION
## Summary

Don't log requests to the `/health` endpoint.

We just shipped a new logging PR in #390, and so far it looks like it works. Yay!

However, this is what our logs look like in New Relic:

<img width="798" alt="Screenshot 2025-06-26 at 15 21 27" src="https://github.com/user-attachments/assets/b289e499-350e-4635-b15a-ed8f5fcee611" />

It turns out we get so `/health` pings that it kind of crowds out everything else.

So let's ignore them.