### PR TITLE
Change site header to say "NOFO Boilerplate Compare" for /guides URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Change site header to say "NOFO Boilerplate Compare" for "/guides" urls
+- Completely redo Content Guide edit page
+  - Add checkboxes to select/deselect which subsections to compare
+
 ### Fixed
 
 ## [3.6.0] - 2025-08-05

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -102,10 +102,15 @@ footer .usa-footer__primary-link:visited {
   background-color: #444782;
 }
 
-/* Make sure header is evenly spaced */
 @media (min-width: 64em) {
+  /* Make sure header is evenly spaced */
   .usa-logo {
     margin-top: 1rem;
+  }
+
+  /* Boilerplate Compare should be on 1 line */
+  .usa-header--basic .usa-navbar {
+    width: 42%;
   }
 }
 

--- a/nofos/bloom_nofos/templates/base.html
+++ b/nofos/bloom_nofos/templates/base.html
@@ -16,16 +16,22 @@
       <div class="usa-navbar">
         <div class="usa-logo">
           <em class="usa-logo__text">
-            <a href="{% url 'index' %}">NOFO Builder</a>
+            {% if '/guides/' not in request.path %}
+              <a href="{% url 'index' %}">NOFO Builder</a>
+            {% else %}
+              <a href="{% url 'guides:guide_index' %}">NOFO Boilerplate Compare</a>
+            {% endif %}         
           </em>
-          {% if user.is_authenticated %}
-            <a class="inline-block usa-tag--link" href="{% url 'test_mode' %}{% if request.path|slice:"-5:" == "/edit" %}?next={{ request.path }}{% endif %}">
-              {% if DOCRAPTOR_LIVE_MODE %}
-                <span class="usa-tag bg-green">Live</span>
-              {% else %}
-                <span class="usa-tag bg-accent-cool-dark">Test</span>
-              {% endif %}
-            </a>
+          {% if '/guides/' not in request.path %}
+            {% if user.is_authenticated %}
+              <a class="inline-block usa-tag--link" href="{% url 'test_mode' %}{% if request.path|slice:"-5:" == "/edit" %}?next={{ request.path }}{% endif %}">
+                {% if DOCRAPTOR_LIVE_MODE %}
+                  <span class="usa-tag bg-green">Live</span>
+                {% else %}
+                  <span class="usa-tag bg-accent-cool-dark">Test</span>
+                {% endif %}
+              </a>
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/nofos/bloom_nofos/templates/base.html
+++ b/nofos/bloom_nofos/templates/base.html
@@ -49,7 +49,11 @@
           {% endif %}
           {% if user.is_authenticated %}
             <li class="usa-nav__primary-item">
-              <a href="{% url 'nofos:nofo_index' %}" class="usa-nav-link" {% if request.resolver_match.url_name == 'nofo_index' %}aria-current="page"{% endif %}>All NOFOs</a>
+              {% if '/guides/' not in request.path %}
+                <a href="{% url 'nofos:nofo_index' %}" class="usa-nav-link" {% if request.resolver_match.url_name == 'nofo_index' %}aria-current="page"{% endif %}>All NOFOs</a>
+              {% else %}
+                <a href="{% url 'guides:guide_index' %}" class="usa-nav-link" {% if request.resolver_match.url_name == 'guide_index' %}aria-current="page"{% endif %}>All content guides</a>
+              {% endif %}
             </li>
           {% endif %}
           <li class="usa-nav__primary-item">


### PR DESCRIPTION
## Summary

This PR is mercifully very small. It changes the header of the site to say "NOFO Boilerplate Compare", and the "All NOFOs" link to say "All content guides" which is in line with what the Figma mocks want.

### Details

There is a fairly crude bit of logic here such that we string match on "/guides". Could it potentially match an unintended URL in the future? Potentially. Could this be more elegant by using blocks a bit more? Maybe. Is it fine for user testing? For sure. It is easy and effective.

With this logic, any path that includes the string "/guides" has a new header that says "NOFO Boilerplate Compare", and also does not show the "LIVE"/"TEST" button.

### Screenshots

Before and after views. Note that our site header is not really mobile (top links disappear) but that's fine.

| before | after |
|--------|-------|
|   Original site header says "NOFO Builder" and includes "TEST" button     |  New site header says "NOFO Boilerplate Compare".     |
|   <img width="1343" height="948" alt="Screenshot 2025-08-05 at 19 06 09" src="https://github.com/user-attachments/assets/46856551-094c-4faa-aae9-77c4cdf909da" />     |   <img width="1343" height="948" alt="Screenshot 2025-08-05 at 19 06 33" src="https://github.com/user-attachments/assets/46c7de24-699b-4a9d-9dc5-6b00a12ea533" />    |
|   <img width="612" height="573" alt="Screenshot 2025-08-05 at 19 06 13" src="https://github.com/user-attachments/assets/acab382b-0333-42d4-9344-dc48cc518282" />     |   <img width="612" height="573" alt="Screenshot 2025-08-05 at 19 06 41" src="https://github.com/user-attachments/assets/c0649193-5d18-471a-a20e-1744049ea24f" />    |


