### PR TITLE
Group multiple subsection deletions in diff before later matching subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Show deletions in compare page in order
+
 ## [3.8.0] - 2025-08-21
 
 ### Added


### PR DESCRIPTION
## Summary

This PR changes the order of how multiple deletions in a row are shown in our diff interface. Grouping them together is more intuitive and solves a problem we observed in user testing. 

### Details

Previously, we would show the deleted subsections interleaved with matched subsections because our ordering algorithm would basically do: 

- check old document subsection
- check new document subsection
- check old document subsection+1
- check new document subsection+1
- old+2
- new+2
- etc. 

So if we had multiple deletions in a row they would get interleaved with Matched subsections from the new document. 

So, for example, if we had this old document:

```
Section 1
Section 1.1
Section 1.2
Section 1.3
Section 2
Section 3
Section 4
Section 5
```

And this new document (Sections 1.1-1.3 deleted):

```
Section 1
Section 2
Section 3
Section 4
Section 5
```

We would end up with this as the result:

```
MATCH: Section 1
MATCH: Section 2
DELETE: Section 1.1
MATCH: Section 3
DELETE: Section 1.2
MATCH: Section 4
DELETE: Section 1.3
MATCH: Section 5
```

This is unintuitive and confused multiple people during our recent round of user testing. Here's what we _should_ present instead:

```
MATCH: Section 1
DELETE: Section 1.1
DELETE: Section 1.2
DELETE: Section 1.3
MATCH: Section 2
MATCH: Section 3
MATCH: Section 4
MATCH: Section 5
```

In this version ☝️ , all of the deletions are grouped _before_ the next match rather than being interspersed among them. 

This new logic implements this change so hopefully it solves this confusing issue without causing new issues 😬 . 

And finally, I'll just note that multiple `ADD`s did not have this same problem, so they are unaffected. They have always been working as you would expect.

### Screenshots

#### Original Word documents

| Old document | New document |
|--------|-------|
|  Includes "1.1", "1.2", "1.3"      |  Goes from 1 to 2, no increments     |
|  <img width="970" height="740" alt="Screenshot 2025-08-26 at 13 45 01" src="https://github.com/user-attachments/assets/9796d23c-b7b2-466e-9f8d-320143ba6e58" />      |   <img width="970" height="740" alt="Screenshot 2025-08-26 at 13 45 29" src="https://github.com/user-attachments/assets/4ba3fd48-541f-46e0-b4df-c4516cb3d506" />    |


#### Diff: OLD document vs NEW document (Subsections "1.1", "1.2", "1.3" are DELETED)

| before | after |
|--------|-------|
|  deletions are interleaved with matches      |    deletions are all grouped before the next match   |
|    <img width="970" height="740" alt="Screenshot 2025-08-26 at 13 44 21" src="https://github.com/user-attachments/assets/fe1254e4-dca3-4aa1-905f-dcbf60b14665" />    |   <img width="970" height="740" alt="Screenshot 2025-08-26 at 13 42 31" src="https://github.com/user-attachments/assets/3759bdc4-4d4f-4c80-9d23-04e1f27cf092" />    |

#### Diff: NEW document vs OLD document (Subsections "1.1", "1.2", "1.3" are ADDED now)

| before | after |
|--------|-------|
|   No change!     |    No change!   |
|     <img width="970" height="740" alt="Screenshot 2025-08-26 at 13 46 04" src="https://github.com/user-attachments/assets/3d86e34c-71c5-4f59-8620-62cf67878665" />   |   <img width="970" height="740" alt="Screenshot 2025-08-26 at 13 46 23" src="https://github.com/user-attachments/assets/e93a793a-bae7-415d-be9d-9d8b50eaffba" />    |

