### PR TITLE
Fix indeterminate subsection checkbox behavior in guide edit template

### DIFF
--- a/nofos/guides/templates/guides/guide_edit.html
+++ b/nofos/guides/templates/guides/guide_edit.html
@@ -244,16 +244,22 @@ document.addEventListener('DOMContentLoaded', function() {
     function updateCompareSectionCheckboxes() {
         sectionCheckboxes.forEach(sectionCheckbox => {
             const sectionId = sectionCheckbox.value;
-
-            // Find all subsection checkboxes for this section
             const sectionSubsectionCheckboxes = document.querySelectorAll(`#section-${sectionId} input[name="compare_subsections"]`);
 
             if (sectionSubsectionCheckboxes.length > 0) {
-                // Check if all subsections in this section are checked
                 const allSectionSubsectionsChecked = Array.from(sectionSubsectionCheckboxes).every(checkbox => checkbox.checked);
+                const someSectionSubsectionsChecked = Array.from(sectionSubsectionCheckboxes).some(checkbox => checkbox.checked);
 
-                // Update section checkbox based on subsection states
-                sectionCheckbox.checked = allSectionSubsectionsChecked;
+                if (allSectionSubsectionsChecked) {
+                    sectionCheckbox.checked = true;
+                    sectionCheckbox.indeterminate = false;
+                } else if (someSectionSubsectionsChecked) {
+                    sectionCheckbox.checked = false;
+                    sectionCheckbox.indeterminate = true;
+                } else {
+                    sectionCheckbox.checked = false;
+                    sectionCheckbox.indeterminate = false;
+                }
             }
         });
     }


### PR DESCRIPTION
Updated the logic for section checkboxes to handle indeterminate states based on subsection selections. Now, if all subsections are checked, the section checkbox is checked; if some are checked, it becomes indeterminate; and if none are checked, it remains unchecked. This improves user feedback and clarity in the guide editing process.