### PR TITLE
Improve side navigation functionality to NOFO editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add left-hand floating menu for in-page navigation of a NOFO's major (H2) headings
+
 ### Changed
 
 - Replace multiple icons in a table cell, should it come to that

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1430,8 +1430,13 @@ del + ins > br {
     transition: left 0.3s ease;
 }
 
+.side-nav-pipe {
+    height: 1.25rem;
+    max-height: 1.25rem;
+    overflow: hidden;
+}
+
 .side-nav-pipe.current {
-    font-size: 1.25rem;
     font-weight: bold;
 }
 

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1414,62 +1414,66 @@ del + ins > br {
 
 /* Side Navigation Styles */
 .side-nav-container {
-    top: 50%;
-    pointer-events: none;
-    transition: transform 0.3s ease;
-    transform: translateY(-50%);
+  top: 50%;
+  pointer-events: none;
+  transform: translateY(-50%);
 }
 
 .side-nav-container.is-open {
-    pointer-events: auto;
+  transition: transform 0.3s ease;
+  pointer-events: auto;
 }
 
 .side-nav-toggle {
-    transform: translateY(-50%);
-    pointer-events: auto;
-    transition: left 0.3s ease;
+  transform: translateY(-50%);
+  pointer-events: auto;
+  transition: left 0.3s ease;
+  cursor: pointer;
 }
 
 .side-nav-pipe {
-    height: 1.25rem;
-    max-height: 1.25rem;
-    overflow: hidden;
+  line-height: 1.15;
+  height: 1.25rem;
+  max-height: 1.25rem;
+  overflow: hidden;
 }
 
 .side-nav-pipe.current {
-    font-weight: bold;
+  font-size: 1.25em;
+  line-height: 0.8;
+  font-weight: bold;
 }
 
 .side-nav-content {
-    left: -330px;
-    width: 320px;
-    transition: left 0.3s ease, transform 0.3s ease;
-    transform: translateY(-50%);
+  left: -330px;
+  width: 320px;
+  transform: translateY(-50%);
 }
 
 .side-nav-container.is-open .side-nav-content {
-    left: 60px;
-    transform: translateY(-50%);
+  transition: left 0.3s ease, transform 0.3s ease;
+  left: 60px;
+  transform: translateY(-50%);
 }
 
 /* Navigation List Styles */
 #side-nav-list {
-    padding: 1rem;
-    margin: 0;
-    list-style: none;
+  padding: 1rem;
+  margin: 0;
+  list-style: none;
 }
 
 /* Responsive Design */
-@media (max-width: 768px) {
-    .side-nav-content {
-        width: 100vw;
-        height: 100vh;
-        left: -100vw;
-        top: 0;
-    }
+@media (max-width: 48em) {
+  .side-nav-content {
+    width: 100vw;
+    height: 100vh;
+    left: -101vw;
+    top: 0;
+  }
 
-    .side-nav-container.is-open .side-nav-content {
-        left: 0;
-        top: 0;
-    }
+  .side-nav-container.is-open .side-nav-content {
+    left: -1vw;
+    top: 0;
+  }
 }

--- a/nofos/bloom_nofos/templates/includes/side_navigation.html
+++ b/nofos/bloom_nofos/templates/includes/side_navigation.html
@@ -1,10 +1,17 @@
 <!-- Side Navigation Component -->
+{% load math_filters %}
+
+{% with num_headings=side_nav_headings|length %}
+{% if num_headings > 0 %}
 <div id="side-nav-container" class="side-nav-container position-fixed left-1 z-top height-auto width-auto" aria-hidden="true">
     <!-- Toggle Button -->
-    <button id="side-nav-toggle" class="side-nav-toggle position-fixed left-1 z-top padding-1 radius-md display-flex flex-align-center flex-justify-center text-primary border-primary bg-white hover:bg-gray-10 " aria-expanded="false"
+    <button id="side-nav-toggle" class="side-nav-toggle position-fixed left-1 z-top width-5 maxw-5 padding-1 radius-md display-flex flex-align-center flex-justify-center text-primary border-primary bg-white hover:bg-gray-10 " aria-expanded="false"
         aria-controls="side-nav-content" aria-label="Toggle table of contents navigation" type="button">
-        <div id="side-nav-pipes" class="side-nav-pipes display-flex flex-column flex-align-center gap-1">
-            <!-- Pipe characters will be populated dynamically by JavaScript -->
+
+        <div id="side-nav-pipes" class="side-nav-pipes display-flex flex-column flex-align-center gap-1" style="height: {{ num_headings|multiply:1.25 }}rem;">
+            {% for heading in side_nav_headings %}
+                <span class="side-nav-pipe" data-section-id="{{ heading.id }}" title="{{ heading.name }}">—</span>
+            {% endfor %}
         </div>
     </button>
 
@@ -24,14 +31,17 @@
         <!-- Navigation List -->
         <nav aria-label="Table of contents navigation">
             <ul id="side-nav-list" class="usa-sidenav">
-                <!-- Navigation items will be populated dynamically by JavaScript -->
+                {% for heading in side_nav_headings %}
+                    <li class="usa-sidenav__item">
+                        <a href="#{{ heading.id }}" data-section-id="{{ heading.id }}" tabindex="-1">
+                            {{ heading.name }}
+                        </a>
+                    </li>
+                {% endfor %}
             </ul>
         </nav>
     </div>
 </div>
-
-
-
 
 <script>
     document.addEventListener('DOMContentLoaded', function () {
@@ -43,15 +53,9 @@
         // Store original positions of headings
         const originalPositions = {};
 
-        // Function to populate navigation from h2 headings
-        function populateNavigation() {
+        // Function to initialize navigation positions and click handlers
+        function initializeNavigation() {
             const headings = document.querySelectorAll('h2[id]');
-            const navItems = [];
-            const sideNavPipes = document.getElementById('side-nav-pipes');
-
-            // Clear existing items
-            sideNavList.innerHTML = '';
-            sideNavPipes.innerHTML = '';
 
             // Store current scroll position
             const currentScrollPosition = window.pageYOffset || document.documentElement.scrollTop;
@@ -59,45 +63,17 @@
             // STICKY Workaround: This is a workaround to get accurate positions when there are sticky elements. Scroll to top to get accurate positions
             window.scrollTo(0, 0);
 
-            headings.forEach(function (heading, index) {
+            headings.forEach(function (heading) {
                 const id = heading.getAttribute('id');
-                const headingText = heading.textContent.trim();
-
                 if (!id) return;
 
                 const headingRect = heading.getBoundingClientRect();
                 const elementOffset = 95; // Additional offset to ensure content below heading is visible
                 originalPositions[id] = headingRect.top + window.pageYOffset - elementOffset;
-
-
-                const listItem = document.createElement('li');
-                listItem.className = 'usa-sidenav__item';
-
-                const link = document.createElement('a');
-                link.href = '#' + id;
-                link.textContent = '      ' + headingText;
-                link.setAttribute('data-section-id', id);
-                link.setAttribute('tabindex', '-1'); // Start with no tab access since nav is closed
-
-                listItem.appendChild(link);
-                navItems.push(listItem);
-
-                const pipe = document.createElement('span');
-                pipe.className = 'side-nav-pipe';
-                pipe.textContent = '—';
-                pipe.setAttribute('data-section-id', id);
-                pipe.setAttribute('tabindex', '-1');
-                pipe.title = headingText;
-                sideNavPipes.appendChild(pipe);
             });
 
             // STICKY Workaround: Scroll back to original position of page load
             window.scrollTo(0, currentScrollPosition);
-
-            // Add navigation items to sidebar
-            navItems.forEach(function (item) {
-                sideNavList.appendChild(item);
-            });
 
             // Add click handlers for smooth scrolling and active state
             const navLinks = sideNavList.querySelectorAll('a');
@@ -236,7 +212,7 @@
         }
 
         // Initialize
-        populateNavigation();
+        initializeNavigation();
         updateActiveState();
 
         // Set initial tabindex for close button (nav starts closed)
@@ -251,7 +227,7 @@
             scrollTimeout = setTimeout(updateActiveState, 100);
         });
 
-        // Re-populate navigation if content changes
+        // Re-initialize navigation if content changes
         const observer = new MutationObserver(function (mutations) {
             let shouldUpdate = false;
             mutations.forEach(function (mutation) {
@@ -260,7 +236,7 @@
                 }
             });
             if (shouldUpdate) {
-                populateNavigation();
+                initializeNavigation();
                 updateActiveState();
             }
         });
@@ -271,3 +247,5 @@
         });
     });
 </script>
+{% endif %}
+{% endwith %}

--- a/nofos/bloom_nofos/templates/includes/side_navigation.html
+++ b/nofos/bloom_nofos/templates/includes/side_navigation.html
@@ -3,7 +3,7 @@
 
 {% with num_headings=side_nav_headings|length %}
 {% if num_headings > 0 %}
-<div id="side-nav-container" class="side-nav-container position-fixed left-1 z-top height-auto width-auto" aria-hidden="true">
+<div id="side-nav-container" class="side-nav-container position-fixed left-1 z-top height-auto width-auto">
     <!-- Toggle Button -->
     <button id="side-nav-toggle" class="side-nav-toggle position-fixed left-1 z-top width-5 maxw-5 padding-1 radius-md display-flex flex-align-center flex-justify-center text-primary border-primary bg-white hover:bg-gray-10 " aria-expanded="false"
         aria-controls="side-nav-content" aria-label="Toggle table of contents navigation" type="button">
@@ -16,7 +16,7 @@
     </button>
 
     <!-- Side Navigation Content -->
-    <div id="side-nav-content" class="side-nav-content position-fixed top-50 z-top height-auto width-card maxh-viewport bg-white border-white border-1px shadow-2 overflow-y-auto overflow-x-hidden radius-lg">
+    <div id="side-nav-content" class="side-nav-content position-fixed top-50 z-top height-auto width-card maxh-viewport bg-white border-white border-1px shadow-2 overflow-y-auto overflow-x-hidden radius-lg" aria-hidden="true">
         <div class="display-flex flex-align-center flex-justify border-bottom-1px border-base-lighter bg-base-lightest">
             <span class="padding-left-2 text-bold text-ink">Contents</span>
             <button id="side-nav-close" class="usa-button usa-modal__close margin-top-05"
@@ -25,7 +25,6 @@
                     <use href="/static/img/usa-icons/close.svg"></use>
                   </svg>
             </button>
-
         </div>
 
         <!-- Navigation List -->
@@ -46,6 +45,7 @@
 <script>
     document.addEventListener('DOMContentLoaded', function () {
         const sideNavContainer = document.getElementById('side-nav-container');
+        const sideNavContent = document.getElementById('side-nav-content');
         const sideNavToggle = document.getElementById('side-nav-toggle');
         const sideNavClose = document.getElementById('side-nav-close');
         const sideNavList = document.getElementById('side-nav-list');
@@ -105,7 +105,7 @@
 
         function openNav() {
             sideNavContainer.classList.add('is-open');
-            sideNavContainer.setAttribute('aria-hidden', 'false');
+            sideNavContent.setAttribute('aria-hidden', 'false');
             sideNavToggle.setAttribute('aria-expanded', 'true');
 
             // Make navigation elements tabbable
@@ -126,7 +126,7 @@
 
         function closeNav() {
             sideNavContainer.classList.remove('is-open');
-            sideNavContainer.setAttribute('aria-hidden', 'true');
+            sideNavContent.setAttribute('aria-hidden', 'true');
             sideNavToggle.setAttribute('aria-expanded', 'false');
 
             // Remove navigation elements from tab order

--- a/nofos/bloom_nofos/templates/includes/side_navigation.html
+++ b/nofos/bloom_nofos/templates/includes/side_navigation.html
@@ -128,6 +128,7 @@
             sideNavContainer.classList.remove('is-open');
             sideNavContent.setAttribute('aria-hidden', 'true');
             sideNavToggle.setAttribute('aria-expanded', 'false');
+            sideNavToggle.focus(); // focus back on toggle
 
             // Remove navigation elements from tab order
             sideNavClose.setAttribute('tabindex', '-1');

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1235,6 +1235,37 @@ def find_h7_headers(nofo):
     return h7_headers
 
 
+def get_side_nav_links(nofo):
+    """
+    Generate a list of dictionaries for the side navigation menu in the NOFO editor.
+
+    Args:
+        nofo: The NOFO instance whose sections will be included in the navigation.
+
+    Returns:
+        list: A list of dictionaries, each representing a navigation link. Each dictionary
+              contains:
+                - 'id': The HTML id of the section (used as an anchor in the page).
+                - 'name': The display name of the section.
+
+    Example:
+        [
+            {'id': 'summary-box-key-information', 'name': 'NOFO Summary'},
+            {'id': 'section-1-html-id', 'name': 'Section 1 Name'},
+            ...
+        ]
+    """
+    if nofo.sections.count() == 0:
+        return []
+
+    side_nav_links = [{"id": "summary-box-key-information", "name": "NOFO Summary"}]
+
+    for section in nofo.sections.all().order_by("order"):
+        side_nav_links.append({"id": section.html_id, "name": section.name})
+
+    return side_nav_links
+
+
 ###########################################################
 #################### SUGGEST VAR FUNCS ####################
 ###########################################################
@@ -2487,8 +2518,8 @@ def modifications_update_announcement_text(nofo):
     Update announcement text in all subsection bodies of a given NOFO.
     Usually this is just in 1 subsection ("Key facts"), but I guess it could be in others.
 
-    - Looks for "Announcement version: New" or "Announcement type: New" (case insensitive).
-    - Replaces them with "Announcement version: Modified" or "Announcement type: Modified".
+    - Looks for "Announcement version: New" or "Announcement type: New" (case insensitive).
+    - Replaces them with "Announcement version: Modified" or "Announcement type: Modified".
     - Mutates the NOFO object in place.
 
     :param nofo: The NOFO object containing sections and subsections.

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -45,7 +45,7 @@ Edit “{{ nofo|nofo_name }}”
 {% endif %}
 </div>
 
-{% include "includes/side_navigation.html" %}
+{% include "includes/side_navigation.html" with side_nav_headings=side_nav_headings %}
 
 <div class="nofo_edit--audit-widget">
   {% timezone "America/New_York" %}

--- a/nofos/nofos/templatetags/math_filters.py
+++ b/nofos/nofos/templatetags/math_filters.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def multiply(value, arg):
+    return value * arg

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -41,6 +41,7 @@ from .nofo import (
     find_subsections_with_nofo_field_value,
     get_cover_image,
     get_sections_from_soup,
+    get_side_nav_links,
     get_step_2_section,
     get_subsections_from_sections,
     is_callout_box_table,
@@ -2829,6 +2830,81 @@ class TestFindH7Headers(TestCase):
         )
         self.assertEqual(h7_headers[1]["section"], nofo.sections.first())
         self.assertEqual(h7_headers[1]["subsection"], subsections[3])
+
+
+class TestGetSideNavLinks(TestCase):
+    def setUp(self):
+        self.sections = [
+            {
+                "name": "Section 1",
+                "order": 1,
+                "html_id": "section-1",
+                "has_section_page": True,
+                "subsections": [
+                    {
+                        "name": "Subsection 1",
+                        "order": 1,
+                        "tag": "h3",
+                        "html_id": "subsection-1",
+                        "body": ["<p>Section 1 body</p>"],
+                    }
+                ],
+            },
+            {
+                "name": "Section 2",
+                "order": 2,
+                "html_id": "section-2",
+                "has_section_page": True,
+                "subsections": [
+                    {
+                        "name": "Subsection 2",
+                        "order": 1,
+                        "tag": "h3",
+                        "html_id": "subsection-2",
+                        "body": ["<p>Section 2 body</p>"],
+                    }
+                ],
+            },
+            {
+                "name": "Section 3",
+                "order": 3,
+                "html_id": "section-3",
+                "has_section_page": True,
+                "subsections": [],
+            },
+        ]
+
+    def test_get_side_nav_links_with_sections(self):
+        """Test that get_side_nav_links returns correct structure with sections"""
+        nofo = create_nofo("Test NOFO", self.sections, opdiv="Test OpDiv")
+
+        result = get_side_nav_links(nofo)
+
+        # Should have summary plus 3 sections
+        self.assertEqual(len(result), 4)
+
+        # First item should always be the summary
+        self.assertEqual(result[0]["id"], "summary-box-key-information")
+        self.assertEqual(result[0]["name"], "NOFO Summary")
+
+        # Check section data
+        self.assertEqual(result[1]["id"], "section-1")
+        self.assertEqual(result[1]["name"], "Section 1")
+
+        self.assertEqual(result[2]["id"], "section-2")
+        self.assertEqual(result[2]["name"], "Section 2")
+
+        self.assertEqual(result[3]["id"], "section-3")
+        self.assertEqual(result[3]["name"], "Section 3")
+
+    def test_get_side_nav_links_with_no_sections(self):
+        """Test that get_side_nav_links returns only summary when no sections exist"""
+        nofo = create_nofo("Empty NOFO", [], opdiv="Test OpDiv")
+
+        result = get_side_nav_links(nofo)
+
+        # Should only have the summary
+        self.assertEqual(len(result), 0)
 
 
 class TestUpdateLinkStatuses(TestCase):

--- a/nofos/nofos/tests_nofos/test_side_navigation.py
+++ b/nofos/nofos/tests_nofos/test_side_navigation.py
@@ -112,8 +112,8 @@ class SideNavigationTemplateTest(TestCase):
         soup = BeautifulSoup(response.content, "html.parser")
 
         # Check ARIA attributes
-        side_nav_container = soup.find("div", {"id": "side-nav-container"})
-        self.assertEqual(side_nav_container.get("aria-hidden"), "true")
+        side_nav_content = soup.find("div", {"id": "side-nav-content"})
+        self.assertEqual(side_nav_content.get("aria-hidden"), "true")
 
         toggle_button = soup.find("button", {"id": "side-nav-toggle"})
         self.assertEqual(toggle_button.get("aria-expanded"), "false")

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -76,6 +76,7 @@ from .nofo import (
     find_external_link,
     find_external_links,
     find_h7_headers,
+    get_side_nav_links,
     find_incorrectly_nested_heading_levels,
     find_matches_with_context,
     find_same_or_higher_heading_levels_consecutive,
@@ -298,6 +299,8 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
         context["DOCRAPTOR_LIVE_MODE"] = is_docraptor_live_mode_active(
             config.DOCRAPTOR_LIVE_MODE
         )
+
+        context["side_nav_headings"] = get_side_nav_links(self.object)
 
         # Clean up stale reimport session data
         self.request.session.pop("reimport_data", None)


### PR DESCRIPTION
# Improve Side Navigation Population in NOFO Editor

## Summary
Refactored the side navigation component to use server-side rendering instead of client-side JavaScript population, improving performance and reliability.

## Related Issue(s)
- https://github.com/HHS/simpler-grants-pdf-builder/issues/278

## Changes Made

### Backend Changes
- **Added `get_side_nav_links()` function** in `nofos/nofo.py` to generate navigation links based on NOFO sections
- **Updated `NofosEditView`** to pass `side_nav_headings` to template context
- **Created `math_filters.py`** template tag with `multiply` filter for dynamic height calculations

### Frontend Changes
- **Enhanced side navigation template** to render navigation links and pipe characters server-side
- **Simplified JavaScript logic** by removing client-side navigation population
- **Added conditional rendering** to hide navigation when no sections exist

### Testing
- **Added comprehensive tests** for `get_side_nav_links()` function
- **Enhanced side navigation tests** to verify correct HTML element generation
- **Added test coverage** for NOFOs with no sections

## Technical Details
- Navigation links are now generated from NOFO sections in the view layer
- Template conditionally renders navigation only when sections exist
- JavaScript focuses on interaction logic (toggle, scroll tracking) rather than content generation
- Maintains all existing functionality while improving underlying architecture
