### PR TITLE
Bump version to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+## [3.6.0] - 2025-08-05
+
+### Changed
+
+- Huge rewrite of HTML diffing engine
+- Content Guide Compare page now supports a side-by-side diff or consolidated diff
+- Content Guide import now defaults all "comparison_type" fields to "body"
+
+### Migrations
+
+- Add migration for setting all "comparison_type" fields to "body" on import
+
 ## [3.5.0] - 2025-08-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nofos"
-version = "3.5.0"
+version = "3.6.0"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Very small PR to bumping the version number since the latest PR includes a migration, as is customary.

Updated CHANGELOG and bumped version to 3.6.0.
