### PR TITLE
Fixes for Application Checklist in Step 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Fix CSS for Application Checklist tables in Step 3
+  - Some very specific CSS would only apply if the tables were in Step 5
+  - Other too general CSS should only apply to tables in Step 5
 - Show "Have questions?" callout box inline when it is _not_ in step 1
 
 ## [3.7.2] - 2025-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Demote heading sizes inside of sections with no title pages
+
 ### Fixed
 
 - Show "Have questions?" callout box inline when it is _not_ in step 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+### Fixed
+
+- Show "Have questions?" callout box inline when it is _not_ in step 1
+
 ## [3.7.2] - 2025-08-18
 
 ### Fixed

--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -488,6 +488,33 @@ div[role="heading"] {
   font-weight: 500;
 }
 
+/* Headings inside of sections with no title page are smaller */
+
+.section--no-section-page h2 {
+  font-size: 28pt;
+}
+
+.section--no-section-page h3 {
+  font-size: 20pt;
+}
+
+.section--no-section-page h4 {
+  font-size: 16pt;
+}
+
+.section--no-section-page h5 {
+  font-size: 14pt;
+}
+
+.section--no-section-page h6 {
+  font-size: 12.5pt;
+}
+
+.section--no-section-page div[role="heading"] {
+  font-size: 11.5pt;
+  font-weight: 700;
+}
+
 /* Running header */
 
 .table--callout-box {

--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -327,30 +327,16 @@ body.cms-white table td img.usa-icon--check_box_outline_blank {
   box-shadow: inset 0px 0px 5px 3px var(--color--table-blue);
 }
 
-.section--step-5-submit-your-application
-  .section--content
-  table
-  tr
-  td.usa-icon__td
-  > div {
+.section--content table tr td.usa-icon__td > div {
   display: flex;
 }
 
-.section--step-5-submit-your-application
-  .section--content
-  table
-  tr
-  td.usa-icon__td {
+.section--content table tr td.usa-icon__td {
   vertical-align: top;
 }
 
-.section--step-5-submit-your-application
-  .section--content
-  table
-  tr
-  td.usa-icon__td
-  span {
-  line-height: 1.25;
+.section--content table tr td.usa-icon__td span {
+  line-height: 1.3;
 }
 
 /* Cinch up the lines on individual <a> tags in the application checklist */

--- a/nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -316,7 +316,7 @@ section.section--appendix > .section--content > table {
   width: calc(216mm - 40mm); /* tables in the appendix should be full-width */
 }
 
-table tr td.usa-icon__td--sublist {
+.section--step-5-submit-your-application table tr td.usa-icon__td--sublist {
   padding-left: 30px;
 }
 
@@ -324,5 +324,7 @@ table tr td.usa-icon__td--sublist {
 .section--tables-full-width table.table--small,
 .section--tables-full-width table.table--large,
 .section--tables-full-width table.table--criterion {
-  width: calc(216mm - 40mm) !important; /* Match large table full-width behavior */
+  width: calc(
+    216mm - 40mm
+  ) !important; /* Match large table full-width behavior */
 }

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -278,7 +278,7 @@
   </section>
 
   {% for section in nofo.sections.all|dictsort:"order" %}
-    <section id="section--{{ section.html_id }}" class="section section--{{ forloop.counter }} {% if forloop.counter > 7 %}section--appendix {% endif %}section--{{ section.html_id }}{% if section.html_class %} {{ section.html_class }}{% endif %}">
+    <section id="section--{{ section.html_id }}" class="section section--{{ forloop.counter }} {% if forloop.counter > 7 %}section--appendix {% endif %}section--{{ section.html_id }}{% if section.html_class %} {{ section.html_class }}{% endif %}{% if not section.has_section_page %} section--no-section-page{% endif %}">
       <!-- SECTION TITLE PAGE -->
       {% if section.has_section_page %}
         <div class="title-page section--title-page">

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -366,25 +366,27 @@
         {% endif %}
 
         <!-- if in portrait mode, add callout boxes in right margin -->
-        {% spaceless %}
-          {% if nofo_theme_orientation == 'portrait' %}
-            {% with callouts=section|get_floating_callout_boxes_from_section %}
-              {% if callouts %}
-                <div class="section--content--right-col{% if callouts|get_combined_wordcount_for_subsections > 79 %} section--content--right-col--smaller{% endif %}">
-                  {% for subsection in callouts %}
-                    {% include "includes/callout_box.html" with subsection=subsection nofo=nofo break_colons=True only %}
-                  {% endfor %}
-                </div>
-              {% endif %}
-            {% endwith %}
-          {% endif %}
-        {% endspaceless %}
+        {% if section.order == 1 %}
+          {% spaceless %}
+            {% if nofo_theme_orientation == 'portrait' %}
+              {% with callouts=section|get_floating_callout_boxes_from_section %}
+                {% if callouts %}
+                  <div class="section--content--right-col{% if callouts|get_combined_wordcount_for_subsections > 79 %} section--content--right-col--smaller{% endif %}">
+                    {% for subsection in callouts %}
+                      {% include "includes/callout_box.html" with subsection=subsection nofo=nofo break_colons=True only %}
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              {% endwith %}
+            {% endif %}
+          {% endspaceless %}
+        {% endif %}
 
         <!-- loop through remaining subsections as usual -->
         {% for subsection in section.subsections.all|dictsort:"order" %}
           {% if subsection.callout_box %}
             {% if nofo_theme_orientation == 'portrait' %}
-              {% if not subsection|is_floating_callout_box %}
+              {% if not section.order == 1 or not subsection|is_floating_callout_box %}
                 {% include "includes/callout_box.html" with subsection=subsection nofo=nofo break_colons=False only %}
               {% endif %}
             {% else %}


### PR DESCRIPTION
## Summary

This PR makes 3 changes to our NOFO rendering:

- Alignment fixes for checklist layout when Application Checklist tables are in Step 3
- Reduces the very large heading sizes in Appendices
- Make the "Have questions?" box inline when we are not in Step 1

### Alignment fixes for Application Checklist tables in step 3

We have added a lot of very specific CSS to fix the application tables, which is bad and I hate.

Luckily, we are trying to improve them this time around, using 3 simple tables instead of one big omni-table. 

However, there are some growing pains here as not all my CSS is applying in the right places.

| before | after |
|--------|-------|
|  checkboxes are vertically higher than text. extra left padding in second table.      |  checkboxes and text are vertically centred. no weird left padding issues in second table.     |
|  <img width="844" height="1035" alt="Screenshot 2025-08-20 at 15 45 25" src="https://github.com/user-attachments/assets/88af340d-7a42-444b-a196-0a10b2509184" />      |   <img width="844" height="950" alt="Screenshot 2025-08-20 at 15 44 52" src="https://github.com/user-attachments/assets/993b4d47-d8bc-4670-873a-429ad5b7d983" />    |

### Smaller headings for appendices

Inside of regular sections, we start with H3s because the H2 is on the section title page.

However, when sections don't have cover pages, we actually put the H2 right at the top of them, and then the H3 right after.

This is jarring and makes the text look way too big, so I think it makes sense to just demote all of the headings when they are in a section without a title page (typically an appendix of some kind).

| before | after |
|--------|-------|
|    Headings are bigger   |  Headings are smaller     |
|   <img width="844" height="836" alt="Screenshot 2025-08-20 at 15 47 14" src="https://github.com/user-attachments/assets/42daee86-bf36-44b4-bf42-c6163a9bec0e" />    |   <img width="844" height="792" alt="Screenshot 2025-08-20 at 15 47 49" src="https://github.com/user-attachments/assets/f9225b11-f6f3-43d7-a2d3-d7f78215cf29" />    |

### "Have questions?" box is inline when we are not in Step 1


| before | after |
|--------|-------|
|  "Have questions?" box is yanked out of the flow and sits at the top right.     |   "Have questions?" box is at the bottom where we expect it.    |
|   <img width="1028" height="995" alt="Screenshot 2025-08-20 at 15 48 45" src="https://github.com/user-attachments/assets/130bdc79-acec-4e50-89f7-0934dd8e9641" />    |   <img width="1028" height="1037" alt="Screenshot 2025-08-20 at 15 48 21" src="https://github.com/user-attachments/assets/51cb6d98-d9ae-4ef4-aab3-6ca1ee1e72d3" />    |

