### PR TITLE
Replace more than 1 icon in a table cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Replace multiple icons in a table cell, should it come to that
+
 ### Fixed
 
 ## [3.4.1] - 2025-07-14


### PR DESCRIPTION
## Summary

If we have a list inside of a table cell, only the first icon was getting replaced. This code will make sure to replace all icons in the table cell.

Simple PR but the logic is pretty ugly to read through. Let's hope this is not a thing that happens very often.

### Screenshots 

| before | after |
|--------|-------|
|   Icons are _not_ replaced in 2nd column. It looks bad.     |  Icons in 2nd column _are_ replaced. It looks good.      |
|   <img width="685" height="468" alt="Screenshot 2025-07-14 at 20 02 58" src="https://github.com/user-attachments/assets/3b718017-228a-4a9c-ab68-3816f47d541f" />     |  <img width="685" height="468" alt="Screenshot 2025-07-14 at 20 01 52" src="https://github.com/user-attachments/assets/b46a7791-4e93-47e4-8f24-828c0a5d71fe" />     |



