### PR TITLE
Table Width Checkbox and NOFO Status dropdown

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1919,3 +1919,7 @@ del + ins > br {
 .usa-button--icon.usa-button--delete::before {
   background-image: url("/static/img/usa-icons/delete.svg");
 }
+
+.usa-summary-box .usa-checkbox {
+  background: transparent;
+}

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -58,144 +58,254 @@ Edit “{{ nofo|nofo_name }}”
   </span>
 </div>
 
-{% if nofo.status == 'cancelled' %}
+<!-- Consolidated NOFO Status and Actions Summary Box -->
 <div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
   <div class="usa-summary-box__body">
-    <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
-      NOFO is ‘<a href="{% url 'nofos:nofo_edit_status' nofo.id %}">{{ nofo.get_status_display }}</a>’.
-    </h2>
-    <div class="usa-summary-box__text">
-      <p>Cancelled NOFOs exist as a record for posterity but can’t be edited in any way. If you would like to restore this NOFO, <a href="{% url 'nofos:nofo_edit_status' nofo.id %}">change its status</a> to something else.</p>
-    </div>
-  </div>
-</div>
-{% elif nofo.archived %}
-<div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
-  <div class="usa-summary-box__body">
-    <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
-      NOFO is ‘Archived’.
-    </h2>
-    <div class="usa-summary-box__text">
-      <p>Archived NOFOs exist as a record for posterity but can’t be edited in any way. If you would like to restore this NOFO, please get in touch with Paul or Adam.</p>
-      {% if nofo.successor %}
-        <p>This is a past version of <a href="{% url 'nofos:nofo_edit' nofo.successor.id %}">{{ nofo.successor }}</a></p>
+    <h4 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
+      <!-- Status Dropdown Form -->
+      {% if not nofo.archived %}
+        <form id="nofo-status--form" method="post" action="{% url 'nofos:nofo_edit_status' nofo.id %}">
+          {% csrf_token %}
+          <div class="usa-form-group margin-bottom-3 margin-top-0">
+              <label class="usa-label display-inline-block font-sans-md margin-top-0" for="{{ status_form.status.name }}"><strong>Status:</strong></label>
+
+            <select
+              class="usa-select border-2px width-auto display-inline-block margin-top-0"
+              name="{{ status_form.status.name }}"
+              id="{{ status_form.status.name }}"
+              onchange="this.form.submit()"
+            >
+              {% for value, label in status_form.status.field.choices %}
+                {% if value == '' %}
+                  <option disabled>{{ label }}</option>
+                {% else %}
+                  <option value="{{ value }}" {% if status_form.status.value == value %}selected{% endif %}>
+                    {{ label }}
+                  </option>
+                {% endif %}
+              {% endfor %}
+            </select>
+          </div>
+        </form>
+      {% else %}
+          NOFO is ‘Archived’.
       {% endif %}
-    </div>
-  </div>
-</div>
-{% elif nofo.status == 'published' and nofo.modifications %}
-<div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
-  <div class="usa-summary-box__body">
-    <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
-      NOFO is ‘<a href="{% url 'nofos:nofo_edit_status' nofo.id %}">{{ nofo.get_status_display }}</a>’ with modifications.
-    </h2>
+    </h4>
+
     <div class="usa-summary-box__text">
-      <p>Make sure to update the “<a href="#modifications">Modifications</a>” section at the end of this NOFO with the changes you’ve made since publication.</p>
-      <p><a href="{% url 'nofos:nofo_history_modifications' nofo.id %}">See changes made since this NOFO was modified</a>.</p>
-      <p>Last modification date on cover page: <a href="{% url 'nofos:nofo_modifications' nofo.id %}">{{ nofo.modifications|date:"F j, Y" }}</a>.</p>
-    </div>
-  </div>
-</div>
-{% elif nofo.status == 'published' %}
-<div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
-  <div class="usa-summary-box__body">
-    <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
-      NOFO is ‘<a href="{% url 'nofos:nofo_edit_status' nofo.id %}">{{ nofo.get_status_display }}</a>’.
-    </h2>
-    <div class="usa-summary-box__text">
-      <p>Ordinarily, published NOFOs can’t be edited, re-imported, or deleted. To edit this NOFO, you can <a href="{% url 'nofos:nofo_edit_status' nofo.id %}">change its
-        status</a>.</p>
+
+      <!-- Status-specific messages and actions -->
+      {% if nofo.archived %}
+        <!-- ARCHIVED NOFO -->
+        <p>Archived NOFOs exist as a record for posterity but can't be edited in any way. If you would like to restore this NOFO, please get in touch with Paul or Adam.</p>
+        {% if nofo.successor %}
+          <p>This is a past version of <a href="{% url 'nofos:nofo_edit' nofo.successor.id %}">{{ nofo.successor }}</a></p>
+        {% endif %}
+
+      {% elif nofo.status == 'cancelled' %}
+        <!-- CANCELLED NOFO -->
+        <p>Cancelled NOFOs exist as a record for posterity but can't be edited in any way. If you would like to restore this NOFO, change its status to something else using the dropdown above.</p>
+
+      {% elif nofo.status == 'published' and nofo.modifications %}
+        <!-- PUBLISHED WITH MODIFICATIONS -->
+        <p><strong>This NOFO is published with modifications.</strong></p>
+        <p>Make sure to update the "<a href="#modifications">Modifications</a>" section at the end of this NOFO with the changes you've made since publication.</p>
+        <p><a href="{% url 'nofos:nofo_history_modifications' nofo.id %}">See changes made since this NOFO was modified</a>.</p>
+        <p>Last modification date on cover page: <a href="{% url 'nofos:nofo_modifications' nofo.id %}">{{ nofo.modifications|date:"F j, Y" }}</a>.</p>
+
+      {% elif nofo.status == 'published' %}
+        <!-- PUBLISHED (NO MODIFICATIONS) -->
+        <p>Ordinarily, published NOFOs can't be edited, re-imported, or deleted. To edit this NOFO, you can change its status using the dropdown above.</p>
         <p class="margin-top-3">However, you can <strong>add modifications</strong> to a NOFO that has already been published.</p>
         <form id="nofo-modifications--form" method="post" action="{% url 'nofos:nofo_modifications' nofo.id %}">
           {% csrf_token %}
           <input type="hidden" name="modifications" value="{% now 'Y-m-d' %}" />
           <p>
           <button class="usa-button usa-button--accent-warm" type="submit">Add modifications</button>
-           — Adds a message to the cover page and a “Modifications” section to the end of the NOFO.
+           — Adds a message to the cover page and a "Modifications" section to the end of the NOFO.
           </p>
         </form>
+
+      {% elif nofo.status == 'review' %}
+        <!-- IN REVIEW -->
+        <p>NOFOs that are in review can't be re-imported or deleted, but they can be edited as needed.</p>
+
+        <div class="margin-top-3">
+          <ul class="usa-list usa-list--unstyled">
+            <li>
+              <p>
+                <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
+                — search and replace text across the entire NOFO
+              </p>
+            </li>
+            {% if page_breaks_count > 3 %}
+            <li>
+              <p>
+                <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
+              </p>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+
+      {% elif nofo.status == 'paused' %}
+        <!-- PAUSED -->
+        <p>NOFOs that are paused can't be re-imported or deleted, but they can be edited as needed.</p>
+
+        <div class="margin-top-3">
+          <ul class="usa-list usa-list--unstyled">
+            <li>
+              <p>
+                <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
+                — search and replace text across the entire NOFO
+              </p>
+            </li>
+            {% if page_breaks_count > 3 %}
+            <li>
+              <p>
+                <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
+              </p>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+
+      {% elif nofo.status == 'doge' %}
+        <!-- DEP SEC (DOGE) -->
+        <p>NOFOs that are in DOGE review can't be re-imported or deleted, but they can be edited as needed.</p>
+
+        <div class="margin-top-3">
+          <ul class="usa-list usa-list--unstyled">
+            <li>
+              <p>
+                <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
+                — search and replace text across the entire NOFO
+              </p>
+            </li>
+            {% if page_breaks_count > 3 %}
+            <li>
+              <p>
+                <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
+              </p>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+
+      {% elif nofo.status == 'ready-for-qa' %}
+        <!-- READY FOR QA -->
+        <div class="margin-top-3">
+          <ul class="usa-list usa-list--unstyled">
+            <li>
+              <p>
+                <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' nofo.id %}">
+                  Check external links
+                </a>— There are {{ external_links|length }} external links in this NOFO
+              </p>
+            </li>
+            <li>
+              <p>
+                <a class="usa-button" href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">
+                  Re-import NOFO
+                </a>— upload an updated NOFO file
+              </p>
+            </li>
+            <li>
+              <p>
+                <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
+                — search and replace text across the entire NOFO
+              </p>
+            </li>
+            {% if page_breaks_count > 3 %}
+            <li>
+              <p>
+                <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
+              </p>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+
+      {% elif nofo.status == 'active' %}
+        <!-- ACTIVE -->
+        <div class="margin-top-3">
+          <ul class="usa-list usa-list--unstyled">
+            <li>
+              <p>
+                <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' nofo.id %}">
+                  Check external links
+                </a>— There are {{ external_links|length }} external links in this NOFO
+              </p>
+            </li>
+            <li>
+              <p>
+                <a class="usa-button" href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">
+                  Re-import NOFO
+                </a>— upload an updated NOFO file
+              </p>
+            </li>
+            <li>
+              <p>
+                <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
+                — search and replace text across the entire NOFO
+              </p>
+            </li>
+            {% if page_breaks_count > 3 %}
+            <li>
+              <p>
+                <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
+              </p>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+
+      {% elif nofo.status == 'draft' %}
+        <!-- DRAFT -->
+        <div class="margin-top-3">
+          <ul class="usa-list usa-list--unstyled">
+            <li>
+              <p>
+                <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' nofo.id %}">
+                  Check external links
+                </a>— There are {{ external_links|length }} external links in this NOFO
+              </p>
+            </li>
+            <li>
+              <p>
+                <a class="usa-button" href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">
+                  Re-import NOFO
+                </a>— upload an updated NOFO file
+              </p>
+            </li>
+            <li>
+              <p>
+                <a class="usa-button usa-button--secondary" href="{% url 'nofos:nofo_archive' nofo.id %}">
+                  Delete NOFO
+                </a>— remove this NOFO completely
+              </p>
+            </li>
+            <li>
+              <p>
+                <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
+                — search and replace text across the entire NOFO
+              </p>
+            </li>
+            {% if page_breaks_count > 3 %}
+            <li>
+              <p>
+                <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
+              </p>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+
+      {% endif %}
+
     </div>
   </div>
 </div>
-{% elif nofo.status == 'review' or nofo.status == 'paused' or nofo.status == 'doge' %}
-<div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
-  <div class="usa-summary-box__body">
-    <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
-      NOFO is ‘<a href="{% url 'nofos:nofo_edit_status' nofo.id %}">{{ nofo.get_status_display }}</a>’.
-    </h2>
-    <div class="usa-summary-box__text">
-    {% if nofo.status == 'doge' %}
-        <p>NOFOs that are in DOGE review can’t be re-imported or deleted, but they can be edited as needed.</p>
-    {% else %}
-        <p>NOFOs that are {{ nofo.get_status_display|lower }} can’t be re-imported or deleted, but they can be edited as needed.</p>
-    {% endif %}
-      <ul class="usa-list usa-list--unstyled">
-        <li>
-          <p>
-            <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
-            — search and replace text across the entire NOFO
-          </p>
-        </li>
-        {% if page_breaks_count > 3 %}
-        <li>
-          <p>
-            <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
-          </p>
-        </li>
-        {% endif %}
-      </ul>
-    </div>
-  </div>
-</div>
-{% else %}
-<div class="usa-summary-box" role="region" aria-labelledby="summary-box-key-information">
-  <div class="usa-summary-box__body">
-    <h2 class="usa-summary-box__heading font-heading-sm" id="summary-box-key-information">
-      NOFO is ‘<a href="{% url 'nofos:nofo_edit_status' nofo.id %}">{{ nofo.get_status_display }}</a>’.
-    </h2>
-    <div class="usa-summary-box__text">
-      <ul class="usa-list usa-list--unstyled">
-        <li>
-          <p>
-            <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' nofo.id %}">
-              Check external links
-            </a>— There are {{ external_links|length }} external links in this NOFO
-          </p>
-        </li>
-        <li>
-          <p>
-            <a class="usa-button" href="{% url 'nofos:nofo_import_overwrite' nofo.id %}">
-              Re-import NOFO
-            </a>— upload an updated NOFO file
-          </p>
-        </li>
-        {% if nofo.status == 'draft' %}
-        <li>
-          <p>
-            <a class="usa-button usa-button--secondary" href="{% url 'nofos:nofo_archive' nofo.id %}">
-              Delete NOFO
-            </a>— remove this NOFO completely
-          </p>
-        </li>
-        {% endif %}
-        <li>
-          <p>
-            <a class="usa-button usa-button--cyan" href="{% url 'nofos:nofo_find_replace' nofo.id %}">Find & Replace</a>
-            — search and replace text across the entire NOFO
-          </p>
-        </li>
-        {% if page_breaks_count > 3 %}
-        <li>
-          <p>
-            <a class="usa-button usa-button--indigo" href="{% url 'nofos:nofo_remove_page_breaks' nofo.id %}">Remove Page Breaks</a> — find and remove page breaks added since import
-          </p>
-        </li>
-        {% endif %}
-      </ul>
-    </div>
-  </div>
-</div>
-{% endif %}
 
 <!-- WARNING MESSAGE FOR BROKEN LINKS -->
 {% if broken_links|length %}

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -88,7 +88,7 @@ Edit “{{ nofo|nofo_name }}”
           </div>
         </form>
       {% else %}
-          NOFO is ‘Archived’.
+          NOFO is Archived.
       {% endif %}
     </h4>
 
@@ -104,7 +104,7 @@ Edit “{{ nofo|nofo_name }}”
 
       {% elif nofo.status == 'cancelled' %}
         <!-- CANCELLED NOFO -->
-        <p>Cancelled NOFOs exist as a record for posterity but can't be edited in any way. If you would like to restore this NOFO, change its status to something else using the dropdown above.</p>
+        <p>Cancelled NOFOs exist as a record for posterity but can't be edited in any way. If you would like to restore this NOFO, change its status to something else.</p>
 
       {% elif nofo.status == 'published' and nofo.modifications %}
         <!-- PUBLISHED WITH MODIFICATIONS -->
@@ -115,7 +115,7 @@ Edit “{{ nofo|nofo_name }}”
 
       {% elif nofo.status == 'published' %}
         <!-- PUBLISHED (NO MODIFICATIONS) -->
-        <p>Ordinarily, published NOFOs can't be edited, re-imported, or deleted. To edit this NOFO, you can change its status using the dropdown above.</p>
+        <p>Published NOFOs can't be edited, re-imported, or deleted. To edit this NOFO, you can change its status to something else.</p>
         <p class="margin-top-3">However, you can <strong>add modifications</strong> to a NOFO that has already been published.</p>
         <form id="nofo-modifications--form" method="post" action="{% url 'nofos:nofo_modifications' nofo.id %}">
           {% csrf_token %}
@@ -172,7 +172,7 @@ Edit “{{ nofo|nofo_name }}”
 
       {% elif nofo.status == 'doge' %}
         <!-- DEP SEC (DOGE) -->
-        <p>NOFOs that are in DOGE review can't be re-imported or deleted, but they can be edited as needed.</p>
+        <p>NOFOs that are in Deputy Secretary review can't be re-imported or deleted, but they can be edited as needed.</p>
 
         <div class="margin-top-3">
           <ul class="usa-list usa-list--unstyled">

--- a/nofos/nofos/templates/nofos/section_detail.html
+++ b/nofos/nofos/templates/nofos/section_detail.html
@@ -28,44 +28,34 @@
       Section options
     </h4>
     <div class="usa-summary-box__text">
-      <p class="margin-bottom-0">
-        <button type="button"
-                id="toggle-tables-btn"
-                class="usa-button {% if section.html_class and 'section--tables-full-width' in section.html_class %}usa-button--secondary{% else %}usa-button--cyan{% endif %}"
-                data-url="{% url 'nofos:section_toggle_tables' section.nofo.id section.id %}"
-                data-csrf-token="{{ csrf_token }}">
-          {% if section.html_class and 'section--tables-full-width' in section.html_class %}
-            Default Tables
-          {% else %}
-            Full-width Tables
-          {% endif %}
-        </button>
-        —
-        <span id="toggle-tables-description">
-          {% if section.html_class and 'section--tables-full-width' in section.html_class %}
-            Restore all tables to their default widths
-          {% else %}
-            Expand all tables in this section to full width
-          {% endif %}
-        </span>
-      </p>
+      <div class="usa-checkbox">
+        <input class="usa-checkbox__input"
+               id="toggle-tables-checkbox"
+               name="toggle-tables"
+               type="checkbox"
+               value="full-width"
+               data-url="{% url 'nofos:section_toggle_tables' section.nofo.id section.id %}"
+               data-csrf-token="{{ csrf_token }}"
+               {% if section.html_class and 'section--tables-full-width' in section.html_class %}checked{% endif %}>
+        <label class="usa-checkbox__label" for="toggle-tables-checkbox">
+          Use full-width tables for this section
+        </label>
+      </div>
     </div>
 
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        const toggleBtn = document.getElementById('toggle-tables-btn');
-        const toggleTablesDescription = document.getElementById('toggle-tables-description');
+        const toggleCheckbox = document.getElementById('toggle-tables-checkbox');
 
-        toggleBtn.addEventListener('click', function() {
-            // Disable button during request
-            toggleBtn.disabled = true;
-            const originalText = toggleBtn.textContent;
-            toggleBtn.textContent = 'Loading...';
+        toggleCheckbox.addEventListener('change', function() {
+            // Disable checkbox during request
+            toggleCheckbox.disabled = true;
+            const originalChecked = toggleCheckbox.checked;
 
-            fetch(toggleBtn.dataset.url, {
+            fetch(toggleCheckbox.dataset.url, {
                 method: 'POST',
                 headers: {
-                    'X-CSRFToken': toggleBtn.dataset.csrfToken,
+                    'X-CSRFToken': toggleCheckbox.dataset.csrfToken,
                     'Content-Type': 'application/json',
                 },
                 credentials: 'same-origin'
@@ -73,33 +63,31 @@
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    // Update button appearance
+                    // Update checkbox state and tooltip based on response
                     const state = data.state;
                     if (state === 'default') {
-                        toggleBtn.textContent = 'Full-width Tables';
-                        toggleBtn.className = 'usa-button usa-button--cyan';
-                        toggleTablesDescription.textContent = 'Expand all tables in this section to full width';
+                        toggleCheckbox.checked = false;
                     } else {
-                        toggleBtn.textContent = 'Default Tables';
-                        toggleBtn.className = 'usa-button usa-button--secondary';
-                        toggleTablesDescription.textContent = 'Restore all tables to their default widths';
+                        toggleCheckbox.checked = true;
                     }
 
                     showMessage(data.message, 'success');
                 } else {
                     const message = data.message || 'An error occurred. Please try again.';
                     showMessage(message, 'error');
-                    toggleBtn.textContent = originalText;
+                    // Revert checkbox state on error
+                    toggleCheckbox.checked = originalChecked;
                 }
             })
             .catch(error => {
                 console.error('Error:', error);
                 showMessage('An error occurred. Please try again.', 'error');
-                toggleBtn.textContent = originalText;
+                // Revert checkbox state on error
+                toggleCheckbox.checked = originalChecked;
             })
             .finally(() => {
-                toggleBtn.disabled = false;
-                toggleBtn.focus();
+                toggleCheckbox.disabled = false;
+                toggleCheckbox.focus();
             });
         });
 

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -310,6 +310,9 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
             "success_heading", "NOFO saved successfully"
         )
 
+        # Add status form for dropdown in template
+        context["status_form"] = NofoStatusForm(instance=self.object)
+
         # Clean up stale reimport session data
         self.request.session.pop("reimport_data", None)
 


### PR DESCRIPTION
# Small UX Improvements: Status Dropdown and Table Width Checkbox

## Overview
This PR introduces two user experience improvements to the NOFO Builder:

1. **Status dropdown integration** - Change NOFO status directly from the edit page
2. **Table width checkbox** - Replace button with intuitive checkbox control

## Related Issues: 
- https://github.com/HHS/simpler-grants-pdf-builder/issues/407

## Changes

### Status Dropdown Form Integration
- Integrated status dropdown form into the NOFO edit template
- Updated view to pass status form to context
- Enhanced summary box with status-specific messages and actions
- Improves workflow efficiency by eliminating navigation to separate pages


| Before | After |
| --- | --- | 
|<img width="400" alt="1_draft" src="https://github.com/user-attachments/assets/aabf3ea1-26d7-4261-84ed-fbde6fd53928" /> | <img width="400" alt="1_draft_new" src="https://github.com/user-attachments/assets/30d350cc-c9e7-4f2a-955e-0bbe70b22a30" /> |
| <img width="400" alt="2_active" src="https://github.com/user-attachments/assets/cf3fc3f0-ab79-4142-b104-56a1ffc477e7" /> | <img width="400" alt="2_active_new" src="https://github.com/user-attachments/assets/2142aa08-d52e-4765-ae51-37505fd49413" /> | 
| <img width="400" alt="3_readyforqa" src="https://github.com/user-attachments/assets/3b0da019-a48e-4fca-9101-ba65e1cdaf6a" /> | <img width="400" alt="3_readyforqa_new" src="https://github.com/user-attachments/assets/9271ab8c-9b19-4d32-a64d-fbeeb4088fef" /> |
| <img width="400" alt="4_inreview" src="https://github.com/user-attachments/assets/00e898b6-2a84-40e4-a27a-575fa58449f7" /> | <img width="400" alt="4_inreview_new" src="https://github.com/user-attachments/assets/cad5c182-7192-4e80-a8d9-5b81013451c4" /> | 
| <img width="400" alt="5_depsec" src="https://github.com/user-attachments/assets/1d13f50d-0dd0-47e1-b6cb-ca4cae47a9ed" /> | <img width="400" alt="5_depsec_new" src="https://github.com/user-attachments/assets/af93cfd7-2f44-4a27-9186-47f5578bca0a" /> | 
| <img width="400" alt="6_1_published" src="https://github.com/user-attachments/assets/524b3f00-50af-4a1d-8ac8-cba21f9a3e56" /> |  <img width="400" alt="6_1_published_new" src="https://github.com/user-attachments/assets/151790b5-773e-4bec-81c8-9c9cdf3e5924" /> | 
| <img width="400" alt="6_2_published_mods" src="https://github.com/user-attachments/assets/cfc15862-f339-4cee-9abb-0ac193e6dde8" /> |  <img width="400" alt="6_2_published_mods_new" src="https://github.com/user-attachments/assets/278598aa-2573-4595-bbc5-274052950948" /> |
|  <img width="400" alt="7_paused" src="https://github.com/user-attachments/assets/e88aabcd-e0b4-4566-9cd4-df846fae34cd" /> | <img width="400" alt="7_paused_new" src="https://github.com/user-attachments/assets/882a09dc-3354-4e87-9fa4-369e270129e1" /> | 
| <img width="400" alt="8_cancelled" src="https://github.com/user-attachments/assets/6dc834f2-5f62-4956-9ca8-e87345c5f8ea" /> |  <img width="400" alt="8_cancelled_new" src="https://github.com/user-attachments/assets/c212650f-0136-4dba-a900-1fbf7accf1f4" /> | 
| <img width="400" alt="9_archived" src="https://github.com/user-attachments/assets/f89d0ce3-60da-4247-a6df-4c6a0a26bf12" /> | <img width="400" alt="9_archived_new" src="https://github.com/user-attachments/assets/634fb4c9-b76e-4bb5-a0ab-554b4792c8f9" /> | 
| --- | --- |

### Table Width Button --> Checkbox ☑️ 
- Replaced toggle button with checkbox for table width control
- Updated styling and maintained existing AJAX functionality
- Checkboxes provide clearer intent and better accessibility for binary toggle states

| Before | After | 
| --- | --- | 
| <img width="983" height="148" alt="Screenshot 2025-08-06 at 12 33 42 PM" src="https://github.com/user-attachments/assets/08b7eb6a-bf99-4be0-98fd-c8f0537e7a56" /> <img width="986" height="147" alt="Screenshot 2025-08-06 at 12 33 35 PM" src="https://github.com/user-attachments/assets/794cc46a-9c85-41e6-876d-cb5127390f6c" /> | <img width="979" height="128" alt="Screenshot 2025-08-06 at 12 33 12 PM" src="https://github.com/user-attachments/assets/a006e708-f49f-469d-b54c-308d3f350f0f" /> |
