### PR TITLE
Fix Word import bug by (temporarily) downgrading python-mammoth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+## [3.7.2] - 2025-08-18
+
 ### Fixed
+
+- Fix Word import bug by downgrading python-mammoth
 
 ## [3.7.1] - 2025-08-18
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -918,13 +918,13 @@ files = [
 
 [[package]]
 name = "mammoth"
-version = "1.10.0"
+version = "1.9.1"
 description = "Convert Word documents from docx to simple and clean HTML and Markdown"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mammoth-1.10.0-py2.py3-none-any.whl", hash = "sha256:a1c87d5b98ca30230394267f98614b58b14b50f8031dc33ac9a535c6ab04eb99"},
-    {file = "mammoth-1.10.0.tar.gz", hash = "sha256:cb6fbba41ccf8b5502859c457177d87a833fef0e0b1d4e6fd23ec372fe892c30"},
+    {file = "mammoth-1.9.1-py2.py3-none-any.whl", hash = "sha256:f0569bd640cee6c77a07e7c75c5dc10d745dc4dc95d530cfcbb0a5d9536d636c"},
+    {file = "mammoth-1.9.1.tar.gz", hash = "sha256:7924254ab8f03efe55fadc0fd5f7828db831190eb2679d63cb4372873e71c572"},
 ]
 
 [package.dependencies]
@@ -1679,4 +1679,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.13"
-content-hash = "c04d92d38a4cdb4566702d281bc17ac44b2ad3b18ad84b259c2c3a38aa53d723"
+content-hash = "8a1ef940a92986e9f9d517908c930bb2aedb8000012891a71ae7f32d6877eef7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nofos"
-version = "3.7.1"
+version = "3.7.2"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"
@@ -24,7 +24,7 @@ requests = "^2.32.3"
 cssutils = "^2.9.0"
 martor = "^1.6.45"
 django-mirror = "^0.1.13"
-mammoth = "^1.9.1"
+mammoth = "1.9.1"
 tomli = "^2.0.2"
 django-ninja = "^1.4.3"
 cryptography = "^45.0.4"


### PR DESCRIPTION
## Summary

The short version is that python-mammoth 1.10.0 introduced a bug whereby when table rows don't have table cells as their immediate children, the import would throw an error.

This affected us because we use content controls inside of tables, and sometimes they end up between the table row and cell.

The previous version of mammoth doesn't have this bug so downgrading the library resolves the bug.

More details in this issue:

https://github.com/mwilliamson/python-mammoth/issues/157