### PR TITLE
Remove empty list items in NOFO Comparison screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning since version 1.0.0.
 - Fixed height for the "filenames" sticky header on diff page
 - Disable "compare" buttons when no subsections are selected on Content Guide edit page
 - Require 3 contiguous characters in heading before merging subsections in diff (previously, it was 1 character)
+- Remove empty elements in diff side-by-side comparisons
 
 ## [3.7.0] - 2025-08-06
 

--- a/nofos/guides/views.py
+++ b/nofos/guides/views.py
@@ -398,6 +398,7 @@ class ContentGuideCompareView(GroupAccessObjectMixin, LoginRequiredMixin, View):
                 for sub in section["subsections"]
                 if sub.status != "MATCH"
             ]
+
             context.update(
                 {
                     "new_nofo": new_nofo,

--- a/nofos/nofos/nofo_compare.py
+++ b/nofos/nofos/nofo_compare.py
@@ -8,6 +8,7 @@ from django.utils.html import escape
 from martor.utils import markdownify
 
 from .models import Nofo
+from .nofo import decompose_empty_tags
 
 
 @dataclass
@@ -363,12 +364,14 @@ def annotate_side_by_side_diffs(comparison):
         soup = BeautifulSoup(diff_html, "html.parser")
         for ins in soup.find_all("ins"):
             ins.decompose()
+        decompose_empty_tags(soup)
         return str(soup) or ""
 
     def extract_new_diff(diff_html: str) -> str:
         soup = BeautifulSoup(diff_html, "html.parser")
         for delete in soup.find_all("del"):
             delete.decompose()
+        decompose_empty_tags(soup)
         return str(soup) or ""
 
     for item in comparison:

--- a/nofos/nofos/tests_nofos/test_compare.py
+++ b/nofos/nofos/tests_nofos/test_compare.py
@@ -512,6 +512,36 @@ class AnnotateSideBySideDiffsTests(TestCase):
         self.assertEqual("<p>Original <del>deleted</del> </p>", annotated.old_diff)
         self.assertEqual("<p>Original  <ins>added</ins></p>", annotated.new_diff)
 
+    def test_list_with_li_del_item(self):
+        subsection = SubsectionDiff(
+            name="Subsection",
+            status="UPDATE",
+            diff="<ul><li>Item 1</li><li><del>Item 2 deleted</del></li><li>Item 3</li></ul>",
+        )
+        section = {"name": "Section A", "subsections": [subsection]}
+        result = annotate_side_by_side_diffs([section])[0]
+        annotated = result["subsections"][0]
+        self.assertEqual(
+            "<ul><li>Item 1</li><li><del>Item 2 deleted</del></li><li>Item 3</li></ul>",
+            annotated.old_diff,
+        )
+        self.assertEqual("<ul><li>Item 1</li><li>Item 3</li></ul>", annotated.new_diff)
+
+    def test_list_with_li_ins_item(self):
+        subsection = SubsectionDiff(
+            name="Subsection",
+            status="UPDATE",
+            diff="<ul><li>Item 1</li><li><ins>Item 2 added</ins></li><li>Item 3</li></ul>",
+        )
+        section = {"name": "Section A", "subsections": [subsection]}
+        result = annotate_side_by_side_diffs([section])[0]
+        annotated = result["subsections"][0]
+        self.assertEqual("<ul><li>Item 1</li><li>Item 3</li></ul>", annotated.old_diff)
+        self.assertEqual(
+            "<ul><li>Item 1</li><li><ins>Item 2 added</ins></li><li>Item 3</li></ul>",
+            annotated.new_diff,
+        )
+
 
 class TestCompareNofos(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

This PR fixes the visual bug that we see when doing a compare of list items that the list with more elements creates empty list items on the other side. 

Now, empty list items are being stripped before being rendered.

## Details

When comparing two documents, the `<del>` tags signify everything that has been removed from the old document, and the `<ins>` tags represent everything that has been added in the new doc, stuff that was not in the original.

The point of this function is to decompose the 'combined' diff into 2 separate diffs, one which shows only deletions (the old doc) and one which shows only inserts (the new doc).

This is how we build out our side-by-side diff comparison UI.

However, there was technically a visual bug where some elements were entirely deleted or added:

- `<li><del>List item deleted</del>`

after stripping the `<del>` tags, we would return this

- `<li></li>`

Which put a bunch of empty list items on the screen.

Clearly, this is wrong. We should be removing empty HTML elements.

We already have a function that does this: we run it when NOFOs are imported for the first time, so I just added it to the nested functions of `annotate_side_by_side_diffs` and Bob's your uncle.

| before | after |
|--------|-------|
|  Empty list items in the right hand column, matching the number in the left hand column      |  No more empty list items     |
|  <img width="1054" height="502" alt="Screenshot 2025-08-12 at 11 21 28" src="https://github.com/user-attachments/assets/f8f87c26-517a-404f-a44f-94b03c177f38" />      |   <img width="1054" height="502" alt="Screenshot 2025-08-12 at 11 18 19" src="https://github.com/user-attachments/assets/691e9a10-1eba-46a0-85b5-3695f2a86897" />    |

