### PR TITLE
Update version of Prince we use to generate PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+### Fixed
+
+## [3.9.0] - 2025-09-05
+
+### Changed
+
+- Use "pipeline: 11" which uses the newest Prince release, Prince 16
+  - More details here: https://www.princexml.com/releases/16/
 - Use USWDS sortable table for NOFO index instead of 3rd party library
 
 ### Fixed

--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -1104,6 +1104,12 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
 
 /* Media queries */
 @media print {
+  @prince-pdf {
+    /* Open Acrobat with bookmarks panel open by default */
+    -prince-pdf-page-mode: show-bookmarks;
+    prince-pdf-role-map: "H7" P;
+  }
+
   /* Tag elements in the PDF */
   .toc ol {
     -prince-pdf-tag-type: TOC;
@@ -1118,14 +1124,8 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   }
 
   div[role="heading"] {
-    prince-pdf-tag-type: "H7";
+    -prince-pdf-tag-type: "H7";
     -prince-bookmark-level: 7;
-  }
-
-  @prince-pdf {
-    /* Open Acrobat with bookmarks panel open by default */
-    -prince-pdf-page-mode: show-bookmarks;
-    prince-pdf-role-map: "H7" P;
   }
 
   .bookmark-level-2 {
@@ -1151,6 +1151,11 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
   .section--title-page--header-nav li a,
   .header-nav--running-header li a {
     -prince-link: none;
+  }
+
+  /* Close table borders when the cell continues onto a new page */
+  table {
+    box-decoration-break: clone;
   }
 
   /* Page break rules */

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1522,6 +1522,7 @@ class PrintNofoAsPDFView(GroupAccessObjectMixin, DetailView):
                     "document_url": nofo_url,
                     "document_type": "pdf",
                     "javascript": False,
+                    "pipeline": 11,
                     "prince_options": {
                         "media": "print",  # use print styles instead of screen styles
                         "profile": "PDF/UA-1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nofos"
-version = "3.8.0"
+version = "3.9.0"
 description = "the no-code solo nofo web flow"
 authors = ["Paul Craig <paul@pcraig.ca>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

We are using DocRaptor for our PDF printing, and "pipeline" version 11 is the latest one (still undocumented, at the time of writing), which brings in Prince version 16.

### Details 

Upgrading our version of Prince allows us to automatically tag H7s in the PDF, and then map them to paragraph tags. Check out Prince's documentation on this here: https://www.princexml.com/doc/prince-output/#pdf-tags

The only visual change I have picked up on is that table borders are 'open' by default instead of 'closed' where table cells continue onto the next page.

| Prince v15 vs v16  |
|--------------|
|       <img width="2540" height="1396" alt="Screenshot 2025-08-22 at 12 23 19" src="https://github.com/user-attachments/assets/6662d123-8fb1-4638-a65f-55e7a4fbe665" />      |

After talking with one of Prince's devs, he told us that we can use this CSS to get back the old behaviour:

```css
   table { box-decoration-break: clone }
```


We are still deciding whether or now we want the new behaviour or the old one, but for the sake of this update, I am just going to keep the old behaviour so that we don't change anything unintentionally.

Sources:

- https://docraptor.com/documentation/api#api_pipeline
- https://www.princexml.com/releases/16/