### PR TITLE
Add export CSV function to compare UI 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Export a CSV list of changes from the Content Guide compare page
+
 ### Changed
 
 - Change site header to say "NOFO Boilerplate Compare" for "/guides" urls

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1603,6 +1603,11 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   background-color: white;
 }
 
+.nofo_view--menu-bar--file-download-button--container {
+  align-self: center;
+  margin-left: auto;
+}
+
 .nofo_compare .nofo_view--menu-bar--button {
   display: flex;
   flex-direction: column;
@@ -1912,8 +1917,27 @@ del + ins > br {
     brightness(102%) contrast(101%);
 }
 
+.usa-button--icon.usa-button--outline::before {
+  filter: brightness(0) saturate(100%) invert(19%) sepia(62%) saturate(3740%)
+    hue-rotate(190deg) brightness(93%) contrast(102%);
+}
+
+.usa-button--icon.usa-button--outline:hover::before {
+  filter: brightness(0) saturate(100%) invert(19%) sepia(94%) saturate(993%)
+    hue-rotate(192deg) brightness(94%) contrast(94%);
+}
+
+.usa-button--icon.usa-button--outline:active::before {
+  filter: brightness(0) saturate(100%) invert(15%) sepia(33%) saturate(1347%)
+    hue-rotate(179deg) brightness(94%) contrast(96%);
+}
+
 .usa-button--icon.usa-button--file-upload::before {
   background-image: url("/static/img/usa-icons/file_upload.svg");
+}
+
+.usa-button--icon.usa-button--file-download::before {
+  background-image: url("/static/img/usa-icons/file_download.svg");
 }
 
 .usa-button--icon.usa-button--delete::before {

--- a/nofos/guides/templates/guides/guide_compare.html
+++ b/nofos/guides/templates/guides/guide_compare.html
@@ -84,7 +84,7 @@
           <div class="nofo_view--menu-bar--file-download-button--container">
             <a class="usa-button usa-button--outline usa-button--icon usa-button--file-download" type="button"
               href="{% url 'guides:guide_compare_result_csv' pk=guide.pk new_nofo_id=new_nofo.pk %}">
-              <span class="margin-left-2">Export differences as CSV</span>
+              <span class="margin-left-2">Export spreadsheet of differences</span>
             </a>
           </div>
         {% endif %}

--- a/nofos/guides/templates/guides/guide_compare.html
+++ b/nofos/guides/templates/guides/guide_compare.html
@@ -73,12 +73,21 @@
           </a>
         {% endwith %}
         <div class="nofo_view--vertical-divider"></div>
-        <button class="nofo_view--menu-bar--button nofo_view--menu-bar--button__expand_less" {% if not comparison %}aria-disabled="true"{% endif %}>
+        <button class="nofo_view--menu-bar--button nofo_view--menu-bar--button__expand_less" {% if not comparison %}aria-disabled="true"{% endif %} type="button">
           Previous section
         </button>
-        <button class="nofo_view--menu-bar--button nofo_view--menu-bar--button__expand_more" {% if not comparison %}aria-disabled="true"{% endif %}>
+        <button class="nofo_view--menu-bar--button nofo_view--menu-bar--button__expand_more" {% if not comparison %}aria-disabled="true"{% endif %} type="button">
           Next section
         </button>
+
+        {% if comparison %}
+          <div class="nofo_view--menu-bar--file-download-button--container">
+            <a class="usa-button usa-button--outline usa-button--icon usa-button--file-download" type="button"
+              href="{% url 'guides:guide_compare_result_csv' pk=guide.pk new_nofo_id=new_nofo.pk %}">
+              <span class="margin-left-2">Export differences as CSV</span>
+            </a>
+          </div>
+        {% endif %}
       </div>
       <div class="nofo_view--title-bar">
         {% if display_mode == 'double' %}

--- a/nofos/guides/test_views.py
+++ b/nofos/guides/test_views.py
@@ -498,6 +498,14 @@ class ContentGuideSubsectionEditViewTests(TestCase):
 
 class ContentGuideDiffCSVViewTests(TestCase):
     def setUp(self):
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            force_password_reset=False,
+            group="bloom",
+        )
+        self.client.login(email="test@example.com", password="testpass123")
+
         self.guide = ContentGuide.objects.create(
             title="Older", group="bloom", opdiv="CDC"
         )

--- a/nofos/guides/urls.py
+++ b/nofos/guides/urls.py
@@ -43,7 +43,12 @@ urlpatterns = [
         name="guide_compare_result",
     ),
     path(
-        "guides/<uuid:pk>/section/<uuid:section_pk>/subsection/<uuid:subsection_pk>/edit",
+        "<uuid:pk>/compare/<uuid:new_nofo_id>/csv/",
+        views.ContentGuideDiffCSVView.as_view(),
+        name="guide_compare_result_csv",
+    ),
+    path(
+        "<uuid:pk>/section/<uuid:section_pk>/subsection/<uuid:subsection_pk>/edit",
         views.ContentGuideSubsectionEditView.as_view(),
         name="subsection_edit",
     ),

--- a/nofos/guides/views.py
+++ b/nofos/guides/views.py
@@ -252,7 +252,9 @@ class ContentGuideSubsectionEditView(GroupAccessObjectMixin, UpdateView):
         return reverse_lazy("guides:guide_edit", kwargs={"pk": self.kwargs["pk"]})
 
 
-class ContentGuideCompareUploadView(BaseNofoImportView):
+class ContentGuideCompareUploadView(
+    GroupAccessObjectMixin, LoginRequiredMixin, BaseNofoImportView
+):
     template_name = "guides/guide_import_compare.html"
     redirect_url_name = "guides:guide_compare_upload"
 
@@ -300,7 +302,7 @@ class ContentGuideCompareUploadView(BaseNofoImportView):
             return HttpResponseBadRequest(f"Error comparing NOFO: {str(e)}")
 
 
-class ContentGuideCompareView(View):
+class ContentGuideCompareView(GroupAccessObjectMixin, LoginRequiredMixin, View):
     def get(self, request, pk, new_nofo_id=None):
         guide = get_object_or_404(ContentGuide, pk=pk)
 
@@ -337,7 +339,7 @@ class ContentGuideCompareView(View):
         return render(request, "guides/guide_compare.html", context)
 
 
-class ContentGuideDiffCSVView(View):
+class ContentGuideDiffCSVView(GroupAccessObjectMixin, LoginRequiredMixin, View):
     def get(self, request, pk, new_nofo_id):
         guide = get_object_or_404(ContentGuide, pk=pk)
         new_nofo = get_object_or_404(Nofo, pk=new_nofo_id)

--- a/nofos/nofos/tests_nofos/test_compare.py
+++ b/nofos/nofos/tests_nofos/test_compare.py
@@ -34,8 +34,9 @@ class MergeRenamedSubsectionsTests(TestCase):
         result = merge_renamed_subsections(input_data)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].status, "UPDATE")
-        self.assertIn("<ins>Overview</ins>", result[0].name)
-        self.assertIn("<del>Summary</del>", result[0].name)
+        self.assertEqual("<del>Summary</del><ins>Overview</ins>", result[0].name)
+        self.assertEqual("Summary", result[0].old_name)
+        self.assertEqual("Overview", result[0].new_name)
         self.assertEqual(result[0].diff, "<p>This is some content.</p>")
 
     def test_renamed_title_and_changed_body(self):
@@ -55,6 +56,8 @@ class MergeRenamedSubsectionsTests(TestCase):
         ]
         result = merge_renamed_subsections(input_data)
         self.assertEqual(len(result), 2)
+        self.assertEqual("Summary", result[0].name)
+        self.assertEqual("Overview", result[1].name)
         self.assertEqual(result[0].status, "ADD")
         self.assertEqual(result[1].status, "DELETE")
 
@@ -75,6 +78,8 @@ class MergeRenamedSubsectionsTests(TestCase):
         ]
         result = merge_renamed_subsections(input_data)
         self.assertEqual(len(result), 2)
+        self.assertEqual("Eligibility", result[0].name)
+        self.assertEqual("Overview", result[1].name)
         self.assertEqual(result[0].status, "ADD")
         self.assertEqual(result[1].status, "DELETE")
 
@@ -96,7 +101,9 @@ class MergeRenamedSubsectionsTests(TestCase):
         result = merge_renamed_subsections(input_data)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].status, "UPDATE")
-        self.assertIn("<ins> b</ins>", result[0].name)
+        self.assertEqual("a<ins> b</ins>", result[0].name)
+        self.assertEqual("a", result[0].old_name)
+        self.assertEqual("a b", result[0].new_name)
         self.assertEqual(result[0].diff, "<p>Groundhog<ins> Day</ins></p>")
 
 

--- a/nofos/nofos/tests_nofos/test_compare.py
+++ b/nofos/nofos/tests_nofos/test_compare.py
@@ -601,6 +601,8 @@ class TestCompareNofos(TestCase):
         subsection_match = subsections[0]
         self.assertEqual(subsection_match.status, "MATCH")
         self.assertEqual(subsection_match.name, "Budget Requirements")
+        self.assertEqual(subsection_match.old_name, "Budget Requirements")
+        self.assertEqual(subsection_match.new_name, "Budget Requirements")
         self.assertEqual(subsection_match.old_value, "Budget must not exceed $100K.")
         self.assertEqual(subsection_match.new_value, "Budget must not exceed $100K.")
 
@@ -621,6 +623,8 @@ class TestCompareNofos(TestCase):
         subsection_update_2 = subsections[2]
         self.assertEqual(subsection_update_2.status, "UPDATE")
         self.assertEqual(subsection_update_2.name, "Application Process")
+        self.assertEqual(subsection_update_2.old_name, "Application Process")
+        self.assertEqual(subsection_update_2.new_name, "Application Process")
         self.assertEqual(subsection_update_2.old_value, "Submit before Jan 1.")
         self.assertEqual(subsection_update_2.new_value, "Submit before Feb 1.")
         self.assertIn(
@@ -631,6 +635,8 @@ class TestCompareNofos(TestCase):
         subsection_add = subsections[3]
         self.assertEqual(subsection_add.status, "ADD")
         self.assertEqual(subsection_add.name, "New NOFO Funding Guidelines")
+        self.assertEqual(subsection_add.old_name, "")
+        self.assertEqual(subsection_add.new_name, "New NOFO Funding Guidelines")
         self.assertEqual(subsection_add.old_value, "")
         self.assertEqual(subsection_add.new_value, "Follow these new rules.")
 
@@ -638,6 +644,8 @@ class TestCompareNofos(TestCase):
         subsection_match_2 = subsections[4]
         self.assertEqual(subsection_match_2.status, "MATCH")
         self.assertEqual(subsection_match_2.name, "Permitting rules")
+        self.assertEqual(subsection_match_2.old_name, "Permitting rules")
+        self.assertEqual(subsection_match_2.new_name, "Permitting rules")
         self.assertEqual(
             subsection_match_2.old_value, "Of course permits must be obtained."
         )
@@ -649,6 +657,8 @@ class TestCompareNofos(TestCase):
         subsection_delete = subsections[5]
         self.assertEqual(subsection_delete.status, "DELETE")
         self.assertEqual(subsection_delete.name, "<del>Old NOFO Fee Requirements</del>")
+        self.assertEqual(subsection_delete.old_name, "Old NOFO Fee Requirements")
+        self.assertEqual(subsection_delete.new_name, "")
         self.assertEqual(subsection_delete.old_value, "Processing fee is $50.")
         self.assertEqual(subsection_delete.new_value, "")
         self.assertIn(
@@ -659,6 +669,8 @@ class TestCompareNofos(TestCase):
         subsection_merge = subsections[6]
         self.assertEqual(subsection_merge.status, "UPDATE")
         self.assertEqual(subsection_merge.name, "<ins>Visit </ins>SAM.gov")
+        self.assertEqual(subsection_merge.old_name, "SAM.gov")
+        self.assertEqual(subsection_merge.new_name, "Visit SAM.gov")
         self.assertEqual(subsection_merge.old_value, "Visit the website to sign up.")
         self.assertEqual(
             subsection_merge.new_value, "This is the website where you can sign up."


### PR DESCRIPTION
## Summary

This PR adds a button to export your differences as a CSV. It also adds the backend view to do the export, so that we can build the CSV. Makes sense to do them both together like this. 

## Details

The CSV you can get after doing your comparison will change format depending on the exact comparison that you have. If there are no merged sections, then we will give you a CSV with these headings:

- `Status, Subsection name, Old value, New value`

However, if there are merged sections, then the subsection name has changed, so we need to include an extra column to show you that.

- `Status, Subsection name, Old value, New subsection name, New value`

So here is an example of each:

| 4-column CSV | 5-column CSV |
|--------|-------|
|  [compare-4-column.csv](https://github.com/user-attachments/files/21621120/content_guide_diff_4e94136d-1b81-4c97-bfe5-11f3af5b5ec6_169cc1bc-3e7b-4fd2-9630-a90b24c3715e.1.csv)      |    [compare-5-column.csv](https://github.com/user-attachments/files/21621154/content_guide_diff_51a74eee-0770-40e6-96bd-40aabf53ccd4_a28019e5-969e-428e-b995-aca2d1f2f490.csv)   |

I think it's about as good as we can expect for now, although I don't really think anyone will like this feature. I strongly suspect they will want a Word document at the end of this, but we can't do that.

### Screenshot

Button has been added to the menu button row in the compare interface, right-aligned.

<img width="1223" height="478" alt="Screenshot 2025-08-06 at 10 27 48" src="https://github.com/user-attachments/assets/76b3a2af-2fe8-4d87-8a4d-ac24539aa34d" />
 
