### PR TITLE
"Find & Replace" and "Remove Page Breaks" should be available for in review NOFOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Show "Find & Replace" and "Page breaks" button in review states
+- Don't allow "Find & Replace" or "Page breaks" after publishing
+  - Once published, NOFOs should generally not be edited
 - Create "Edit" links for tables where all values are on 1 page
   - This means we remove the "Edit" links from table rows (for individual values)
 - Change all app logs to JSON strings

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -121,15 +121,28 @@ Edit “{{ nofo|nofo_name }}”
     <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
       NOFO is ‘<a href="{% url 'nofos:nofo_edit_status' nofo.id %}">{{ nofo.get_status_display }}</a>’.
     </h2>
+    <div class="usa-summary-box__text">
     {% if nofo.status == 'doge' %}
-      <div class="usa-summary-box__text">
         <p>NOFOs that are in DOGE review can’t be re-imported or deleted, but they can be edited as needed.</p>
-      </div>
     {% else %}
-      <div class="usa-summary-box__text">
         <p>NOFOs that are {{ nofo.get_status_display|lower }} can’t be re-imported or deleted, but they can be edited as needed.</p>
-      </div>
     {% endif %}
+      <ul class="usa-list usa-list--unstyled">
+        <li>
+          <p>
+            <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
+            — search and replace text across the entire NOFO
+          </p>
+        </li>
+        {% if page_breaks_count > 3 %}
+        <li>
+          <p>
+            <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
+          </p>
+        </li>
+        {% endif %}
+      </ul>
+    </div>
   </div>
 </div>
 {% else %}

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -790,7 +790,10 @@ class NofoImportNumberView(BaseNofoEditView):
 
 
 class NofoFindReplaceView(
-    PreventIfArchivedOrCancelledMixin, GroupAccessObjectMixin, DetailView
+    PreventIfArchivedOrCancelledMixin,
+    PreventIfPublishedMixin,
+    GroupAccessObjectMixin,
+    DetailView,
 ):
     model = Nofo
     template_name = "nofos/nofo_find_replace.html"
@@ -873,7 +876,10 @@ class NofoFindReplaceView(
 
 
 class NofoRemovePageBreaksView(
-    PreventIfArchivedOrCancelledMixin, GroupAccessObjectMixin, DetailView
+    PreventIfArchivedOrCancelledMixin,
+    PreventIfPublishedMixin,
+    GroupAccessObjectMixin,
+    DetailView,
 ):
     model = Nofo
     template_name = "nofos/nofo_remove_page_breaks.html"


### PR DESCRIPTION
## Summary

This PR does 3 things:

- Add "Find & Replace" and "Remove Page Breaks" to 'in review' statuses (In review, paused, DOGE)
- Don't allow "Find & Replace" or "Remove Page Breaks" after publishing
- Rearrange views in views.py so that that similar functions are grouped together

Sort of a small change, but overall we want people to be able to edit nofos after they come back from review.