### PR TITLE
Create "uploads" app to list images

### DIFF
--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -86,6 +86,10 @@ aws_dns_name = env.get_value("LOAD_BALANCER_DNS_NAME", default="")
 if aws_dns_name:
     ALLOWED_HOSTS.append(aws_dns_name)
 
+# AWS CONFIG
+AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME", default=None)
+AWS_REGION = env("AWS_REGION", default="us-east-1")
+
 # SECURITY HEADERS
 SECURE_SSL_REDIRECT = is_prod
 SECURE_REDIRECT_EXEMPT = [r"^health/?$"]
@@ -125,6 +129,7 @@ INSTALLED_APPS = [
     "nofos.apps.NofosConfig",
     "guides.apps.GuidesConfig",
     "users.apps.UsersConfig",
+    "uploads.apps.UploadsConfig",
     "django_mirror",
     "ninja",
 ]

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -283,6 +283,16 @@ if not is_prod and DATABASES["default"]["HOST"].startswith("/cloudsql"):
     DATABASES["default"]["HOST"] = "127.0.0.1"
     DATABASES["default"]["PORT"] = 5432
 
+# Cache
+# https://docs.djangoproject.com/en/5.2/topics/cache/
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-uploads-cache",
+    }
+}
+
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -508,8 +508,7 @@ label.usa-label {
 }
 
 /* Alert styles */
-#nofo-editor-success-alert,
-#nofo-editor-error-alert {
+.usa-alert--fixed {
   position: fixed;
   bottom: 0;
   left: 50%;
@@ -543,6 +542,14 @@ label.usa-label {
 
 .usa-alert__text {
   margin: 0;
+}
+
+.usa-alert code {
+  font-size: 0.85em;
+  padding: 3px 5px;
+  margin: 0 2px;
+  border: 1px solid grey;
+  border-radius: 4px;
 }
 
 /* Ensure warning messages stay on top */

--- a/nofos/bloom_nofos/templates/includes/alerts.html
+++ b/nofos/bloom_nofos/templates/includes/alerts.html
@@ -1,10 +1,12 @@
 {% for message in messages %}
   {% if "success" in message.tags and success_heading %}
-    <div id="nofo-editor-success-alert" class="usa-alert usa-alert--success margin-bottom-3" role="alert" aria-live="polite">
+    <div id="nofo-editor-success-alert" class="usa-alert usa-alert--success margin-bottom-3{% if stick_to_bottom %} usa-alert--fixed{% endif %}" role="alert" aria-live="polite">
       <div class="usa-alert__body">
-        <button type="button" class="usa-alert__close" aria-label="Dismiss success message" tabindex="0">
-          <span aria-hidden="true">×</span>
-        </button>
+        {% if stick_to_bottom %}
+          <button type="button" class="usa-alert__close" aria-label="Dismiss success message" tabindex="0">
+            <span aria-hidden="true">×</span>
+          </button>
+        {% endif %}
         <h4 class="usa-alert__heading">{{ success_heading }}</h4>
         <p class="usa-alert__text">
           {{ message | safe }}
@@ -12,11 +14,13 @@
       </div>
     </div>
   {% elif "error" in message.tags and error_heading %}
-    <div id="nofo-editor-error-alert" class="usa-alert usa-alert--error margin-bottom-3" role="alert" aria-live="assertive">
+    <div id="nofo-editor-error-alert" class="usa-alert usa-alert--error margin-bottom-3{% if stick_to_bottom %} usa-alert--fixed{% endif %}" role="alert" aria-live="assertive">
       <div class="usa-alert__body">
-        <button type="button" class="usa-alert__close" aria-label="Dismiss error message" tabindex="0">
-          <span aria-hidden="true">×</span>
-        </button>
+        {% if stick_to_bottom %}
+          <button type="button" class="usa-alert__close" aria-label="Dismiss error message" tabindex="0">
+            <span aria-hidden="true">×</span>
+          </button>
+        {% endif %}
         <h4 class="usa-alert__heading">{{ error_heading }}</h4>
         <p class="usa-alert__text">
           {{ message | safe }}
@@ -28,12 +32,12 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    const ALERT_SELECTORS = '#nofo-editor-success-alert, #nofo-editor-error-alert';
+    const ALERT_SELECTOR = '.usa-alert--fixed';
     const ANIMATION_DURATION = 300; // Duration of fade animation in ms
     const AUTO_DISMISS_DELAY = 4000; // Time before auto-dismissal in ms
 
     // Handle close button clicks and keyboard events
-    const alerts = document.querySelectorAll(ALERT_SELECTORS);
+    const alerts = document.querySelectorAll(ALERT_SELECTOR);
     requestAnimationFrame(() => {
       alerts.forEach(alert => alert.style.opacity = '1');
     });

--- a/nofos/bloom_nofos/urls.py
+++ b/nofos/bloom_nofos/urls.py
@@ -46,6 +46,7 @@ urlpatterns = [
     path("nofos/", include("nofos.urls")),
     path("guides/", include("guides.urls")),
     path("users/", include("users.urls")),
+    path("uploads/", include("uploads.urls")),
     path("admin/", admin.site.urls),
     path("test-mode", views.TestModeView.as_view(), name="test_mode"),
     path("", views.index, name="index"),

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -10,7 +10,7 @@ Edit “{{ nofo|nofo_name }}”
 {% block body_class %}nofo_edit nofo_status--{{ nofo.status }}{% if nofo.modifications %} nofo--modifications{% endif %}{% if nofo.archived %} nofo--archived{% endif %}{% endblock %}
 
 {% block content %}
-{% include "includes/alerts.html" with messages=messages success_heading="NOFO saved successfully" error_heading="Subsection deleted" only %}
+{% include "includes/alerts.html" with messages=messages success_heading="NOFO saved successfully" error_heading="Subsection deleted" stick_to_bottom=True only %}
 
 <!-- WARNING MESSAGE FOR ARCHIVED/SUCCESSOR NOFOS -->
 {% if nofo.archived %}

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -103,6 +103,12 @@ from .nofo import (
 from .nofo_compare import compare_nofos, compare_nofos_metadata
 from .utils import create_nofo_audit_event, create_subsection_html_id
 
+import boto3
+from django.http import JsonResponse
+import re
+import os
+
+
 GroupAccessObjectMixin = GroupAccessObjectMixinFactory(Nofo)
 
 ###########################################################

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1,8 +1,11 @@
 import io
 import json
+import os
+import re
 import uuid
 from datetime import datetime
 
+import boto3
 import docraptor
 from bloom_nofos.logs import log_exception
 from bloom_nofos.utils import cast_to_boolean, is_docraptor_live_mode_active
@@ -14,7 +17,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.forms.models import model_to_dict
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils import dateformat, dateparse, timezone
@@ -102,12 +105,6 @@ from .nofo import (
 )
 from .nofo_compare import compare_nofos, compare_nofos_metadata
 from .utils import create_nofo_audit_event, create_subsection_html_id
-
-import boto3
-from django.http import JsonResponse
-import re
-import os
-
 
 GroupAccessObjectMixin = GroupAccessObjectMixinFactory(Nofo)
 

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1,11 +1,8 @@
 import io
 import json
-import os
-import re
 import uuid
 from datetime import datetime
 
-import boto3
 import docraptor
 from bloom_nofos.logs import log_exception
 from bloom_nofos.utils import cast_to_boolean, is_docraptor_live_mode_active
@@ -17,7 +14,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import transaction
 from django.forms.models import model_to_dict
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils import dateformat, dateparse, timezone

--- a/nofos/uploads/apps.py
+++ b/nofos/uploads/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class UploadsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "uploads"

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -10,8 +10,12 @@
   {% include "includes/alerts.html" with messages=messages error_heading="SSO token error" only %}
 
   <h1>Uploaded Images</h1>
+  <p>These images are available to be used as cover images for NOFO documents.</p>
   {% if images %}
     <table class="usa-table usa-table--borderless width-full">
+      <caption>
+        Table: {{ images | length }} images returned
+      </caption>
       <thead>
         <tr>
           <th scope="col">Filename</th>
@@ -25,7 +29,7 @@
         <tr>
           <th scope="row"><a href="{{ image.url }}" target="_blank">{{ image.key }}</a></th>
           <td>
-            {{ image.size_kb }} KB
+            {{ image.size_display }}
           </td>
           <td>{{ image.last_modified|date:"Y-m-d" }}</td>
           <td>

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>Uploaded Images</h1>
+  <ul>
+    {% for image in images %}
+      <li>
+        <a href="https://{{ AWS_STORAGE_BUCKET_NAME }}.s3.amazonaws.com/{{ image }}" target="_blank">
+          {{ image }}
+        </a>
+      </li>
+    {% empty %}
+      <li>No images found.</li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -10,8 +10,9 @@
   {% include "includes/alerts.html" with messages=messages error_heading="SSO token error" only %}
 
   <h1>Uploaded Images</h1>
-  <p>These images are available to be used as cover images for NOFO documents.</p>
   {% if images %}
+    <p>These images are available to be used as cover images for NOFO documents.</p>
+
     <table class="usa-table usa-table--borderless width-full">
       <caption>
         Table: {{ images | length }} images returned

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -1,18 +1,41 @@
 {% extends "base.html" %}
 
+{% block title %}
+  Uploaded images
+{% endblock %}
+
+{% block body_class %}uploaded-images{% endblock %}
+
 {% block content %}
   {% include "includes/alerts.html" with messages=messages error_heading="SSO token error" only %}
 
   <h1>Uploaded Images</h1>
-  {% for image in images %}
-  <ul>
-    <li>
-      <a href="https://{{ AWS_STORAGE_BUCKET_NAME }}.s3.amazonaws.com/{{ image }}" target="_blank">
-        {{ image }}
-      </a>
-    </li>
-  </ul>
-  {% empty %}
-  <p>No images returned.</p>
-  {% endfor %}
+  {% if images %}
+    <table class="usa-table usa-table--borderless width-full">
+      <thead>
+        <tr>
+          <th scope="col">Filename</th>
+          <th scope="col">Size</th>
+          <th scope="col">Last modified</th>
+          <th scope="col">Image</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for image in images %}
+        <tr>
+          <th scope="row"><a href="{{ image.url }}" target="_blank">{{ image.key }}</a></th>
+          <td>
+            {{ image.size_kb }} KB
+          </td>
+          <td>{{ image.last_modified|date:"Y-m-d" }}</td>
+          <td>
+            <img class="border-2px radius-md maxh-card" src="{{ image.url }}" alt="{{ image.key }}" />
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p>No images returned.</p>
+  {% endif %}
 {% endblock %}

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -1,16 +1,18 @@
 {% extends "base.html" %}
 
 {% block content %}
+  {% include "includes/alerts.html" with messages=messages error_heading="SSO token error" only %}
+
   <h1>Uploaded Images</h1>
+  {% for image in images %}
   <ul>
-    {% for image in images %}
-      <li>
-        <a href="https://{{ AWS_STORAGE_BUCKET_NAME }}.s3.amazonaws.com/{{ image }}" target="_blank">
-          {{ image }}
-        </a>
-      </li>
-    {% empty %}
-      <li>No images found.</li>
-    {% endfor %}
+    <li>
+      <a href="https://{{ AWS_STORAGE_BUCKET_NAME }}.s3.amazonaws.com/{{ image }}" target="_blank">
+        {{ image }}
+      </a>
+    </li>
   </ul>
+  {% empty %}
+  <p>No images returned.</p>
+  {% endfor %}
 {% endblock %}

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -34,7 +34,7 @@
           </td>
           <td>{{ image.last_modified|date:"Y-m-d" }}</td>
           <td>
-            <img class="border-2px radius-md maxh-card" src="{{ image.url }}" alt="{{ image.key }}" />
+            <img class="border-2px radius-md maxh-card" src="{{ image.url }}" alt="{{ image.key }}" loading="lazy" />
           </td>
         </tr>
         {% endfor %}

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -7,7 +7,7 @@
 {% block body_class %}uploaded-images{% endblock %}
 
 {% block content %}
-  {% include "includes/alerts.html" with messages=messages error_heading="SSO token error" only %}
+  {% include "includes/alerts.html" with messages=messages error_heading="SSO token error" success_heading="Image cache reset" only %}
 
   <h1>Uploaded Images</h1>
   {% if images %}

--- a/nofos/uploads/tests.py
+++ b/nofos/uploads/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/nofos/uploads/tests.py
+++ b/nofos/uploads/tests.py
@@ -75,6 +75,9 @@ class ImageListViewTests(TestCase):
     @patch("uploads.views.boto3.client")
     def test_token_missing_shows_message(self, mock_boto_client):
         from botocore.exceptions import SSOTokenLoadError
+        from django.core.cache import cache
+
+        cache.delete("uploads_images")  # Ensure it hits boto3
 
         mock_boto_client.side_effect = SSOTokenLoadError(
             profile_name="grants", error_msg="Token for grants does not exist"
@@ -88,6 +91,10 @@ class ImageListViewTests(TestCase):
     @override_settings(AWS_STORAGE_BUCKET_NAME="fake-bucket")
     @patch("uploads.views.boto3.client")
     def test_token_retrieval_error_shows_message(self, mock_boto_client):
+        from django.core.cache import cache
+
+        cache.delete("uploads_images")  # Ensure it hits boto3
+
         mock_boto_client.side_effect = TokenRetrievalError(
             provider="sso", error_msg="Token has expired and refresh failed"
         )

--- a/nofos/uploads/tests.py
+++ b/nofos/uploads/tests.py
@@ -1,5 +1,12 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase, override_settings
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from unittest.mock import patch, MagicMock
+from botocore.exceptions import TokenRetrievalError
+from datetime import datetime, timezone
 from .utils import get_display_size
+
+User = get_user_model()
 
 
 class GetDisplaySizeTests(SimpleTestCase):
@@ -18,3 +25,76 @@ class GetDisplaySizeTests(SimpleTestCase):
         self.assertEqual(get_display_size(1024 * 1024), "1.0 MB")
         self.assertEqual(get_display_size(5 * 1024 * 1024), "5.0 MB")
         self.assertEqual(get_display_size(3145728), "3.0 MB")  # 3 MB
+
+
+class ImageListViewTests(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            email="grant+super@grants.gov", password="pass"
+        )
+        self.regular_user = User.objects.create_user(
+            email="grant@grants.gov", password="pass", group="acf"
+        )
+        self.url = reverse("uploads_images")
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME="fake-bucket")
+    @patch("uploads.views.boto3.client")
+    def test_superuser_sees_images(self, mock_boto_client):
+        # Mock S3 client and response
+        mock_s3 = MagicMock()
+        mock_boto_client.return_value = mock_s3
+        mock_s3.list_objects_v2.return_value = {
+            "Contents": [
+                {
+                    "Key": "images/photo1.jpg",
+                    "Size": 1048576,
+                    "LastModified": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    "ETag": '"abc123"',
+                }
+            ]
+        }
+        mock_s3.generate_presigned_url.return_value = "https://fake-url/photo1.jpg"
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "images/photo1.jpg")
+        self.assertContains(response, "1.0 MB")
+        self.assertContains(response, "https://fake-url/photo1.jpg")
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME=None)
+    def test_missing_bucket_shows_error(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, "No AWS bucket configured", status_code=200)
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME="fake-bucket")
+    @patch("uploads.views.boto3.client")
+    def test_token_missing_shows_message(self, mock_boto_client):
+        from botocore.exceptions import SSOTokenLoadError
+
+        mock_boto_client.side_effect = SSOTokenLoadError(
+            profile_name="grants", error_msg="Token for grants does not exist"
+        )
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+
+        self.assertContains(response, "No AWS SSO token found")
+
+    @override_settings(AWS_STORAGE_BUCKET_NAME="fake-bucket")
+    @patch("uploads.views.boto3.client")
+    def test_token_retrieval_error_shows_message(self, mock_boto_client):
+        mock_boto_client.side_effect = TokenRetrievalError(
+            provider="sso", error_msg="Token has expired and refresh failed"
+        )
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertContains(response, "Your AWS SSO token has expired")
+
+    def test_non_superuser_is_denied(self):
+        self.client.force_login(self.regular_user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)

--- a/nofos/uploads/tests.py
+++ b/nofos/uploads/tests.py
@@ -1,3 +1,20 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
+from .utils import get_display_size
 
-# Create your tests here.
+
+class GetDisplaySizeTests(SimpleTestCase):
+
+    def test_bytes(self):
+        self.assertEqual(get_display_size(0), "0 B")
+        self.assertEqual(get_display_size(512), "512 B")
+        self.assertEqual(get_display_size(1023), "1023 B")
+
+    def test_kilobytes(self):
+        self.assertEqual(get_display_size(1024), "1.0 KB")
+        self.assertEqual(get_display_size(1536), "1.5 KB")
+        self.assertEqual(get_display_size(10 * 1024), "10.0 KB")
+
+    def test_megabytes(self):
+        self.assertEqual(get_display_size(1024 * 1024), "1.0 MB")
+        self.assertEqual(get_display_size(5 * 1024 * 1024), "5.0 MB")
+        self.assertEqual(get_display_size(3145728), "3.0 MB")  # 3 MB

--- a/nofos/uploads/tests.py
+++ b/nofos/uploads/tests.py
@@ -1,9 +1,11 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import TokenRetrievalError
+from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
-from django.contrib.auth import get_user_model
-from unittest.mock import patch, MagicMock
-from botocore.exceptions import TokenRetrievalError
-from datetime import datetime, timezone
+
 from .utils import get_display_size
 
 User = get_user_model()

--- a/nofos/uploads/urls.py
+++ b/nofos/uploads/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from . import views
 
 urlpatterns = [

--- a/nofos/uploads/urls.py
+++ b/nofos/uploads/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("images/", views.ImageListView.as_view(), name="uploads_images"),
+]

--- a/nofos/uploads/utils.py
+++ b/nofos/uploads/utils.py
@@ -1,0 +1,9 @@
+def get_display_size(size_bytes):
+    if size_bytes < 1024:
+        return "{} B".format(size_bytes)
+    elif size_bytes < 1024 * 1024:
+        size_kb = size_bytes / 1024
+        return "{:.1f} KB".format(size_kb)
+    else:
+        size_mb = size_bytes / (1024 * 1024)
+        return "{:.1f} MB".format(size_mb)

--- a/nofos/uploads/views.py
+++ b/nofos/uploads/views.py
@@ -1,11 +1,13 @@
-from django.views.generic import TemplateView
-from django.contrib.auth.mixins import UserPassesTestMixin
+import re
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import SSOTokenLoadError, TokenRetrievalError
 from django.conf import settings
 from django.contrib import messages
-from botocore.exceptions import SSOTokenLoadError, TokenRetrievalError
-from botocore.client import Config
-import boto3
-import re
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.views.generic import TemplateView
+
 from .utils import get_display_size
 
 

--- a/nofos/uploads/views.py
+++ b/nofos/uploads/views.py
@@ -6,6 +6,7 @@ from botocore.exceptions import TokenRetrievalError
 from botocore.client import Config
 import boto3
 import re
+from .utils import get_display_size
 
 
 class ImageListView(UserPassesTestMixin, TemplateView):
@@ -47,11 +48,14 @@ class ImageListView(UserPassesTestMixin, TemplateView):
                         {
                             "key": key,
                             "url": url,
-                            "size_kb": round(obj["Size"] / 1024, 1),
+                            "size_display": get_display_size(obj["Size"]),
                             "last_modified": obj["LastModified"],
                             "etag": obj["ETag"].strip('"'),
                         }
                     )
+
+                # Sort by last modified, descending. More recent image is first.
+                images.sort(key=lambda img: img["last_modified"], reverse=True)
 
                 context["images"] = images
 

--- a/nofos/uploads/views.py
+++ b/nofos/uploads/views.py
@@ -2,7 +2,7 @@ from django.views.generic import TemplateView
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.conf import settings
 from django.contrib import messages
-from botocore.exceptions import TokenRetrievalError
+from botocore.exceptions import SSOTokenLoadError, TokenRetrievalError
 from botocore.client import Config
 import boto3
 import re
@@ -64,6 +64,12 @@ class ImageListView(UserPassesTestMixin, TemplateView):
             messages.error(
                 self.request,
                 "Your AWS SSO token has expired. Please run <code>aws sso login</code> in your terminal to refresh it.",
+            )
+
+        except SSOTokenLoadError:
+            messages.error(
+                self.request,
+                "No AWS SSO token found. Please run <code>aws sso login</code> in your terminal to authenticate.",
             )
 
         return context

--- a/nofos/uploads/views.py
+++ b/nofos/uploads/views.py
@@ -1,6 +1,8 @@
 from django.views.generic import TemplateView
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.conf import settings
+from django.contrib import messages
+from botocore.exceptions import TokenRetrievalError
 import boto3
 import re
 
@@ -13,18 +15,27 @@ class ImageListView(UserPassesTestMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
-        s3 = boto3.client("s3")
         bucket_name = settings.AWS_STORAGE_BUCKET_NAME
-
-        response = s3.list_objects_v2(Bucket=bucket_name)
-        images = []
-
-        for obj in response.get("Contents", []):
-            key = obj["Key"]
-            if re.search(r"\.(jpe?g|png)$", key, re.IGNORECASE):
-                images.append(key)
-
-        context["images"] = images
+        context["images"] = []
         context["AWS_STORAGE_BUCKET_NAME"] = bucket_name
+
+        try:
+            s3 = boto3.client("s3")
+            response = s3.list_objects_v2(Bucket=bucket_name)
+
+            images = []
+            for obj in response.get("Contents", []):
+                key = obj["Key"]
+                if re.search(r"\.(jpe?g|png)$", key, re.IGNORECASE):
+                    images.append(key)
+
+            context["images"] = images
+
+        except TokenRetrievalError as e:
+            # Handle SSO token expiration gracefully
+            messages.error(
+                self.request,
+                "Your AWS SSO token has expired. Please run <code>aws sso login</code> in your terminal to refresh it.",
+            )
+
         return context

--- a/nofos/uploads/views.py
+++ b/nofos/uploads/views.py
@@ -74,4 +74,10 @@ class ImageListView(UserPassesTestMixin, TemplateView):
                 "No AWS SSO token found. Please run <code>aws sso login</code> in your terminal to authenticate.",
             )
 
+        except Exception as e:
+            messages.error(
+                self.request,
+                f"An error occurred while accessing the AWS bucket: {e}",
+            )
+
         return context

--- a/nofos/uploads/views.py
+++ b/nofos/uploads/views.py
@@ -1,0 +1,30 @@
+from django.views.generic import TemplateView
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.conf import settings
+import boto3
+import re
+
+
+class ImageListView(UserPassesTestMixin, TemplateView):
+    template_name = "uploads/images.html"
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        s3 = boto3.client("s3")
+        bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+
+        response = s3.list_objects_v2(Bucket=bucket_name)
+        images = []
+
+        for obj in response.get("Contents", []):
+            key = obj["Key"]
+            if re.search(r"\.(jpe?g|png)$", key, re.IGNORECASE):
+                images.append(key)
+
+        context["images"] = images
+        context["AWS_STORAGE_BUCKET_NAME"] = bucket_name
+        return context


### PR DESCRIPTION
## Summary

This PR creates a new "uploads" app which lists images uploaded to our S3 bucket(s). It is only viewable by superusers and doesn't do anything right now other than list images that have been uploaded via the AWS console. 

## Details

This PR is setting us up for a near-future scenario where we want to allow users to upload their own cover images for NOFOs. 

Regular users shouldn't have access to this route, but superusers should be able to see uploaded images and which NOFOs they belong to. Maybe we want to introduce a "media library" at some point to let people pick from existing images, but for now that is off the table.

At this point, this route doesn't really do anything, instead it's meant to set the foundations for continuing with this story (eg, establishing that we can connect to the S3 bucket and retrieve images that are in there).

### Screenshots

| images loaded | no AWS bucket in env | not logged in |
|--------|-------|-------|
|  If everything is set up, you can see a list of images in a table     |  If you don't have an AWS bucket configured in your env, you get this     |  If you are not logged in, you get this message |
|    <img width="2904" height="4580" alt="localhost_8000_uploads_images_" src="https://github.com/user-attachments/assets/89792aa0-9882-4d17-8c9f-1df0a04015c1" />    |   <img width="1579" height="962" alt="Screenshot 2025-07-17 at 17 56 40" src="https://github.com/user-attachments/assets/42ccb16a-a111-4cc3-a08a-f9b37c55f757" />    | <img width="1579" height="962" alt="Screenshot 2025-07-17 at 18 21 47" src="https://github.com/user-attachments/assets/9ca15be0-ed28-4ae5-aefe-8e23fc4ba372" />   |




To see this route, you need to be a superuser, otherwise you get a permissions error.

### How to test this

As a prerequisite, you need to have access to our AWS environment.  Once you have that, everything else should work.

1. Log in on the cli with `aws sso login`. You will get bumped into the browser and you can complete the sign in there.
2. Make sure you have these variables in your `.env` file: `AWS_STORAGE_BUCKET_NAME`
3. `poetry run python manage.py runserver`
4. Visit `http://localhost:8000/uploads/images/`
5. You should see a table with a list of images _or_ an error message of some sort.

If you can see the images, that's it! 

### Next steps

I think the next step after this would be to get the images for the cover page to actually load from the S3 bucket in the HTML view of the NOFO _and_ be printable from Docraptor. Once that is working, we can move existing images into the S3 bucket and then we can build out a user upload feature.