### PR TITLE
Fixes for the sticky header on the "Compare Content Guide" UI

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1529,9 +1529,10 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
   position: sticky;
-  top: 110px;
+  top: 109px;
   z-index: 1;
   border-bottom: 1px solid var(--color--light-grey);
+  border-top: 1px solid var(--color--light-grey);
   background-color: white;
 }
 

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1513,7 +1513,7 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 .nofo_compare--content-guide .nofo_view h4,
 .nofo_compare--content-guide .nofo_view h5,
 .nofo_compare--content-guide .nofo_view h6 {
-  scroll-margin-top: 125px;
+  scroll-margin-top: 195px;
 }
 
 .nofo_compare--content-guide .nofo_view,
@@ -1618,7 +1618,7 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 .nofo_compare--content-guide .nofo_view .nofo_view--changes--list {
   position: sticky;
-  top: 185px;
+  top: 190px;
   height: calc(100vh - 124px);
   display: flex;
   flex-direction: column;

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1546,9 +1546,12 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 .nofo_compare--content-guide
   .nofo_view
-  .nofo_view--table-container--no-comparison,
+  .nofo_view--table-container--no-comparison {
+  flex: 1 1 43%;
+}
+
 .nofo_compare--content-guide .nofo_view .nofo_view--table-container--empty {
-  flex: 1 1 40%; /* Start with 40% but can grow */
+  flex: 1 1 37%;
 }
 
 .nofo_compare--content-guide
@@ -1642,7 +1645,7 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 
 .guide_compare_upload {
   position: sticky;
-  top: 150px;
+  top: 190px;
 }
 
 .nofo_compare--content-guide

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1366,7 +1366,8 @@ main .back-link a::before,
   main
   table.table--section
   .nofo-edit-table--subsection--manage
-  .usa-checkbox .usa-checkbox__label {
+  .usa-checkbox
+  .usa-checkbox__label {
   position: absolute;
   top: 0;
   right: 1.8rem;
@@ -1594,8 +1595,16 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   border-bottom: 1px solid #dfe1e2;
 }
 
+.nofo_compare--content-guide .nofo_view--title-bar td .usa-tooltip {
+  width: 100%;
+}
+
 .nofo_compare--content-guide .nofo_view--title-bar h2 {
   font-size: 1.2rem;
+  /* prevent the filename from wrapping to the next line, adds "..." at the end */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .nofo_compare--content-guide .nofo_view--title-bar .nofo_view--title-changes,

--- a/nofos/guides/templates/guides/guide_compare.html
+++ b/nofos/guides/templates/guides/guide_compare.html
@@ -342,7 +342,7 @@
 {% block js_footer %}
 <script>
   document.addEventListener("DOMContentLoaded", function () {
-    const OFFSET = 130; // 5px more than scroll-margin-top
+    const OFFSET = 200; // 5px more than scroll-margin-top
     const navLinks = Array.from(document.querySelectorAll(".nofo_view--changes--list a"));
     const prevBtn = document.querySelector(".nofo_view--menu-bar--button__expand_less");
     const nextBtn = document.querySelector(".nofo_view--menu-bar--button__expand_more");

--- a/nofos/guides/templates/guides/guide_compare.html
+++ b/nofos/guides/templates/guides/guide_compare.html
@@ -106,11 +106,19 @@
             <table>
               <tr>
                 <td>
-                  <h2 class="margin-0 font-mono-md">{{ guide.title }}</h2>
+                  {% if guide.title|length > 40 %}
+                    <h2 class="margin-0 font-mono-md usa-tooltip" data-position="top" title="{{ guide.title }}">{{ guide.title }}</h2>
+                  {% else %}
+                    <h2 class="margin-0 font-mono-md">{{ guide.title }}</h2>
+                  {% endif %}
                 </td>
                 {% if comparison %}
                   <td>
-                    <h2 class="margin-0 font-mono-md">{{ new_nofo.filename }}</h2>
+                    {% if new_nofo.filename|length > 40 %}
+                      <h2 class="margin-0 font-mono-md usa-tooltip" data-position="top" title="{{ new_nofo.filename }}">{{ new_nofo.filename }}</h2>
+                    {% else %}
+                      <h2 class="margin-0 font-mono-md" data-position="top" title="{{ new_nofo.filename }}">{{ new_nofo.filename }}</h2>
+                    {% endif %}
                   </td>
                 {% endif %}
               </tr>
@@ -121,7 +129,13 @@
             <table>
               <tr>
                 <td>
-                  <h2 class="margin-0 font-mono-md">{{ guide.title }} & {{ new_nofo.filename }}</h2>
+                  {% with guide.title|add:new_nofo.filename as combined_title %}
+                    {% if combined_title|length > 60 %}
+                      <h2 class="margin-0 font-mono-md usa-tooltip" data-position="top" title="{{ guide.title }} & {{ new_nofo.filename }}">{{ guide.title }} & {{ new_nofo.filename }}</h2>
+                    {% else %}
+                      <h2 class="margin-0 font-mono-md">{{ guide.title }} & {{ new_nofo.filename }}</h2>
+                    {% endif %}
+                  {% endwith %}
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
## Summary

This PR makes a handful of small changes to the sticky header.

1. Clip document titles that are too long and add a tooltip on hover
2. Fix scroll offset now that the sticky header is larger
3. Fix for the safari bug that was 1px off
4. Make the column for a single NOFO a little wider

### Screenshots 

#### 1. Clip document titles that are too long + add tooltip 

| before | after |
|--------|-------|
|   Second document title overlaps "All differences"     |  Second document title is clipped but we have a tooltip      |
|   <img width="1207" height="200" alt="Screenshot 2025-08-08 at 11 17 06" src="https://github.com/user-attachments/assets/f4edb7f8-49d1-4bdb-a51c-c1da0dd55a3c" />     |   <img width="1213" height="209" alt="Screenshot 2025-08-08 at 11 16 39" src="https://github.com/user-attachments/assets/23753510-a419-49d2-be9b-4a9cc1ae389a" />    |

#### 4. Make the column for a single NOFO a little wider

| before | after |
|--------|-------|
|   Empty (grey column) seems wider than the actual content, which is what we care about. Also, text is not visible on scrolling down.     |  Empty column is more balanced, and text is visible.      |
| <img width="1198" height="446" alt="Screenshot 2025-08-08 at 11 37 43" src="https://github.com/user-attachments/assets/7692ece9-60d6-42ba-89f8-7d2fa67ce2a1" />       |   <img width="1197" height="445" alt="Screenshot 2025-08-08 at 11 36 54" src="https://github.com/user-attachments/assets/c6213b68-4046-426c-ae3e-f83fe46876ea" />    |

