### PR TITLE
Change "active" link for a nav link to blue + Float the document headings on the compare page

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1493,8 +1493,9 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 .nofo_compare--content-guide .nofo_view {
   padding-top: 1rem;
+  padding-bottom: 1rem;
   background-color: #f5f5f5;
-  border-top: 2px solid var(--color--light-grey);
+  border-top: 1px solid var(--color--light-grey);
 }
 
 .nofo_compare--content-guide .nofo_view h2,
@@ -1507,10 +1508,21 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 .nofo_compare--content-guide .nofo_view,
 .nofo_compare--content-guide .nofo_view--title-bar {
+  padding-left: 0;
+  padding-right: 1rem;
   display: flex;
   gap: 1rem;
-  padding-bottom: 1rem;
   align-items: stretch; /* ensures all children match the tallest */
+}
+
+.nofo_compare--content-guide .nofo_view--title-bar {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  position: sticky;
+  top: 110px;
+  z-index: 1;
+  border-bottom: 1px solid var(--color--light-grey);
+  background-color: white;
 }
 
 .nofo_compare--content-guide
@@ -1573,6 +1585,10 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   border-bottom: 1px solid #dfe1e2;
 }
 
+.nofo_compare--content-guide .nofo_view--title-bar h2 {
+  font-size: 1.2rem;
+}
+
 .nofo_compare--content-guide .nofo_view--title-bar .nofo_view--title-changes,
 .nofo_compare--content-guide .nofo_view .nofo_view--changes {
   flex: 0 1 20%; /* 20% width, can shrink and grow but fixed max width of 180px */
@@ -1584,7 +1600,7 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 .nofo_compare--content-guide .nofo_view .nofo_view--changes--list {
   position: sticky;
-  top: 124px;
+  top: 185px;
   height: calc(100vh - 124px);
   display: flex;
   flex-direction: column;
@@ -1628,7 +1644,6 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   top: 0;
   padding-bottom: 1rem;
   padding-top: 1rem;
-  margin-bottom: 1rem;
   z-index: 1;
   display: flex;
   border-bottom: 1px solid var(--color--light-grey);

--- a/nofos/guides/templates/guides/guide_compare.html
+++ b/nofos/guides/templates/guides/guide_compare.html
@@ -98,11 +98,11 @@
             <table>
               <tr>
                 <td>
-                  <h2 class="margin-0">{{ guide.title }}</h2>
+                  <h2 class="margin-0 font-mono-md">{{ guide.title }}</h2>
                 </td>
                 {% if comparison %}
                   <td>
-                    <h2 class="margin-0">{{ new_nofo.filename }}</h2>
+                    <h2 class="margin-0 font-mono-md">{{ new_nofo.filename }}</h2>
                   </td>
                 {% endif %}
               </tr>
@@ -113,7 +113,7 @@
             <table>
               <tr>
                 <td>
-                  <h2 class="margin-0">{{ guide.title }} + {{ new_nofo.filename }}</h2>
+                  <h2 class="margin-0 font-mono-md">{{ guide.title }} & {{ new_nofo.filename }}</h2>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
## Summary

This PR makes 3 changes:

1. Make the filenames smaller (and monospace font)
2. Float the menu bar that includes filenames and "All differences"
3. change the styling on our nav links to be blue 



### Screenshots

#### 1. Filename stuff

Now it floats! 

| before | after |
|--------|-------|
|   Filenames are not there as we scroll down    |   Filenames are there (outlined with the red dashed line)    |
|  <img width="1232" height="702" alt="Screenshot 2025-08-07 at 17 12 55" src="https://github.com/user-attachments/assets/35f11255-3798-4de4-8c0d-4c8dcdffd745" />   |   <img width="1232" height="702" alt="Screenshot 2025-08-07 at 17 12 00" src="https://github.com/user-attachments/assets/a9452e0b-dd43-49c2-94d5-e193c5b6d45a" />  |




#### 3. Active nav links are blue

We want to match the other buttons we have and blue has been our active state thus far.

| before | after |
|--------|-------|
|   Always black     |   Hover is black, "active" is blue, and hover + active is blue border & dark blue text    |
|   ![Screen Recording 2025-08-07 at 16 37 03](https://github.com/user-attachments/assets/f9e4aaee-d1f1-4290-9fa4-31458f9ca6c2)     |     ![Screen Recording 2025-08-07 at 16 36 03](https://github.com/user-attachments/assets/a55b66a4-2755-44de-813d-41de1c0b6630)  |

