### PR TITLE
Remove unintentional top border from borderless tables

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -67,23 +67,18 @@ blockquote {
 
 /* General USWDS CSS */
 
-.usa-prose > table th,
-.usa-table th {
-  font-weight: 400;
-}
-
-.usa-prose > table thead th,
-.usa-table thead th {
-  font-weight: 700;
-}
-
 .usa-table thead td,
 .usa-table tfoot td,
 .usa-table th {
   line-height: 1.5;
 }
 
-.usa-table--borderless :not(thead) th {
+.usa-prose > table th:not(thead th),
+.usa-table th:not(thead th) {
+  font-weight: 400;
+}
+
+.usa-table--borderless th:not(thead th) {
   border-top: 1px solid #1b1b1b;
 }
 


### PR DESCRIPTION
## Summary

Simple PR to remove the top-border from our tables.

### Details

This was actually a botched "fix" that I shipped after updating USWDS in #438.

I was trying to target table headings that are _not_ in the table body.

I wrote a CSS selector like this:

- `.usa-table--borderless :not(thead) th`

but this is the _right_ selector:

- `.usa-table--borderless th:not(thead th)`
