### PR TITLE
Implement cover image upload and removal functionality

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1502,3 +1502,43 @@ del + ins > br {
     top: 0;
   }
 }
+
+
+/* Image aspect ratio utilities */
+.cover-image {
+  width: 100%;
+  object-fit: cover;
+  object-position: left;
+}
+
+.usa-button.usa-button--icon {
+  margin: 0 !important;
+}
+
+.usa-button--icon {
+  margin: 0;
+  /* min-width: 5rem; */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.usa-button--icon::before {
+  content: "";
+  background-repeat: no-repeat;
+  background-position: center left;
+  background-size: cover;
+  display: inline-flex;
+  height: 18px;
+  width: 18px;
+  filter: invert(100%) sepia(0%) saturate(2%) hue-rotate(331deg)
+    brightness(102%) contrast(101%);
+}
+
+.usa-button--icon.usa-button--file-upload::before {
+  background-image: url("/static/img/usa-icons/file_upload.svg");
+}
+
+.usa-button--icon.usa-button--delete::before {
+  background-image: url("/static/img/usa-icons/delete.svg");
+}

--- a/nofos/bloom_nofos/templates/includes/file_input.html
+++ b/nofos/bloom_nofos/templates/includes/file_input.html
@@ -19,5 +19,6 @@
     name="{{ id }}"
     aria-describedby="{% if hint %}{{ id }}--hint{% endif %}{% if error %} {{ id }}--error{% endif %}"
     accept="{% if accept %}{{ accept }}{% else %}.docx{% endif %}"
+    {% if required %}required{% endif %}
   />
 </div>

--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -160,18 +160,6 @@ class NofoCoverImageForm(forms.ModelForm):
         model = Nofo
         fields = ["cover_image", "cover_image_alt_text"]
 
-    def __init__(self, *args, **kwargs):
-        super(NofoCoverImageForm, self).__init__(*args, **kwargs)
-
-        # Disable the 'cover_image' field so it cannot be modified
-        self.fields["cover_image"].disabled = True
-        self.fields["cover_image"].widget.attrs[
-            "is_disabled"
-        ] = "disabled"  # Custom attribute to use in the template
-
-        # Make 'cover_image_alt_text' optional
-        self.fields["cover_image_alt_text"].required = False
-
 
 # this one needs a custom field and a custom widget so don't use the factory function
 class NofoMetadataForm(forms.ModelForm):

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -883,7 +883,9 @@ def upload_cover_image_to_s3(nofo, uploaded_file, alt_text=""):
         )
 
     # Rename file to have NOFO name
-    uploaded_file.name = f"{nofo.number}{file_extension}".lower()
+    uploaded_file.name = (
+        f"{nofo.number or nofo.title.replace(' ', '-')}{file_extension}".lower()
+    )
 
     # Upload file to S3
     s3_key = upload_file_to_s3(uploaded_file, key_prefix="img/cover-img")

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -10,7 +10,7 @@ Edit “{{ nofo|nofo_name }}”
 {% block body_class %}nofo_edit nofo_status--{{ nofo.status }}{% if nofo.modifications %} nofo--modifications{% endif %}{% if nofo.archived %} nofo--archived{% endif %}{% endblock %}
 
 {% block content %}
-{% include "includes/alerts.html" with messages=messages success_heading="NOFO saved successfully" error_heading="Error" stick_to_bottom=True only %}
+{% include "includes/alerts.html" with messages=messages success_heading=success_heading error_heading=error_heading stick_to_bottom=True only %}
 
 <!-- WARNING MESSAGE FOR ARCHIVED/SUCCESSOR NOFOS -->
 {% if nofo.archived %}
@@ -441,12 +441,6 @@ Edit “{{ nofo|nofo_name }}”
       <th scope="row">Cover style</th>
       <td>{{ nofo.get_cover_display|get_value_or_none:"Standard image" }}</td>
     </tr>
-    {% if nofo.cover_image and nofo.cover != 'nofo--cover-page--text' %}
-      <tr>
-        <th scope="row">Cover alt text</th>
-        <td>{% if nofo.cover_image_alt_text %}“{% endif%}{{ nofo.cover_image_alt_text|get_value_or_none:"alt text" }}{% if nofo.cover_image_alt_text %}”{% endif %}</td>
-      </tr>
-    {% endif %}
     <tr>
       <th scope="row">Icon style</th>
       <td>{{ nofo.get_icon_style_display|get_value_or_none:"Outlined" }}</td>
@@ -478,10 +472,12 @@ Edit “{{ nofo|nofo_name }}”
       <th scope="row">Cover image</th>
       <td>{{ nofo.cover_image|get_value_or_none:"cover image" }}</td>
     </tr>
+    {% if nofo.cover_image %}
     <tr>
       <th scope="row">Cover alt text</th>
       <td>{{ nofo.cover_image_alt_text|get_value_or_none:"cover alt text" }}</td>
     </tr>
+    {% endif %}
   </tbody>
 </table>
 

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -10,7 +10,7 @@ Edit “{{ nofo|nofo_name }}”
 {% block body_class %}nofo_edit nofo_status--{{ nofo.status }}{% if nofo.modifications %} nofo--modifications{% endif %}{% if nofo.archived %} nofo--archived{% endif %}{% endblock %}
 
 {% block content %}
-{% include "includes/alerts.html" with messages=messages success_heading="NOFO saved successfully" error_heading="Subsection deleted" stick_to_bottom=True only %}
+{% include "includes/alerts.html" with messages=messages success_heading="NOFO saved successfully" error_heading="Error" stick_to_bottom=True only %}
 
 <!-- WARNING MESSAGE FOR ARCHIVED/SUCCESSOR NOFOS -->
 {% if nofo.archived %}
@@ -450,6 +450,37 @@ Edit “{{ nofo|nofo_name }}”
     <tr>
       <th scope="row">Icon style</th>
       <td>{{ nofo.get_icon_style_display|get_value_or_none:"Outlined" }}</td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="usa-table usa-table--borderless width-full table--hide-edit-if-archived">
+  <caption>
+    <div>
+      <h2 class="margin-bottom-0">NOFO cover image</h2>
+      <span class="padding-right-2 font-sans-sm">
+        {% if nofo.cover_image %}
+          <a href="{% url 'nofos:nofo_edit_cover_image' nofo.id %}">Edit<span class="usa-sr-only">: NOFO cover image</span></a>
+        {% else %}
+          <a href="{% url 'nofos:nofo_upload_cover_image' nofo.id %}">Edit<span class="usa-sr-only">: NOFO cover image</span></a>
+        {% endif %}
+      </span>
+    </div>
+  </caption>
+  <thead class="usa-sr-only">
+    <tr>
+      <th scope="col">Key</th>
+      <th scope="col">Value</th>
+    </tr>
+  </thead>
+  <tbody class="no-edit-link">
+    <tr>
+      <th scope="row">Cover image</th>
+      <td>{{ nofo.cover_image|get_value_or_none:"cover image" }}</td>
+    </tr>
+    <tr>
+      <th scope="row">Cover alt text</th>
+      <td>{{ nofo.cover_image_alt_text|get_value_or_none:"cover alt text" }}</td>
     </tr>
   </tbody>
 </table>

--- a/nofos/nofos/templates/nofos/nofo_edit_cover_image.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_cover_image.html
@@ -31,14 +31,14 @@ Edit NOFO cover image for "{{ nofo|nofo_name }}"
     <div class="grid-col-12 tablet:grid-col-auto margin-top-1">
       <a class="usa-button usa-button--icon usa-button--file-upload usa-button--cyan" type="button"
         href="{% url 'nofos:nofo_upload_cover_image' nofo.id %}">
-        <span class="margin-left-2">Replace Cover Image</span>
+        <span class="margin-left-2">Replace cover image</span>
       </a>
     </div>
 
     <div class="grid-col-12 tablet:grid-col-auto margin-top-1">
       <a class="usa-button usa-button--icon usa-button--delete usa-button--secondary" type="button" data-open-modal
         aria-controls="delete-cover-image-modal">
-        <span class="margin-left-2">Remove Cover Image</span>
+        <span class="margin-left-2">Remove cover image</span>
       </a>
     </div>
 
@@ -59,7 +59,7 @@ Edit NOFO cover image for "{{ nofo|nofo_name }}"
       <div class="grid-col-12 margin-top-2">
         <button class="usa-button usa-tooltip" type="submit" data-position="bottom"
           title="Save alternate cover image text">
-          Save Alt Text
+          Save alternate text
         </button>
       </div>
     </div>

--- a/nofos/nofos/templates/nofos/nofo_edit_cover_image.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_cover_image.html
@@ -2,38 +2,102 @@
 {% load static nofo_name %}
 
 {% block title %}
-  NOFO cover image alt text
+Edit NOFO cover image for "{{ nofo|nofo_name }}"
 {% endblock %}
 
 {% block content %}
-  {% with nofo|nofo_name as nofo_name_str %}
-  {% with "Back to  “"|add:nofo_name_str|add:"”" as back_text %}
-    {% url 'nofos:nofo_edit' nofo.id as back_href %}
-    {% include "includes/page_heading.html" with title="NOFO cover image alt text" back_text=back_text back_href=back_href only %}
-  {% endwith %}
-  {% endwith %}
 
-  <p>You can’t change the image, but you can add alternate text.</p>
-  <p>Good alt text concisely describes the image’s content, providing context and meaning for users who can’t see it.</p>
+{% with nofo|nofo_name as nofo_name_str %}
+{% with "Back to "|add:nofo_name_str|add:"" as back_text %}
+{% url 'nofos:nofo_edit' nofo.id as back_href %}
+{% include "includes/page_heading.html" with title="Edit NOFO cover image for "|add:nofo_name_str|add:"" back_text=back_text back_href=back_href only %}
+{% endwith %}
+{% endwith %}
 
-  <details>
-    <summary><span>Expand to see cover image</span></summary>
-    <div class="margin-top-1 width-tablet-lg">
-      {% spaceless%}
-        {% if nofo_cover_image|slice:":4" == "img/" %}
-          <img class="border-05 radius-md" alt="{{ nofo.cover_image_alt_text }}" title="{{nofo.cover_image_alt_text}}" src="{% static nofo_cover_image %}">
-        {% else %}
-          <img class="border-05 radius-md" alt="{{ nofo.cover_image_alt_text }}" title="{{nofo.cover_image_alt_text}}" src="{{ nofo_cover_image }}">
-        {% endif %}
-      {% endspaceless %}
+<div class="">
+  <div class="grid-row margin-top-3">
+    <div class="grid-col-12 tablet:grid-col-8">
+      {% if nofo_cover_image|slice:":4" == "img/" %}
+      <img class="border-05 radius-md cover-image" alt="{{ nofo.cover_image_alt_text }}"
+        title="{{nofo.cover_image_alt_text}}" src="{% static nofo_cover_image %}" />
+      {% else %}
+      <img class="border-05 radius-md cover-image" alt="{{ nofo.cover_image_alt_text }}"
+        title="{{nofo.cover_image_alt_text}}" src="{{ nofo_cover_image }}" />
+      {% endif %}
     </div>
-  </details>
+  </div>
+
+  <div class="grid-row grid-gap">
+    <div class="grid-col-12 tablet:grid-col-auto margin-top-1">
+      <a class="usa-button usa-button--icon usa-button--file-upload usa-button--cyan" type="button"
+        href="{% url 'nofos:nofo_upload_cover_image' nofo.id %}">
+        <span class="margin-left-2">Replace Cover Image</span>
+      </a>
+    </div>
+
+    <div class="grid-col-12 tablet:grid-col-auto margin-top-1">
+      <a class="usa-button usa-button--icon usa-button--delete usa-button--secondary" type="button" data-open-modal
+        aria-controls="delete-cover-image-modal">
+        <span class="margin-left-2">Remove Cover Image</span>
+      </a>
+    </div>
+
+    <div class="grid-col-fill">
+    </div>
+  </div>
 
   <form id="nofo-cover-image--form" method="post">
     {% csrf_token %}
-
-    {% include "includes/form_macro.html" %}
-
-    <button class="usa-button margin-top-3" type="submit">Save cover image alt text</button>
+    <div class="grid-row">
+      <div class="grid-col-12">
+        {% with id="cover_image_alt_text" label="Enter a short description of the image for screen readers." hint="(Optional) This will be used as the alt text for the image. Good alt text concisely describes the image's content, providing context and meaning for users who can't see it." value=nofo.cover_image_alt_text %}
+        {% include "includes/_text_input.html" with id=id label=label hint=hint value=value only %}
+        {% endwith %}
+      </div>
+    </div>
+    <div class="grid-row">
+      <div class="grid-col-12 margin-top-2">
+        <button class="usa-button usa-tooltip" type="submit" data-position="bottom"
+          title="Save alternate cover image text">
+          Save Alt Text
+        </button>
+      </div>
+    </div>
   </form>
+</div>
+
+
+<!-- Delete Cover Image Confirmation Modal -->
+<div class="usa-modal" id="delete-cover-image-modal" aria-labelledby="delete-cover-image-modal-heading"
+  aria-describedby="delete-cover-image-modal-description">
+  <div class="usa-modal__content">
+    <div class="usa-modal__main">
+      <h2 class="usa-modal__heading" id="delete-cover-image-modal-heading">
+        Remove cover image?
+      </h2>
+      <div class="usa-prose">
+        <p id="delete-cover-image-modal-description">
+          Are you sure you want to remove the cover image for this NOFO? This action cannot be undone.
+        </p>
+      </div>
+      <div class="usa-modal__footer">
+        <ul class="usa-button-group">
+          <li class="usa-button-group__item">
+            <form action="{% url 'nofos:nofo_delete_cover_image' nofo.id %}" method="post" style="display: inline;">
+              {% csrf_token %}
+              <button type="submit" class="usa-button usa-button--secondary">
+                Yes, remove image
+              </button>
+            </form>
+          </li>
+          <li class="usa-button-group__item">
+            <button type="button" class="usa-button usa-button--unstyled padding-105 text-center" data-close-modal>
+              Cancel
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/nofos/nofos/templates/nofos/nofo_upload_cover_image.html
+++ b/nofos/nofos/templates/nofos/nofo_upload_cover_image.html
@@ -24,7 +24,7 @@
 
 <form id="nofo-upload-cover-image--form" class="form-import--loading" method="post" enctype="multipart/form-data">
   {% csrf_token %}
-  {% with id="cover_image" label="Select an image file." hint="Accepts .jpg, .jpeg or .png files." accept=".png,.jpg,.jpeg" %}
+  {% with id="cover_image" label="Select an image file." hint="Accepts .jpg or .png files." accept=".png,.jpg,.jpeg" %}
     {% for message in messages %}
       {% if "error" in message.tags %}
         {% include "includes/file_input.html" with id=id label=label hint=hint accept=accept error=message required=True only %}

--- a/nofos/nofos/templates/nofos/nofo_upload_cover_image.html
+++ b/nofos/nofos/templates/nofos/nofo_upload_cover_image.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% load static nofo_name %}
+
+{% block title %}
+  Upload a cover image for "{{ nofo|nofo_name }}"
+{% endblock %}
+
+{% block body_class %}nofo_import{% endblock %}
+
+{% block content %}
+
+{% with nofo|nofo_name as nofo_name_str %}
+{% with "Back to "|add:nofo_name_str|add:"" as back_text %}
+  {% url 'nofos:nofo_edit' nofo.id as back_href %}
+  {% include "includes/page_heading.html" with title="Upload a cover image for "|add:nofo_name_str|add:"" back_text=back_text back_href=back_href only %}
+{% endwith %}
+{% endwith %}
+
+<form id="nofo-upload-cover-image--form" class="form-import--loading" method="post" enctype="multipart/form-data">
+  {% csrf_token %}
+  {% with id="cover_image" label="Select an image file. We recommend the images of at least 1000px by 1500px (2:3 aspect ratio)." hint="Accepts .jpg or .png files." accept=".png,.jpg" %}
+    {% for message in messages %}
+      {% if "error" in message.tags %}
+        {% include "includes/file_input.html" with id=id label=label hint=hint accept=accept error=message required=True only %}
+      {% endif %}
+    {% empty %}
+      {% include "includes/file_input.html" with id=id label=label hint=hint accept=accept required=True only %}
+    {% endfor %}
+  {% endwith %}
+  {% include "includes/loading_horse.html" %}
+
+  {% with id="cover_image_alt_text" label="Enter a short description of the image for screen readers." hint="(Optional) This will be used as the alt text for the image. Good alt text concisely describes the image’s content, providing context and meaning for users who can’t see it." value=nofo.cover_image_alt_text %}
+    {% include "includes/_text_input.html" with id=id label=label hint=hint value=value only %}
+  {% endwith %}
+
+
+  <button class="usa-button margin-top-3 submit-button" type="submit">Upload</button>
+</form>
+{% endblock %}

--- a/nofos/nofos/templates/nofos/nofo_upload_cover_image.html
+++ b/nofos/nofos/templates/nofos/nofo_upload_cover_image.html
@@ -16,9 +16,15 @@
 {% endwith %}
 {% endwith %}
 
+<p>
+  <strong>
+    For best results, upload an image that is at least 1000 by 1500 pixels (2:3 aspect ratio) and no larger than 5MB.
+  </strong>
+</p>
+
 <form id="nofo-upload-cover-image--form" class="form-import--loading" method="post" enctype="multipart/form-data">
   {% csrf_token %}
-  {% with id="cover_image" label="Select an image file. We recommend the images of at least 1000px by 1500px (2:3 aspect ratio)." hint="Accepts .jpg or .png files." accept=".png,.jpg" %}
+  {% with id="cover_image" label="Select an image file." hint="Accepts .jpg, .jpeg or .png files." accept=".png,.jpg,.jpeg" %}
     {% for message in messages %}
       {% if "error" in message.tags %}
         {% include "includes/file_input.html" with id=id label=label hint=hint accept=accept error=message required=True only %}

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -1863,7 +1863,10 @@ class NofoCoverImageTests(TestCase):
 class UploadCoverImageToS3Tests(TestCase):
     def setUp(self):
         self.nofo = Nofo.objects.create(
-            title="Test NOFO Title", short_name="TEST-001", number="TEST-001", opdiv="Test Agency"
+            title="Test NOFO Title",
+            short_name="TEST-001",
+            number="TEST-001",
+            opdiv="Test Agency",
         )
 
         # Create valid test file
@@ -1903,9 +1906,7 @@ class UploadCoverImageToS3Tests(TestCase):
 
         mock_upload_to_s3.return_value = "img/cover-img/test-001.jpg"
 
-        result = upload_cover_image_to_s3(
-            self.nofo, self.valid_jpg_file, ""
-        )
+        result = upload_cover_image_to_s3(self.nofo, self.valid_jpg_file, "")
 
         self.assertTrue(result)
 

--- a/nofos/nofos/urls.py
+++ b/nofos/nofos/urls.py
@@ -116,6 +116,16 @@ urlpatterns = [
         name="nofo_edit_cover_image",
     ),
     path(
+        "<uuid:pk>/upload/cover-image",
+        views.NofoUploadCoverImageView.as_view(),
+        name="nofo_upload_cover_image",
+    ),
+    path(
+        "<uuid:pk>/delete/cover-image",
+        views.NofoDeleteCoverImageView.as_view(),
+        name="nofo_delete_cover_image",
+    ),
+    path(
         "<uuid:pk>/edit/status",
         views.NofoEditStatusView.as_view(),
         name="nofo_edit_status",

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1125,7 +1125,9 @@ class NofoUploadCoverImageView(BaseNofoEditView):
             messages.error(request, f"Failed to upload cover image: {e.message}")
             return self.get(request, *args, **kwargs)
         except Exception as e:
-            messages.error(request, f"Failed to upload cover image. Contact an administrator.")
+            messages.error(
+                request, f"Failed to upload cover image. Contact an administrator."
+            )
             return self.get(request, *args, **kwargs)
 
 

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -22,6 +22,7 @@
           <th scope="col">Filename</th>
           <th scope="col">Size</th>
           <th scope="col">Last modified</th>
+          <th scope="col">Used by NOFOs</th>
           <th scope="col">Image</th>
         </tr>
       </thead>
@@ -33,6 +34,25 @@
             {{ image.size_display }}
           </td>
           <td>{{ image.last_modified|date:"Y-m-d" }}</td>
+          <td>
+            {% if image.used_by_nofos %}
+              <ul class="usa-list usa-list--unstyled">
+                {% for nofo in image.used_by_nofos %}
+                  <li>
+                    <a href="{% url 'nofos:nofo_edit' pk=nofo.id %}" class="usa-link">
+                      {% if nofo.short_name %}
+                        {{ nofo.short_name }}
+                      {% else %}
+                        {{ nofo.title|default:"Untitled NOFO" }}
+                      {% endif %}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% else %}
+              <span class="text-base-light">Not used</span>
+            {% endif %}
+          </td>
           <td>
             <img class="border-2px radius-md maxh-card" src="{{ image.url }}" alt="{{ image.key }}" loading="lazy" />
           </td>

--- a/nofos/uploads/templates/uploads/images.html
+++ b/nofos/uploads/templates/uploads/images.html
@@ -36,19 +36,45 @@
           <td>{{ image.last_modified|date:"Y-m-d" }}</td>
           <td>
             {% if image.used_by_nofos %}
-              <ul class="usa-list usa-list--unstyled">
-                {% for nofo in image.used_by_nofos %}
-                  <li>
-                    <a href="{% url 'nofos:nofo_edit' pk=nofo.id %}" class="usa-link">
-                      {% if nofo.short_name %}
-                        {{ nofo.short_name }}
-                      {% else %}
-                        {{ nofo.title|default:"Untitled NOFO" }}
-                      {% endif %}
-                    </a>
-                  </li>
-                {% endfor %}
-              </ul>
+              {% if image.used_by_nofos|length == 1 %}
+                {% with nofo=image.used_by_nofos|first %}
+                  <a href="{% url 'nofos:nofo_edit' pk=nofo.id %}" class="usa-link">
+                    {% if nofo.short_name %}
+                      {{ nofo.short_name }}
+                    {% else %}
+                      {{ nofo.title|default:"Untitled NOFO" }}
+                    {% endif %}
+                  </a>
+                {% endwith %}
+              {% else %}
+                <div class="usa-accordion">
+                  <h4 class="usa-accordion__heading">
+                    <button
+                      class="usa-accordion__button"
+                      aria-expanded="false"
+                      aria-controls="accordion-content-{{ forloop.counter }}"
+                      type="button"
+                    >
+                      Used by {{ image.used_by_nofos|length }} NOFOs
+                    </button>
+                  </h4>
+                  <div id="accordion-content-{{ forloop.counter }}" class="usa-accordion__content usa-prose">
+                    <ul class="usa-list">
+                      {% for nofo in image.used_by_nofos %}
+                        <li>
+                          <a href="{% url 'nofos:nofo_edit' pk=nofo.id %}" class="usa-link">
+                            {% if nofo.short_name %}
+                              {{ nofo.short_name }}
+                            {% else %}
+                              {{ nofo.title|default:"Untitled NOFO" }}
+                            {% endif %}
+                          </a>
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  </div>
+                </div>
+              {% endif %}
             {% else %}
               <span class="text-base-light">Not used</span>
             {% endif %}

--- a/nofos/uploads/views.py
+++ b/nofos/uploads/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
 from django.views.generic import TemplateView
 
+from nofos.models import Nofo
 from .utils import get_display_size
 
 
@@ -19,9 +20,44 @@ class ImageListView(UserPassesTestMixin, TemplateView):
     def test_func(self):
         return self.request.user.is_superuser
 
+    def get_nofos_using_images(self, image_keys):
+        """
+        Returns a dictionary mapping image keys to lists of NOFOs that use them.
+
+        Args:
+            image_keys: List of S3 image keys to check
+
+        Returns:
+            dict: {image_key: [list of NOFO objects], ...}
+        """
+        if not image_keys:
+            return {}
+
+        # Query NOFOs that have cover_image matching any of our S3 keys
+        nofos_using_images = (
+            Nofo.objects.filter(
+                cover_image__in=image_keys,
+                archived__isnull=True,  # Exclude archived NOFOs
+            )
+            .select_related()
+            .only(
+                "id", "title", "short_name", "number", "opdiv", "status", "cover_image"
+            )
+        )
+
+        # Create mapping of image key to list of NOFOs
+        key_to_nofos = {}
+        for nofo in nofos_using_images:
+            key = nofo.cover_image
+            if key not in key_to_nofos:
+                key_to_nofos[key] = []
+            key_to_nofos[key].append(nofo)
+
+        return key_to_nofos
+
     def get(self, request, *args, **kwargs):
         if request.GET.get("cache") == "false":
-            cache.delete("uploads_images")
+            cache.delete("uploads_images_basic")
             messages.success(request, "Image cache has been cleared.")
 
         return super().get(request, *args, **kwargs)
@@ -40,9 +76,17 @@ class ImageListView(UserPassesTestMixin, TemplateView):
             )
             return context
 
-        # Try to get cached images
-        cached_images = cache.get("uploads_images")
+        # Try to get cached basic image data (without NOFO usage info)
+        cached_images = cache.get("uploads_images_basic")
         if cached_images:
+            # We have cached S3 image data, now add fresh NOFO usage information
+            image_keys = [img["key"] for img in cached_images]
+            key_to_nofos = self.get_nofos_using_images(image_keys)
+
+            # Add NOFO usage information to each cached image
+            for image in cached_images:
+                image["used_by_nofos"] = key_to_nofos.get(image["key"], [])
+
             context["images"] = cached_images
             return context
 
@@ -50,10 +94,13 @@ class ImageListView(UserPassesTestMixin, TemplateView):
             s3 = boto3.client("s3", config=Config(signature_version="s3v4"))
             response = s3.list_objects_v2(Bucket=bucket_name)
             images = []
+            image_keys = []
 
+            # First pass: collect image data and keys
             for obj in response.get("Contents", []):
                 key = obj["Key"]
                 if re.search(r"\.(jpe?g|png)$", key, re.IGNORECASE):
+                    image_keys.append(key)
 
                     url = s3.generate_presigned_url(
                         "get_object",
@@ -73,6 +120,13 @@ class ImageListView(UserPassesTestMixin, TemplateView):
 
             # Sort by last modified, descending. More recent image is first.
             images.sort(key=lambda img: img["last_modified"], reverse=True)
+
+            # Get NOFO usage information for all images
+            key_to_nofos = self.get_nofos_using_images(image_keys)
+
+            # Add NOFO usage information to each image
+            for image in images:
+                image["used_by_nofos"] = key_to_nofos.get(image["key"], [])
 
             context["images"] = images
 


### PR DESCRIPTION
# Cover Image Upload and Management System

## Summary

This PR implements a comprehensive cover image upload and management system for NOFO (Notice of Funding Opportunity) documents. Users can now upload, replace, and remove cover images directly through the web interface, with all images stored securely in AWS S3.


## 📝 Related Issues
- https://github.com/HHS/simpler-grants-pdf-builder/issues/93


## ✨ Key Features

### 1. **Cover Image Upload**
- Secure file upload to AWS S3 with proper validation
- Support for PNG, JPG, and JPEG formats
- 5MB file size limit to ensure optimal performance
- Automatic file renaming based on NOFO short name
- Alt text support 

### 2. **Cover Image Removal**
- One-click removal with confirmation modal
- Automatic cleanup from S3 storage
- Graceful fallback to default cover image

### 3. **Enhanced User Interface**
- Intuitive upload form with file selection and preview
- Modal confirmation dialogs for destructive actions
- Clear success/error messaging
- Responsive design following USWDS standards

### 4. **Robust Error Handling**
- Comprehensive AWS authentication error handling
- File validation with user-friendly error messages
- Graceful degradation when S3 is unavailable
- Proper logging for debugging and monitoring

## 🏗️ Technical Implementation

### Backend Changes

#### **New Views (`views.py`)**
- `NofoUploadCoverImageView`: Handles file upload and S3 integration
- `NofoDeleteCoverImageView`: Manages cover image removal

#### **Business Logic (`nofo.py`)**
- `upload_cover_image_to_s3()`: Complete upload workflow with validation
- `remove_cover_image_from_s3()`: Safe removal with error handling
- Enhanced file validation (size, type, extension)

#### **S3 Utilities (`s3/utils.py`)**
- `upload_file_to_s3()`: Generic S3 upload with metadata
- `remove_file_from_s3()`: Safe S3 object deletion
- Improved error handling for AWS authentication issues

#### **URL Routing (`urls.py`)**
- `/upload/cover-image`: Cover image upload endpoint
- `/delete/cover-image`: Cover image removal endpoint

### Frontend Changes

#### **Templates**
- **`nofo_upload_cover_image.html`**: New dedicated upload page
- **`nofo_edit_cover_image.html`**: Enhanced with upload/remove functionality
- **`nofo_edit.html`**: Updated navigation and image display
- **`file_input.html`**: Improved file input component - added `required` based on input boolean, defaults to not required

## 🧪 Testing

### **Comprehensive Test Coverage**
- `s3/tests.py` covering all S3 operations
- `test_nofo.py` for business logic validation in updated views
- Error condition testing for AWS authentication failures
- File validation testing for various scenarios
- End-to-end workflow testing

## 🚀 Deployment Notes

### **Prerequisites**
- AWS S3 bucket configured via `GENERAL_S3_BUCKET_URL`
- Proper IAM permissions for S3 operations
- AWS SSO authentication configured

### **Environment Variables**
- Ensure `GENERAL_S3_BUCKET_URL` is properly configured
- Verify AWS credentials are available for the application

### **Database**
- No migrations required (uses existing `cover_image` and `cover_image_alt_text` fields)