### PR TITLE
Add "Edit" links to tables in `nofo_edit` page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Create "Edit" links for tables where all values are on 1 page
+  - This means we remove the "Edit" links from table rows (for individual values)
 - Change all app logs to JSON strings
   - Fixes very long multi-line console output in our app logs in prod
 

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -952,7 +952,12 @@ _:future,
   padding: 0;
 }
 
-.nofo_edit main table.usa-table > tbody > tr:first-of-type > td:last-of-type {
+.nofo_edit
+  main
+  table.usa-table
+  > tbody:not(.no-edit-link)
+  > tr:first-of-type
+  > td:last-of-type {
   width: 5%;
   text-align: right;
 }

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -274,6 +274,29 @@ Edit “{{ nofo|nofo_name }}”
 </section>
 {% endif %}
 
+<table class="usa-table usa-table--borderless width-full table--hide-edit-if-archived">
+  <caption>
+    <div>
+      <h2 class="margin-bottom-0">NOFO status</h2>
+    </div>
+  </caption>
+  <thead class="usa-sr-only">
+    <tr>
+      <th scope="col">Key</th>
+      <th scope="col">Value</th>
+      <th scope="col">Manage</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">NOFO status</th>
+      <td>{{ nofo.get_status_display|get_value_or_none:"draft" }}</td>
+      <td><a href="{% url 'nofos:nofo_edit_status' nofo.id %}">Edit<span class="usa-sr-only"> NOFO status</span></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <table class="usa-table usa-table--borderless width-full table--hide-edit-if-published table--hide-edit-if-archived">
   <caption>
     <div>
@@ -352,30 +375,29 @@ Edit “{{ nofo|nofo_name }}”
   <caption>
     <div>
       <h2 class="margin-bottom-0">NOFO metadata</h2>
+      <span class="padding-right-2 font-sans-sm">
+        <a href="{% url 'nofos:nofo_edit_metadata' nofo.id %}">Edit<span class="usa-sr-only"> metadata: NOFO theme, cover style, and icon style</span></a>
+      </span>
     </div>
   </caption>
   <thead class="usa-sr-only">
     <tr>
       <th scope="col">Key</th>
       <th scope="col">Value</th>
-      <th scope="col">Manage</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody class="no-edit-link">
     <tr>
       <th scope="row">Author</th>
       <td>{{ nofo.author|get_value_or_none:"author" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_metadata' nofo.id %}">Edit<span class="usa-sr-only"> metadata</span></a></td>
     </tr>
     <tr>
       <th scope="row">Subject</th>
       <td>{{ nofo.subject|get_value_or_none:"subject" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_metadata' nofo.id %}">Edit<span class="usa-sr-only"> metadata</span></a></td>
     </tr>
     <tr>
       <th scope="row">Keywords</th>
       <td>{{ nofo.keywords|get_value_or_none:"keywords" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_metadata' nofo.id %}">Edit<span class="usa-sr-only"> metadata</span></a></td>
     </tr>
   </tbody>
 </table>
@@ -384,41 +406,35 @@ Edit “{{ nofo|nofo_name }}”
   <caption>
     <div>
       <h2 class="margin-bottom-0">NOFO theme options</h2>
+      <span class="padding-right-2 font-sans-sm">
+        <a href="{% url 'nofos:nofo_edit_theme_options' nofo.id %}">Edit<span class="usa-sr-only">: NOFO theme, cover style, and icon style</span></a>
+      </span>
     </div>
   </caption>
   <thead class="usa-sr-only">
     <tr>
       <th scope="col">Key</th>
       <th scope="col">Value</th>
-      <th scope="col">Manage</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody class="no-edit-link">
     <tr>
       <th scope="row">Theme</th>
       <td>{{ nofo.get_theme_display|get_value_or_none:"theme" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_theme_options' nofo.id %}">Edit<span class="usa-sr-only"> theme options: NOFO theme, cover style, and icon style</span></a></td>
     </tr>
     <tr>
       <th scope="row">Cover style</th>
       <td>{{ nofo.get_cover_display|get_value_or_none:"Standard image" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_theme_options' nofo.id %}" aria-hidden="true">Edit<span class="usa-sr-only"> theme options</span></a></td>
     </tr>
     {% if nofo.cover_image and nofo.cover != 'nofo--cover-page--text' %}
       <tr>
         <th scope="row">Cover alt text</th>
         <td>{% if nofo.cover_image_alt_text %}“{% endif%}{{ nofo.cover_image_alt_text|get_value_or_none:"alt text" }}{% if nofo.cover_image_alt_text %}”{% endif %}</td>
-        <td><a href="{% url 'nofos:nofo_edit_cover_image' nofo.id %}">Edit<span class="usa-sr-only"> cover image alt text</span></a></td>
       </tr>
     {% endif %}
     <tr>
       <th scope="row">Icon style</th>
       <td>{{ nofo.get_icon_style_display|get_value_or_none:"Outlined" }}</td>
-      <td>
-        {% if "-acl" not in nofo.theme %}
-          <a href="{% url 'nofos:nofo_edit_theme_options' nofo.id %}" aria-hidden="true">Edit<span class="usa-sr-only"> theme options</span></a>
-        {% endif %}
-      </td>
     </tr>
   </tbody>
 </table>
@@ -426,34 +442,26 @@ Edit “{{ nofo|nofo_name }}”
 <table class="usa-table usa-table--borderless width-full table--hide-edit-if-archived">
   <caption>
     <div>
-      <h2 class="margin-bottom-0">NOFO management options</h2>
+      <h2 class="margin-bottom-0">NOFO coach and designer</h2>
+      <span class="padding-right-2 font-sans-sm">
+        <a href="{% url 'nofos:nofo_edit_coach_designer' nofo.id %}">Edit<span class="usa-sr-only">: NOFO theme, cover style, and icon style</span></a>
+      </span>
     </div>
   </caption>
   <thead class="usa-sr-only">
     <tr>
       <th scope="col">Key</th>
       <th scope="col">Value</th>
-      <th scope="col">Manage</th>
     </tr>
   </thead>
-  <tbody>
-    <tr>
-      <th scope="row">NOFO status</th>
-      <td>{{ nofo.get_status_display|get_value_or_none:"draft" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_status' nofo.id %}">Edit<span class="usa-sr-only"> NOFO status</span></a>
-      </td>
-    </tr>
+  <tbody class="no-edit-link">
     <tr>
       <th scope="row">Coach name</th>
       <td>{{ nofo.get_coach_display|get_value_or_none:"coach" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_coach_designer' nofo.id %}">Edit<span class="usa-sr-only"> coach</span></a>
-      </td>
     </tr>
     <tr>
       <th scope="row">Designer name</th>
       <td>{{ nofo.get_designer_display|get_value_or_none:"designer" }}</td>
-      <td><a href="{% url 'nofos:nofo_edit_coach_designer' nofo.id %}">Edit<span class="usa-sr-only"> designer</span></a>
-      </td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary

Add "Edit" links to tables in `nofo_edit` page where the values are on 1 screen.

## Details 

Most of our "Edit" links go to a page where we can only change that one value (eg, NOFO name, NOFO number).

However, some of them we have grouped to all be on 1 page. In the cases where they are all on one page, we just moved the "Edit" link to the top of the table instead of having it be in every row.

Not a huge huge change, but hopefully it cleans things up a bit.

## Screenshots

| before | after |
|--------|-------|
|        |       |
|   ![Screenshot 2025-06-27 at 14 56 24](https://github.com/user-attachments/assets/4cd1ef32-9ad7-442f-89a4-7cfa669f7701)    |  ![Screenshot 2025-06-27 at 14 55 10](https://github.com/user-attachments/assets/733e7e98-ae92-4cbf-90c2-27dcacfaaabf)     |

