### PR TITLE
add_page_breaks_to_headings function now checks for section name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning since version 1.0.0.
   - Some very specific CSS would only apply if the tables were in Step 5
   - Other too general CSS should only apply to tables in Step 5
 - Show "Have questions?" callout box inline when it is _not_ in step 1
+- Shave .5 px off small toc items now that we have seen some GS-exported templates
 
 ## [3.7.2] - 2025-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning since version 1.0.0.
 ### Changed
 
 - Demote heading sizes inside of sections with no title pages
+- Application Checklist subsection only gets a page-break when in Step 5
 
 ### Fixed
 

--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -713,7 +713,7 @@ div[role="heading"] {
 }
 
 .toc.toc--small ol li {
-  margin-top: 5px;
+  margin-top: 4.5px;
 }
 
 .toc a {

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -283,17 +283,30 @@ def add_headings_to_document(
 
 
 def add_page_breaks_to_headings(document):
+    """
+    Assign 'page-break-before' to subsections whose name matches a target
+    heading and whose parent section name contains the specified substring.
+
+    Example:
+        ("eligibility", "step 1") will match a subsection named "Eligibility"
+        inside a section named "Step 1: Review the Opportunity".
+    """
     page_break_headings = [
-        "eligibility",
-        "program description",
-        "application checklist",
+        ("eligibility", "step 1"),
+        ("program description", "step 1"),
+        ("application checklist", "step 5"),
     ]
 
     for section in document.sections.all():
+        section_name = (section.name or "").lower()
         for subsection in section.subsections.all():
-            if subsection.name and subsection.name.lower() in page_break_headings:
-                subsection.html_class = "page-break-before"
-                subsection.save()
+            for match_subsection, match_section in page_break_headings:
+                # subsection name must match exactly (case insensitive)
+                if subsection.name and subsection.name.lower() == match_subsection:
+                    # section name must be a substring
+                    if match_section in section_name:
+                        subsection.html_class = "page-break-before"
+                        subsection.save()
 
 
 def _build_document(document, sections, SectionModel, SubsectionModel):

--- a/nofos/nofos/tests_nofos/test_page_breaks.py
+++ b/nofos/nofos/tests_nofos/test_page_breaks.py
@@ -44,7 +44,10 @@ class NofoRemovePagebreaksViewTest(TestCase):
 
         # Create a test section
         self.section = Section.objects.create(
-            name="Test Section", order=1, nofo=self.nofo, html_id="test-section"
+            name="Step 1: Review the Opportunity",
+            order=1,
+            nofo=self.nofo,
+            html_id="step-1-review-the-opportunity",
         )
 
         # Log in the user
@@ -396,6 +399,7 @@ class NofoRemovePagebreaksViewTest(TestCase):
             tag="h3",
         )
 
+        # should NOT get a page break: wrong section name
         application_checklist_subsection = Subsection.objects.create(
             section=self.section,
             name="Application Checklist",
@@ -424,9 +428,8 @@ class NofoRemovePagebreaksViewTest(TestCase):
         # Check that page breaks were added to the right subsections
         self.assertEqual(eligibility_subsection.html_class, "page-break-before")
         self.assertEqual(program_description_subsection.html_class, "page-break-before")
-        self.assertEqual(
-            application_checklist_subsection.html_class, "page-break-before"
-        )
+        # No page break because the section name doesn't match
+        self.assertEqual(application_checklist_subsection.html_class, "")
 
         # Check that regular subsection didn't get a page break
         self.assertEqual(regular_subsection.html_class, "")


### PR DESCRIPTION
## Summary

This PR makes our `add_page_breaks_to_headings` method look for section names as well as the subsection name.

## Details

We used to just always add the heading class to the subsections as long as they matched our hardcoded names (eg, "Application checklist). However, in the new version of the content guide, "Application checklist" should not have a new page break when it is on step 3.

But we _do_ want to still add the page break when it is in Step 5.

Also fixes some tests to account for new logic.

| before | after |
|--------|-------|
|     Page break automatically injected   |  Page break is not injected anymore     |
|   <img width="917" height="720" alt="Screenshot 2025-08-21 at 12 13 13" src="https://github.com/user-attachments/assets/139446cb-1e8c-4b75-97d3-3807c517e582" />     |   <img width="917" height="720" alt="Screenshot 2025-08-21 at 12 13 03" src="https://github.com/user-attachments/assets/f55fd95b-f4d1-40bb-a0f5-add04b0888cc" />    |

