### PR TITLE
Add delete icon for Content Guides index page

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -189,6 +189,10 @@ footer .usa-footer__primary-link:visited {
   background-image: url("/static/img/usa-icons/check.svg");
 }
 
+.usa-button--icon--before.usa-button--add::before {
+  background-image: url("/static/img/usa-icons/add.svg");
+}
+
 /* expand width of usa-prose/usa-content */
 .usa-content ol:not(.usa-accordion):not(.usa-accordion--bordered),
 .usa-content p,
@@ -1036,7 +1040,7 @@ _:future,
   transform: none;
 }
 
-/* Safari fix for add-button positioning - ensure proper table cell context */
+/* Safari fix for add button inside of section detail view - ensure proper table cell context */
 _::-webkit-full-page-media,
 _:future,
 :root
@@ -1052,7 +1056,7 @@ _:future,
   .section_edit
   table.table--section
   td.nofo-edit-table--subsection--manage
-  .add-button {
+  .usa-button--add {
   position: absolute;
   bottom: 0;
   white-space: nowrap;
@@ -1181,33 +1185,27 @@ main .back-link a::before,
 
 /* add button generic */
 
-.section_edit .add_button,
-.subsection_edit .add-button {
+.section_edit .usa-button--add,
+.subsection_edit .usa-button--add {
   padding: 0.55rem 0.9rem 0.55rem 0.6rem;
   font-weight: 400;
 }
 
-.section_edit .add-button::before,
-.subsection_edit .add-button::before {
-  background-image: url(/static/img/usa-icons/add.svg);
-  background-repeat: no-repeat;
-  content: "";
-  background-position: center center;
-  background-size: cover;
-  display: inline-flex;
+.section_edit .usa-button--add::before,
+.subsection_edit .usa-button--add::before {
   filter: invert(20%) sepia(99%) saturate(1868%) hue-rotate(190deg)
     brightness(95%) contrast(98%);
 }
 
-.section_edit .add-button:hover::before,
-.subsection_edit .add-button:hover::before {
+.section_edit .usa-button--add:hover::before,
+.subsection_edit .usa-button--add:hover::before {
   filter: invert(16%) sepia(92%) saturate(1493%) hue-rotate(201deg)
     brightness(98%) contrast(88%);
 }
 
 /* add button specific */
 
-.section_edit table.table--section .add-button {
+.section_edit table.table--section .usa-button--add {
   position: absolute;
   bottom: 0;
   left: 50%;
@@ -1218,12 +1216,16 @@ main .back-link a::before,
   box-shadow: inset 0 0 0 0.75px var(--color--text-default);
 }
 
+.section_edit table.table--section .usa-button--add:hover {
+  box-shadow: inset 0 0 0 1px #1a4480; /* match text colour */
+}
+
 .usa-button--outline {
   background-color: transparent;
   color: #005ea2;
 }
 
-.section_edit table.table--section .add-button::before {
+.section_edit table.table--section .usa-button--add::before {
   height: 9px;
   width: 16px;
 }
@@ -1451,11 +1453,7 @@ main .back-link a::before,
   font-style: italic;
 }
 
-.subsection_edit .add-button {
-  box-shadow: inset 0 0 0 1.5px var(--color--text-default);
-}
-
-.subsection_edit .add-button::before {
+.subsection_edit .usa-button--add::before {
   height: 11px;
   width: 18px;
 }

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -125,6 +125,70 @@ footer .usa-footer__primary-link:visited {
   background-color: #444782;
 }
 
+/* Icon Buttons */
+.usa-button--icon--before::before {
+  content: "";
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  display: inline-flex;
+}
+
+.usa-button--icon--after::after {
+  content: "";
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  display: inline-flex;
+}
+
+.usa-button--icon[aria-disabled]::before {
+  filter: brightness(0) saturate(100%) invert(21%) sepia(0%) saturate(232%)
+    hue-rotate(216deg) brightness(100%) contrast(80%);
+}
+
+.usa-button--icon.usa-button--outline::before {
+  filter: brightness(0) saturate(100%) invert(19%) sepia(62%) saturate(3740%)
+    hue-rotate(190deg) brightness(93%) contrast(102%);
+}
+
+.usa-button--icon.usa-button--outline:hover::before {
+  filter: brightness(0) saturate(100%) invert(19%) sepia(94%) saturate(993%)
+    hue-rotate(192deg) brightness(94%) contrast(94%);
+}
+
+.usa-button--icon.usa-button--outline:active::before {
+  filter: brightness(0) saturate(100%) invert(15%) sepia(33%) saturate(1347%)
+    hue-rotate(179deg) brightness(94%) contrast(96%);
+}
+
+.usa-button--icon.usa-button--file_upload::before {
+  background-image: url("/static/img/usa-icons/file_upload.svg");
+}
+
+.usa-button--icon.usa-button--file_download::before {
+  background-image: url("/static/img/usa-icons/file_download.svg");
+}
+
+.usa-button--icon.usa-button--delete::before {
+  background-image: url("/static/img/usa-icons/delete.svg");
+}
+
+.usa-button--icon--before.usa-button--arrow_upward::before,
+.usa-button--icon--after.usa-button--arrow_upward::after {
+  background-image: url("/static/img/usa-icons/arrow_upward.svg");
+}
+
+.usa-button--icon--before.usa-button--content_copy::before,
+.usa-button--icon--after.usa-button--content_copy::after {
+  background-image: url("/static/img/usa-icons/content_copy.svg");
+}
+
+.usa-button--icon--before.usa-button--check::before,
+.usa-button--icon--after.usa-button--check::after {
+  background-image: url("/static/img/usa-icons/check.svg");
+}
+
 /* expand width of usa-prose/usa-content */
 .usa-content ol:not(.usa-accordion):not(.usa-accordion--bordered),
 .usa-content p,
@@ -163,12 +227,6 @@ footer .usa-footer__primary-link:visited {
 }
 
 a.back-to-top::before {
-  content: "";
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
-  display: inline-flex;
-  background-image: url("/static/img/usa-icons/arrow_upward.svg");
   height: 12px;
   width: 18px;
   margin-right: 5px;
@@ -357,7 +415,7 @@ label.usa-label {
   top: 25%;
 }
 
-/* Import  page */
+/* Import page */
 
 .nofo_import .form-import--loading {
   position: relative;
@@ -511,12 +569,12 @@ label.usa-label {
   margin-bottom: 0;
 }
 
-.nofo_edit .usa-site-alert .usa-button-icon--copy-button {
+.nofo_edit .usa-site-alert .usa-button--content_copy {
   padding: 0.75rem 1rem 0.75rem 0.9rem;
   position: absolute;
   right: 0;
   top: 2rem;
-  margin-right: 4rem; /* match the padding on usa-alert__body */
+  margin-right: 4rem !important; /* match the padding on usa-alert__body */
 }
 
 .nofo_edit .usa-site-alert--broken-links a,
@@ -676,42 +734,27 @@ label.usa-label {
   flex-grow: 1;
 }
 
-.nofo_edit .section--copy-button .usa-button-icon--copy-button,
-.nofo_edit .subsection--copy-button .usa-button-icon--copy-button {
+.nofo_edit .usa-button--content_copy {
   padding: 5px;
   border-radius: 3px;
 }
 
-.nofo_edit .subsection--copy-button .usa-button-icon--copy-button {
+.nofo_edit .subsection--copy-button .usa-button--content_copy {
   padding: 4px;
 }
 
-.nofo_edit .section--copy-button .usa-button-icon--copy-button:hover,
-.nofo_edit .subsection--copy-button .usa-button-icon--copy-button:hover {
+.nofo_edit .usa-button--content_copy:hover {
   background: rgba(180, 180, 180, 0.2);
 }
 
-.nofo_edit .section--copy-button .usa-button-icon--copy-button::after,
-.nofo_edit .subsection--copy-button .usa-button-icon--copy-button::after {
-  content: "";
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
-  display: inline-flex;
-  background-image: url("/static/img/usa-icons/content_copy.svg");
+.nofo_edit .usa-button--content_copy::after {
   filter: invert(0%) sepia(68%) saturate(995%) hue-rotate(19deg)
     brightness(102%) contrast(79%);
   width: 18px;
   height: 17px;
 }
 
-.nofo_edit .usa-alert__body .usa-button-icon--copy-button::before {
-  content: "";
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
-  display: inline-flex;
-  background-image: url("/static/img/usa-icons/content_copy.svg");
+.nofo_edit .usa-alert__body .usa-button--content_copy::before {
   filter: invert(99%) sepia(100%) saturate(207%) hue-rotate(194deg)
     brightness(111%) contrast(100%);
   width: 13px;
@@ -719,18 +762,12 @@ label.usa-label {
   margin-right: 4px;
 }
 
-.nofo_edit
-  .section--copy-button
-  .usa-button-icon--copy-button.usa-button-icon--copy-button--copied::after,
-.nofo_edit
-  .subsection--copy-button
-  .usa-button-icon--copy-button.usa-button-icon--copy-button--copied::after {
-  background-image: url("/static/img/usa-icons/check.svg");
+.nofo_edit .usa-button--content_copy.usa-button--check::after {
   filter: invert(36%) sepia(93%) saturate(2132%) hue-rotate(58deg)
     brightness(92%) contrast(101%);
 }
 
-.nofo_edit .subsection--copy-button .usa-button-icon--copy-button::after {
+.nofo_edit .subsection--copy-button .usa-button--content_copy::after {
   width: 15px;
   height: 15px;
 }
@@ -2013,38 +2050,6 @@ del + ins > br {
   width: 18px;
   filter: invert(100%) sepia(0%) saturate(2%) hue-rotate(331deg)
     brightness(102%) contrast(101%);
-}
-
-.usa-button--icon[aria-disabled]::before {
-  filter: brightness(0) saturate(100%) invert(21%) sepia(0%) saturate(232%)
-    hue-rotate(216deg) brightness(100%) contrast(80%);
-}
-
-.usa-button--icon.usa-button--outline::before {
-  filter: brightness(0) saturate(100%) invert(19%) sepia(62%) saturate(3740%)
-    hue-rotate(190deg) brightness(93%) contrast(102%);
-}
-
-.usa-button--icon.usa-button--outline:hover::before {
-  filter: brightness(0) saturate(100%) invert(19%) sepia(94%) saturate(993%)
-    hue-rotate(192deg) brightness(94%) contrast(94%);
-}
-
-.usa-button--icon.usa-button--outline:active::before {
-  filter: brightness(0) saturate(100%) invert(15%) sepia(33%) saturate(1347%)
-    hue-rotate(179deg) brightness(94%) contrast(96%);
-}
-
-.usa-button--icon.usa-button--file-upload::before {
-  background-image: url("/static/img/usa-icons/file_upload.svg");
-}
-
-.usa-button--icon.usa-button--file-download::before {
-  background-image: url("/static/img/usa-icons/file_download.svg");
-}
-
-.usa-button--icon.usa-button--delete::before {
-  background-image: url("/static/img/usa-icons/delete.svg");
 }
 
 .usa-summary-box .usa-checkbox {

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -189,6 +189,10 @@ footer .usa-footer__primary-link:visited {
   background-image: url("/static/img/usa-icons/check.svg");
 }
 
+.usa-button--icon--after.usa-button--delete::after {
+  background-image: url("/static/img/usa-icons/delete.svg");
+}
+
 .usa-button--icon--before.usa-button--add::before {
   background-image: url("/static/img/usa-icons/add.svg");
 }
@@ -1384,7 +1388,20 @@ main .back-link a::before,
   font-weight: 600;
 }
 
-/* Content guides */
+/* Content guide index page */
+.content_guide_index .table--section thead th:last-of-type,
+.content_guide_index .table--section tbody td:last-of-type {
+  text-align: center;
+}
+
+.content_guide_index .usa-button--delete::after {
+  filter: invert(14%) sepia(84%) saturate(3191%) hue-rotate(349deg)
+    brightness(94%) contrast(113%);
+  width: 22px;
+  height: 18px;
+}
+
+/* Content guide edit page */
 .nofo_guide_edit--header .nofo_guide_edit--header--h1 h1 {
   white-space: normal;
   font-size: 1.95rem;

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -193,6 +193,14 @@ footer .usa-footer__primary-link:visited {
   background-image: url("/static/img/usa-icons/add.svg");
 }
 
+.usa-button--icon--before.usa-button--arrow_back::before {
+  background-image: url("/static/img/usa-icons/arrow_back.svg");
+}
+
+.usa-button--icon--after.usa-button--arrow_forward::after {
+  background-image: url("/static/img/usa-icons/arrow_forward.svg");
+}
+
 /* expand width of usa-prose/usa-content */
 .usa-content ol:not(.usa-accordion):not(.usa-accordion--bordered),
 .usa-content p,
@@ -1141,32 +1149,21 @@ main .back-link a,
 main .back-link a::before,
 .section_edit .edit_section--other_sections a::before,
 .section_edit .edit_section--other_sections a::after {
-  content: "";
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
-  display: inline-flex;
   filter: invert(25%) sepia(62%) saturate(1908%) hue-rotate(183deg)
     brightness(93%) contrast(104%);
 }
 
 main .back-link a::before,
-.section_edit
-  .edit_section--other_sections
-  a.section_edit--previous-section::before {
-  background-image: url("/static/img/usa-icons/arrow_back.svg");
+.section_edit .edit_section--other_sections a.usa-button--arrow_back::before,
+.section_edit .edit_section--other_sections a.usa-button--arrow_forward::after {
   height: 12px;
   width: 18px;
   margin-right: 3px;
 }
 
-.section_edit
-  .edit_section--other_sections
-  a.section_edit--next-section::after {
-  background-image: url("/static/img/usa-icons/arrow_forward.svg");
-  height: 12px;
-  width: 18px;
+.section_edit .edit_section--other_sections a.usa-button--arrow_forward::after {
   margin-left: 3px;
+  margin-right: 0;
 }
 
 .nofo_edit .table--section tr,

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -201,6 +201,22 @@ footer .usa-footer__primary-link:visited {
   background-image: url("/static/img/usa-icons/arrow_forward.svg");
 }
 
+.usa-button--icon--before.usa-button--content_copy::before {
+  background-image: url("/static/img/usa-icons/content_copy.svg");
+}
+
+.usa-button--icon--before.usa-button--blank_file::before {
+  background-image: url("/static/img/blank_file.svg");
+}
+
+.usa-button--icon--before.usa-button--expand_more::before {
+  background-image: url("/static/img/usa-icons/expand_more.svg");
+}
+
+.usa-button--icon--before.usa-button--expand_less::before {
+  background-image: url("/static/img/usa-icons/expand_less.svg");
+}
+
 /* expand width of usa-prose/usa-content */
 .usa-content ol:not(.usa-accordion):not(.usa-accordion--bordered),
 .usa-content p,
@@ -1772,11 +1788,6 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
 }
 
 .nofo_compare .nofo_view--menu-bar .nofo_view--menu-bar--button::before {
-  content: "";
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
-  display: inline-flex;
   filter: brightness(0) saturate(100%) invert(49%) sepia(6%) saturate(369%)
     hue-rotate(164deg) brightness(92%) contrast(86%);
   width: 22px;
@@ -1797,28 +1808,6 @@ details.usa-accordion .usa-accordion__content ul li:not(:last-of-type) {
   .nofo_view--menu-bar--button.is-active:hover::before {
   filter: brightness(0) saturate(100%) invert(14%) sepia(20%) saturate(6652%)
     hue-rotate(187deg) brightness(103%) contrast(103%);
-}
-
-.nofo_compare
-  .nofo_view--menu-bar
-  .nofo_view--menu-bar--button__content_copy::before {
-  background-image: url("/static/img/usa-icons/content_copy.svg");
-}
-
-.nofo_compare .nofo_view--menu-bar .nofo_view--menu-bar--button__file::before {
-  background-image: url("/static/img/blank_file.svg");
-}
-
-.nofo_compare
-  .nofo_view--menu-bar
-  .nofo_view--menu-bar--button__expand_more::before {
-  background-image: url("/static/img/usa-icons/expand_more.svg");
-}
-
-.nofo_compare
-  .nofo_view--menu-bar
-  .nofo_view--menu-bar--button__expand_less::before {
-  background-image: url("/static/img/usa-icons/expand_less.svg");
 }
 
 .nofo_compare .nofo_view--vertical-divider {

--- a/nofos/guides/templates/guides/guide_compare.html
+++ b/nofos/guides/templates/guides/guide_compare.html
@@ -67,23 +67,23 @@
         {% with current_view=request.path %}
           <a
             href="{{ current_view }}?display=double"
-            class="nofo_view--menu-bar--button nofo_view--menu-bar--button__content_copy{% if display_mode == 'double' %} is-active{% endif %}"
+            class="nofo_view--menu-bar--button usa-button--icon--before usa-button--content_copy {% if display_mode == 'double' %} is-active{% endif %}"
           >
             Side-by-side view
           </a>
           <a
             href="{{ current_view }}?display=single"
-            class="nofo_view--menu-bar--button nofo_view--menu-bar--button__file{% if display_mode == 'single' %} is-active{% endif %}"
+            class="nofo_view--menu-bar--button usa-button--icon--before usa-button--blank_file{% if display_mode == 'single' %} is-active{% endif %}"
             {% if not comparison %}aria-disabled="true"{% endif %}
           >
             Single view
           </a>
         {% endwith %}
         <div class="nofo_view--vertical-divider"></div>
-        <button class="nofo_view--menu-bar--button nofo_view--menu-bar--button__expand_less" {% if not comparison %}aria-disabled="true"{% endif %} type="button">
+        <button class="nofo_view--menu-bar--button usa-button--icon--before usa-button--expand_less" {% if not comparison %}aria-disabled="true"{% endif %} type="button">
           Previous section
         </button>
-        <button class="nofo_view--menu-bar--button nofo_view--menu-bar--button__expand_more" {% if not comparison %}aria-disabled="true"{% endif %} type="button">
+        <button class="nofo_view--menu-bar--button usa-button--icon--before usa-button--expand_more" {% if not comparison %}aria-disabled="true"{% endif %} type="button">
           Next section
         </button>
 
@@ -344,8 +344,8 @@
   document.addEventListener("DOMContentLoaded", function () {
     const OFFSET = 200; // 5px more than scroll-margin-top
     const navLinks = Array.from(document.querySelectorAll(".nofo_view--changes--list a"));
-    const prevBtn = document.querySelector(".nofo_view--menu-bar--button__expand_less");
-    const nextBtn = document.querySelector(".nofo_view--menu-bar--button__expand_more");
+    const prevBtn = document.querySelector(".usa-button--expand_less");
+    const nextBtn = document.querySelector(".usa-button--expand_more");
 
     const sections = navLinks.map(link => {
       const id = link.getAttribute("href").substring(1);

--- a/nofos/guides/templates/guides/guide_compare.html
+++ b/nofos/guides/templates/guides/guide_compare.html
@@ -89,12 +89,12 @@
 
           <div class="nofo_view--menu-bar--file-download-button--container">
             {% if comparison %}
-              <a class="usa-button usa-button--outline usa-button--icon usa-button--file-download" type="button"
+              <a class="usa-button usa-button--outline usa-button--icon usa-button--file_download" type="button"
                 href="{% url 'guides:guide_compare_result_csv' pk=guide.pk new_nofo_id=new_nofo.pk %}">
                 <span class="margin-left-2">Export spreadsheet of differences</span>
               </a>
             {% else %}
-              <a class="usa-button usa-button--icon usa-button--file-download" aria-disabled="true">
+              <a class="usa-button usa-button--icon usa-button--file_download" aria-disabled="true">
                 <span class="margin-left-2">Export spreadsheet of differences</span>
               </a>
             {% endif %}

--- a/nofos/guides/templates/guides/guide_index.html
+++ b/nofos/guides/templates/guides/guide_index.html
@@ -39,7 +39,7 @@
           <td>
             <a href="{% url 'guides:guide_compare' guide.pk %}">Compare to a NOFO</a>
           </td>
-          <td><a href="{% url 'guides:guide_archive' guide.pk %}" class="text-secondary-dark">Delete</a></td>
+          <td><a href="{% url 'guides:guide_archive' guide.pk %}" class="text-secondary-dark usa-button--icon--after usa-button--delete"><span class="usa-sr-only">Delete this content guide</span></a></td>
         </tr>
       {% endfor %}
       </tbody>

--- a/nofos/guides/templates/guides/subsection_edit.html
+++ b/nofos/guides/templates/guides/subsection_edit.html
@@ -47,7 +47,7 @@
         </div>
 
         <div class="diff-strings--button-container">
-          <button type="button" class="usa-button usa-button--outline margin-top-4 diff-strings--button add-button display-none">
+          <button type="button" class="usa-button usa-button--outline margin-top-4 diff-strings--button usa-button--icon--before usa-button--add display-none">
             Add required string
           </button>
         </div>

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -313,7 +313,7 @@ Edit “{{ nofo|nofo_name }}”
   <div class="usa-alert">
     <div class="usa-alert__body">
       <h3 class="usa-alert__heading">Warning: some internal links are broken</h3>
-      <button class="usa-button usa-button--outline usa-button--inverse usa-button-icon--copy-button font-sans-2xs" type="button">Copy links</button>
+      <button class="usa-button usa-button--outline usa-button--inverse usa-button--icon usa-button--icon--before usa-button--content_copy font-sans-2xs" type="button">Copy links</button>
       <div>
         <details>
           <summary>
@@ -626,7 +626,7 @@ Edit “{{ nofo|nofo_name }}”
       <span class="section--copy-button">
         <button
           type="button"
-          class="usa-button usa-button--unstyled usa-tooltip usa-button-icon--copy-button"
+          class="usa-button usa-button--unstyled usa-tooltip usa-button--icon--after usa-button--content_copy"
           data-position="bottom"
           data-section-id="{{ section.html_id }}"
           title="Copy link to this section"
@@ -641,7 +641,7 @@ Edit “{{ nofo|nofo_name }}”
 
       <span class="add-or-remove-subsections"><a href="{% url 'nofos:section_detail' nofo.id section.id %}">Configure section</a></span>
       <span>
-        <a class="back-to-top" href="#back-to-top">Top</a>
+        <a class="back-to-top usa-button--icon usa-button--icon--before usa-button--arrow_upward" href="#back-to-top">Top</a>
       </span>
     </div>
   </caption>
@@ -677,7 +677,7 @@ Edit “{{ nofo|nofo_name }}”
             <span class="subsection--copy-button floating">
               <button
                 type="button"
-                class="usa-button usa-button--unstyled usa-tooltip usa-button-icon--copy-button"
+                class="usa-button usa-button--unstyled usa-tooltip usa-button--icon--after usa-button--content_copy"
                 data-position="bottom"
                 data-section-id="{{ subsection.html_id }}"
                 title="Copy link to this heading"
@@ -721,28 +721,28 @@ Edit “{{ nofo|nofo_name }}”
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     // Copy buttons for the heading ids
-    const tableButtons = document.querySelectorAll('.table--section .usa-button-icon--copy-button');
+    const tableButtons = document.querySelectorAll('.table--section .usa-button--content_copy');
     tableButtons.forEach(button => {
         button.addEventListener('click', function() {
             // Copy data-section-id to clipboard
             navigator.clipboard.writeText(`#${this.getAttribute('data-section-id')}`);
 
             // Add class to button
-            this.classList.add('usa-button-icon--copy-button--copied');
+            this.classList.add('usa-button--check');
 
             // Change the text inside the button's span
             this.querySelector('span').textContent = 'Copied';
 
             // Set a timer to revert changes after 1 second
             setTimeout(() => {
-                this.classList.remove('usa-button-icon--copy-button--copied');
+                this.classList.remove('usa-button--check');
                 this.querySelector('span').textContent = 'Copy section id';
             }, 1000);
         });
     });
 
     // Copy buttons inside of the alert boxes (eg, copy broken links)
-    const alertButtons = document.querySelectorAll('.usa-site-alert .usa-button-icon--copy-button');
+    const alertButtons = document.querySelectorAll('.usa-site-alert .usa-button--content_copy');
     alertButtons.forEach(button => {
         button.addEventListener('click', function() {
             // Find the nearest parent with the class '.usa-site-alert'

--- a/nofos/nofos/templates/nofos/nofo_edit_cover_image.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_cover_image.html
@@ -29,7 +29,7 @@ Edit NOFO cover image for "{{ nofo|nofo_name }}"
 
   <div class="grid-row grid-gap">
     <div class="grid-col-12 tablet:grid-col-auto margin-top-1">
-      <a class="usa-button usa-button--icon usa-button--file-upload usa-button--cyan" type="button"
+      <a class="usa-button usa-button--icon usa-button--file_upload usa-button--cyan" type="button"
         href="{% url 'nofos:nofo_upload_cover_image' nofo.id %}">
         <span class="margin-left-2">Replace cover image</span>
       </a>

--- a/nofos/nofos/templates/nofos/section_detail.html
+++ b/nofos/nofos/templates/nofos/section_detail.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 <div class="back-link font-body-md margin-bottom-105">
-  <a href="{% url 'nofos:nofo_edit' nofo.id %}">Edit “{{ nofo|nofo_name }}”</a>
+  <a class="usa-button--icon--before usa-button--arrow_back" href="{% url 'nofos:nofo_edit' nofo.id %}">Edit “{{ nofo|nofo_name }}”</a>
 </div>
 <div class="section_edit--header">
   <h1 class="font-heading-xl margin-y-1">Configure section <span class="usa-sr-only"> for {{ section.name }}</span></h1>
@@ -129,11 +129,11 @@
     <div class="usa-accordion__content usa-prose">
       <div class="edit_section--other_sections">
         {% if section.get_previous_section %}
-          <a href="{% url 'nofos:section_detail' section.nofo.id section.get_previous_section.id %}" class="section_edit--previous-section">{{ section.get_previous_section.name }}</a>
+          <a href="{% url 'nofos:section_detail' section.nofo.id section.get_previous_section.id %}" class="usa-button--icon--before usa-button--arrow_back">{{ section.get_previous_section.name }}</a>
         {% endif %}
 
         {% if section.get_next_section %}
-          <a href="{% url 'nofos:section_detail' section.nofo.id section.get_next_section.id %}" class="section_edit--next-section">{{ section.get_next_section.name }}</a>
+          <a href="{% url 'nofos:section_detail' section.nofo.id section.get_next_section.id %}" class="usa-button--icon--after usa-button--arrow_forward">{{ section.get_next_section.name }}</a>
         {% endif %}
       </div>
     </div>

--- a/nofos/nofos/templates/nofos/section_detail.html
+++ b/nofos/nofos/templates/nofos/section_detail.html
@@ -185,7 +185,7 @@
           </a>
         </span>
 
-        <a class="usa-button usa-button--outline add-button" type="button" href="{% url 'nofos:subsection_create' section.nofo.id subsection.section.id %}?prev_subsection={{subsection.id}}">
+        <a class="usa-button usa-button--outline usa-button--icon--before usa-button--add" type="button" href="{% url 'nofos:subsection_create' section.nofo.id subsection.section.id %}?prev_subsection={{subsection.id}}">
           Add subsection
         </a>
       </td>
@@ -194,7 +194,7 @@
   </tbody>
 </table>
 <script>
-  // Function to set table width CSS custom property for Safari compatibility dealing with the add-button positioning
+  // Function to set table width CSS custom property for Safari compatibility dealing with the usa-button--add positioning
   function setTableWidthVariable() {
       const table = document.querySelector('table.table--section');
       if (table) {


### PR DESCRIPTION
## Summary

There is a one visible change in this PR, which is adding trash bin icons for the "delete" column in the Content Guide index page.

There is also a non-visible change, which was reorganizing the icon buttons so that they are using more or less consistently applied classnames and styling. It saves us a few lines of code and makes our CSS file a little bit more manageable.

### Screenshots

| before | after |
|--------|-------|
|  <img width="1450" height="991" alt="Screenshot 2025-08-13 at 19 21 26" src="https://github.com/user-attachments/assets/e986fb15-ea90-4a38-8388-0ccdfe5c055f" />      |   <img width="1450" height="991" alt="Screenshot 2025-08-13 at 19 21 04" src="https://github.com/user-attachments/assets/adde0f9f-1d06-46d6-8295-b21fd589bef6" />    |

