### PR TITLE
Add new nav breadcrumb for "Build your application"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add new nav breadcrumb for "Build your application"
+
 ### Changed
 
 - Create "Edit" links for tables where all values are on 1 page

--- a/nofos/nofos/templatetags/utils/__init__.py
+++ b/nofos/nofos/templatetags/utils/__init__.py
@@ -240,6 +240,7 @@ def get_breadcrumb_text(section_name):
         "write your application": "Write",
         "understand review": "Understand",
         "prepare your application": "Prepare",
+        "build your application": "Build",
         "learn about review": "Learn",
         "submit": "Submit",
         "learn what happens": "Award",


### PR DESCRIPTION
## Summary

Pretty simple PR: adds a new breadcrumb link for Sections called "Build your appliation"

### Screenshot

| before | after |
|--------|-------|
|  "TODO" for (3)      |    "3. Build"    |
|     <img width="844" alt="Screenshot 2025-06-27 at 17 30 50" src="https://github.com/user-attachments/assets/d688d8d6-ff07-45bb-a2f4-bf911a240709" />   |    <img width="844" alt="Screenshot 2025-06-27 at 17 31 08" src="https://github.com/user-attachments/assets/0eeeedd0-8bfd-43d7-864e-30f9aab861b3" />   |


