### PR TITLE
Find + Replace function can now be used to replace href strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Find and replace functions can replace hrefs if formatted as links
 - Replace multiple icons in a table cell, should it come to that
 
 ### Fixed

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -25,7 +25,8 @@ from .utils import (
     clean_string,
     create_subsection_html_id,
     extract_highlighted_context,
-    replace_text_not_markdown_links,
+    replace_text_exclude_markdown_links,
+    replace_text_include_markdown_links,
     strip_markdown_links,
     style_map_manager,
 )
@@ -2664,9 +2665,16 @@ def replace_value_in_subsections(
 
         # Update body
         if subsection.body:
-            new_body = replace_text_not_markdown_links(
-                subsection.body, old_value, new_value
-            )
+            # Strip links unless "old value" starts with "http" or "#"
+            if old_value.lower().startswith(("http", "#")):
+                new_body = replace_text_include_markdown_links(
+                    subsection.body, old_value, new_value
+                )
+            else:
+                new_body = replace_text_exclude_markdown_links(
+                    subsection.body, old_value, new_value
+                )
+
             if new_body != subsection.body:
                 subsection.body = new_body
                 updated = True

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -2585,7 +2585,12 @@ def find_matches_with_context(nofo, find_text, include_name=False):
             name_highlight = None
 
             # --- Match body ---
-            cleaned_body = strip_markdown_links(subsection.body or "")
+            # Strip links unless search term starts with "http" or "#"
+            if find_text.lower().startswith(("http", "#")):
+                cleaned_body = subsection.body or ""
+            else:
+                cleaned_body = strip_markdown_links(subsection.body or "")
+
             if cleaned_body and pattern.search(cleaned_body):
                 body_snippets = extract_highlighted_context(cleaned_body, pattern)
                 body_highlight = "".join(f"<div>{s}</div>" for s in body_snippets)

--- a/nofos/nofos/tests_nofos/test_side_navigation.py
+++ b/nofos/nofos/tests_nofos/test_side_navigation.py
@@ -1,7 +1,7 @@
-from django.contrib.auth import get_user_model
-from django.test import TestCase, Client
-from django.urls import reverse
 from bs4 import BeautifulSoup
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
 from users.models import BloomUser
 
 from nofos.models import Nofo, Section, Subsection

--- a/nofos/nofos/tests_nofos/test_utils.py
+++ b/nofos/nofos/tests_nofos/test_utils.py
@@ -17,7 +17,8 @@ from nofos.utils import (
     extract_highlighted_context,
     get_icon_path_choices,
     match_view_url,
-    replace_text_not_markdown_links,
+    replace_text_exclude_markdown_links,
+    replace_text_include_markdown_links,
     strip_markdown_links,
 )
 
@@ -227,22 +228,77 @@ class ExtractHighlightedContextTests(TestCase):
         self.assertIn('<mark class="bg-yellow">Match</mark>', result[0])
 
 
-class ReplaceOutsideMarkdownLinksTests(TestCase):
+class ReplaceIncludeMarkdownLinksTests(TestCase):
+    def test_simple_replacement(self):
+        text = "The application deadline is June 1, 2025."
+        result = replace_text_include_markdown_links(
+            text, "June 1, 2025", "August 1, 2025"
+        )
+        self.assertEqual(result, "The application deadline is August 1, 2025.")
+
+    def test_replacement_inside_markdown_link_text(self):
+        text = "Visit [the deadline](https://grants.gov/deadline) for info."
+        result = replace_text_include_markdown_links(text, "deadline", "date")
+        self.assertEqual(result, "Visit [the date](https://grants.gov/date) for info.")
+
+    def test_replacement_inside_url(self):
+        text = "Check out [this link](https://example.com/deadline-info)"
+        result = replace_text_include_markdown_links(text, "deadline", "date")
+        self.assertEqual(result, "Check out [this link](https://example.com/date-info)")
+
+    def test_case_insensitive_replacement(self):
+        text = "Apply before the DEADLINE. Visit [Deadline Info](https://example.com/DEADLINE)."
+        result = replace_text_include_markdown_links(text, "deadline", "date")
+        expected = "Apply before the date. Visit [date Info](https://example.com/date)."
+        self.assertEqual(result, expected)
+
+    def test_multiple_occurrences(self):
+        text = (
+            "Apply by the deadline. See [the deadline](https://example.com/deadline) "
+            "and [deadline info](#section-deadline)."
+        )
+        result = replace_text_include_markdown_links(text, "deadline", "date")
+        expected = (
+            "Apply by the date. See [the date](https://example.com/date) "
+            "and [date info](#section-date)."
+        )
+        self.assertEqual(result, expected)
+
+    def test_no_links(self):
+        text = "The deadline is approaching."
+        result = replace_text_include_markdown_links(text, "deadline", "date")
+        self.assertEqual(result, "The date is approaching.")
+
+    def test_empty_input(self):
+        self.assertEqual(replace_text_include_markdown_links("", "foo", "bar"), "")
+        self.assertIsNone(replace_text_include_markdown_links(None, "foo", "bar"))
+
+    def test_special_characters_in_link(self):
+        text = "Click [this (weird) deadline](https://example.com/deadline-stuff)"
+        result = replace_text_include_markdown_links(text, "deadline", "date")
+        self.assertEqual(
+            result, "Click [this (weird) date](https://example.com/date-stuff)"
+        )
+
+
+class ReplaceExcludeMarkdownLinksTests(TestCase):
     def test_simple_replacement_outside_link(self):
         text = "The application deadline is June 1, 2025."
-        result = replace_text_not_markdown_links(text, "June 1, 2025", "August 1, 2025")
+        result = replace_text_exclude_markdown_links(
+            text, "June 1, 2025", "August 1, 2025"
+        )
         self.assertEqual(result, "The application deadline is August 1, 2025.")
 
     def test_replacement_inside_markdown_text_only(self):
         text = "Visit [the deadline](https://grants.gov/deadline) for info."
-        result = replace_text_not_markdown_links(text, "deadline", "date")
+        result = replace_text_exclude_markdown_links(text, "deadline", "date")
         self.assertEqual(
             result, "Visit [the date](https://grants.gov/deadline) for info."
         )
 
     def test_no_change_inside_url(self):
         text = "Check out [this link](https://example.com/deadline-info)"
-        result = replace_text_not_markdown_links(text, "deadline", "date")
+        result = replace_text_exclude_markdown_links(text, "deadline", "date")
         self.assertEqual(
             result, "Check out [this link](https://example.com/deadline-info)"
         )
@@ -252,7 +308,7 @@ class ReplaceOutsideMarkdownLinksTests(TestCase):
             "Apply by the deadline. See [the deadline](https://example.com/deadline) "
             "and [deadline info](#section-deadline)."
         )
-        result = replace_text_not_markdown_links(text, "deadline", "date")
+        result = replace_text_exclude_markdown_links(text, "deadline", "date")
         expected = (
             "Apply by the date. See [the date](https://example.com/deadline) "
             "and [date info](#section-deadline)."
@@ -261,7 +317,7 @@ class ReplaceOutsideMarkdownLinksTests(TestCase):
 
     def test_case_insensitive(self):
         text = "Apply before the DEADLINE. Visit [Deadline Info](https://example.com/deadline)."
-        result = replace_text_not_markdown_links(text, "deadline", "date")
+        result = replace_text_exclude_markdown_links(text, "deadline", "date")
         expected = (
             "Apply before the date. Visit [date Info](https://example.com/deadline)."
         )
@@ -269,16 +325,16 @@ class ReplaceOutsideMarkdownLinksTests(TestCase):
 
     def test_no_links(self):
         text = "The deadline is approaching."
-        result = replace_text_not_markdown_links(text, "deadline", "date")
+        result = replace_text_exclude_markdown_links(text, "deadline", "date")
         self.assertEqual(result, "The date is approaching.")
 
     def test_empty_input(self):
-        self.assertEqual(replace_text_not_markdown_links("", "foo", "bar"), "")
-        self.assertEqual(replace_text_not_markdown_links(None, "foo", "bar"), None)
+        self.assertEqual(replace_text_exclude_markdown_links("", "foo", "bar"), "")
+        self.assertEqual(replace_text_exclude_markdown_links(None, "foo", "bar"), None)
 
     def test_link_with_special_chars(self):
         text = "Click [this (weird) deadline](https://example.com/deadline-stuff)"
-        result = replace_text_not_markdown_links(text, "deadline", "date")
+        result = replace_text_exclude_markdown_links(text, "deadline", "date")
         self.assertEqual(
             result, "Click [this (weird) date](https://example.com/deadline-stuff)"
         )

--- a/nofos/nofos/utils.py
+++ b/nofos/nofos/utils.py
@@ -124,7 +124,15 @@ def extract_highlighted_context(body, pattern, context_chars=100, group_distance
     return results
 
 
-def replace_text_not_markdown_links(text, old_value, new_value):
+def replace_text_include_markdown_links(text, old_value, new_value):
+    if not text:
+        return text
+
+    pattern = re.compile(re.escape(old_value), re.IGNORECASE)
+    return pattern.sub(new_value, text)
+
+
+def replace_text_exclude_markdown_links(text, old_value, new_value):
     if not text:
         return text
 


### PR DESCRIPTION
## Summary

This PR updates our "Find and Replace" function so that it _can_ find URLs if your search term starts with a `#` or the string `http`. 

## Details 

Previously, I excluded hrefs from the "Find and Replace" function with the supposition that it would be unintentional if people were replacing hrefs when they really wanted to just replace a word somewhere.

However, when people are explicitly looking for links (for example, if you have a NOFO with 10-15 broken links that all go to the same place) that you want to bulk update, this code turned out to be a nuisance. So the new rule is that if a search term starts with a `#` (for anchor links) or `http` (for external links), then we _will_ just look for everything in the text without excluding links. 

Tested it locally and it works just fine.

## Screenshots

| before | after |
|--------|-------|
| Only finds links that are in `<a>` tags, no markdown link text identified       |   Finds all instances of this internal link    |
|    <img width="2904" height="3022" alt="localhost_8000_nofos_d7ba79cb-f404-4111-a2ed-2fa32006d16a_find-replace (1)" src="https://github.com/user-attachments/assets/a2db6c67-3276-4d04-b895-5c5613cf2212" />    |    <img width="2904" height="6550" alt="localhost_8000_nofos_d7ba79cb-f404-4111-a2ed-2fa32006d16a_find-replace" src="https://github.com/user-attachments/assets/a6673e7f-7a0c-4207-bad6-20af78399e82" />   |

