### PR TITLE
Make the criteria to "merge" subsections harder

### DIFF
--- a/nofos/guides/views.py
+++ b/nofos/guides/views.py
@@ -387,8 +387,12 @@ class ContentGuideCompareView(GroupAccessObjectMixin, LoginRequiredMixin, View):
 
             # Filter out sections that contain ONLY "ADDs".
             comparison = [
-                section for section in comparison
-                if not all(sub.comparison_type == "body" and sub.status == "ADD" for sub in section["subsections"])
+                section
+                for section in comparison
+                if not all(
+                    sub.comparison_type == "body" and sub.status == "ADD"
+                    for sub in section["subsections"]
+                )
             ]
 
             changed_subsections = [

--- a/nofos/nofos/nofo_compare.py
+++ b/nofos/nofos/nofo_compare.py
@@ -236,10 +236,11 @@ def merge_renamed_subsections(
             heading_diff = html_diff(old_name, new_name)
 
             is_rename_only = old_body == new_body
+
             # look for if there is shared text in the header (remove del and ins and keep remainder)
-            has_shared_heading = bool(
-                re.sub(r"<(del|ins)>.*?</\1>", "", heading_diff or "").strip()
-            )
+            # "Shared heading" means at least 3 contiguous characters of overlap, case-sensitive
+            remaining_text = re.sub(r"<(del|ins)>.*?</\1>", " ", heading_diff or "")
+            has_shared_heading = bool(re.search(r"[A-Za-z0-9]{3,}", remaining_text))
 
             if is_rename_only or has_shared_heading:
                 merged.append(

--- a/nofos/nofos/tests_nofos/test_compare.py
+++ b/nofos/nofos/tests_nofos/test_compare.py
@@ -83,28 +83,82 @@ class MergeRenamedSubsectionsTests(TestCase):
         self.assertEqual(result[0].status, "ADD")
         self.assertEqual(result[1].status, "DELETE")
 
+    # One shared character ("s" at the end) should fail to merge
     def test_minimal_shared_heading(self):
         input_data = [
             SubsectionDiff(
-                name="a b",
+                name="Cost-sharing commitments",
                 status="ADD",
                 old_value="",
-                new_value="Groundhog Day",
+                new_value="Text no overlap",
             ),
             SubsectionDiff(
-                name="a",
+                name="Program focus",
                 status="DELETE",
-                old_value="Groundhog",
+                old_value="Explanation completely different",
+                new_value="",
+            ),
+        ]
+        result = merge_renamed_subsections(input_data)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual("Cost-sharing commitments", result[0].name)
+        self.assertEqual("Program focus", result[1].name)
+        self.assertEqual(result[0].status, "ADD")
+        self.assertEqual(result[1].status, "DELETE")
+
+    # Four shared _non-contigious_ characters ("Co" at the beginnning, "ts" at the end) should fail to merge
+    def test_three_character_shared_heading_non_contiguous(self):
+        input_data = [
+            SubsectionDiff(
+                name="Cost-sharing commitments",
+                status="ADD",
+                old_value="",
+                new_value="Text no overlap",
+            ),
+            SubsectionDiff(
+                name="Colorado chalets",
+                status="DELETE",
+                old_value="Explanation completely different",
+                new_value="",
+            ),
+        ]
+        result = merge_renamed_subsections(input_data)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual("Cost-sharing commitments", result[0].name)
+        self.assertEqual("Colorado chalets", result[1].name)
+        self.assertEqual(result[0].status, "ADD")
+        self.assertEqual(result[1].status, "DELETE")
+
+    def test_three_character_shared_heading(self):
+        input_data = [
+            SubsectionDiff(
+                name="Cost-sharing commitments",
+                status="ADD",
+                old_value="",
+                new_value="Text no overlap",
+            ),
+            SubsectionDiff(
+                name="Cosmic horror is required",
+                status="DELETE",
+                old_value="Explanation completely different",
                 new_value="",
             ),
         ]
         result = merge_renamed_subsections(input_data)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].status, "UPDATE")
-        self.assertEqual("a<ins> b</ins>", result[0].name)
-        self.assertEqual("a", result[0].old_name)
-        self.assertEqual("a b", result[0].new_name)
-        self.assertEqual(result[0].diff, "<p>Groundhog<ins> Day</ins></p>")
+        self.assertEqual(
+            "Cos<del>mic horror is required</del><ins>t-sharing commitments</ins>",
+            result[0].name,
+        )
+        self.assertEqual("Cosmic horror is required", result[0].old_name)
+        self.assertEqual("Cost-sharing commitments", result[0].new_name)
+        self.assertEqual(
+            result[0].diff,
+            "<p><del>Explanation completely different</del><ins>Text no overlap</ins></p>",
+        )
 
 
 class FilterComparisonByStatusTests(TestCase):


### PR DESCRIPTION
## Summary

This PR solves a bug where two subsections in our diff were getting matched that were not the same at all. It essentially changes the bar for "matching subsections" to include 3 contiguous characters, where before it was only 1 character in common.

### Details 

Previously, we would merge subsections (as in, classify a separate `ADD` and `DELETE` as an `UPDATE`) if there was any matching text at all in the headings.

This failed recently on a couple of very unlike subsections.

Subsection 1: `Cost-sharing commitments`
Subsection 2: `Program focus`
Diff: `<del>Cost-sharing commitment</del><ins>Program focu</ins>s`

Because there was a shared "s", they were grouped together, leading to a very confusing diff.

In reality, these subsections should _not_ match because they are totally different and their body text is also totally different.

The new rule to this effect now changes the match criteria to look for 3 contiguous characters in the heading, otherwise they don't match.

### Screensaver

| before | after |
|--------|-------|
|  These two subsections were being matched together      |     Program focus and Cost-sharing commitments are now separated  |
|  <img width="1184" height="724" alt="Screenshot 2025-08-09 at 19 11 18" src="https://github.com/user-attachments/assets/afdc9d32-f7a5-4c83-9743-634b5be9d315" />      |   <img width="1184" height="724" alt="Screenshot 2025-08-09 at 19 12 00" src="https://github.com/user-attachments/assets/4a1591bf-58f5-4ab2-86b2-868362c71c5e" />    |

