### PR TITLE
Patch Dockerfile by updating libgnutls30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,15 @@ RUN apt-get update && \
 # - libcap2: CVE-2025-1390
 # - login, passwd: CVE-2023-4641, CVE-2023-29383, 
 # - libsystemd0, libudev1: CVE-2025-4598
+# - libgnutls30: CVE-2025-32990
 RUN apt-get update && \
   apt-get install -y --only-upgrade \
   libcap2 \
   login \
   passwd \
   libsystemd0 \
-  libudev1 && \
+  libudev1 \
+  libgnutls30 && \
   rm -rf /var/lib/apt/lists/*
 
 # Install Poetry and create user


### PR DESCRIPTION
## Summary

Small PR to explicitly update libgnutls30 inside of Dockerfile.

This is to address identified vulnerability which was flagged by grype.

```
NAME         INSTALLED        FIXED IN         TYPE  VULNERABILITY   SEVERITY  EPSS %  RISK
libgnutls30  3.7.9-2+deb12u4  3.7.9-2+deb12u5  deb   CVE-2025-32990  Medium    18.55   < 0.1
libgnutls30  3.7.9-2+deb12u4  3.7.9-2+deb12u5  deb   CVE-2025-6395   Medium    16.40   < 0.1
libgnutls30  3.7.9-2+deb12u4  3.7.9-2+deb12u5  deb   CVE-2025-32988  Medium    16.26   < 0.1
libgnutls30  3.7.9-2+deb12u4  3.7.9-2+deb12u5  deb   CVE-2025-32989  Medium    3.87    < 0.1
```