### PR TITLE
Remove white outline in table headings in PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Remove 1px outline from table headings in PDFs
+
 ## [3.9.0] - 2025-09-05
 
 ### Changed

--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -265,7 +265,6 @@ table th.header-row-empty[colspan] {
 
 table thead th,
 table tbody tr:first-of-type th {
-  background-clip: padding-box;
   font-weight: 600;
   line-height: 1.3;
   text-align: left;


### PR DESCRIPTION
## Summary

This PR makes a CSS change to remove a white outline that is unexpectedly showing up in our PDF output since upgrading the Prince version in #456.

This CSS rule makes no visible difference in the HTML rendering, but in the new version of Prince, it results in a white outline around table headings that we don't think should be there.

So let's remove it. It seems like is not doing anything useful for us but it _is_ causing problems.

### Screenshots

| before | after |
|--------|-------|
|   Grey border, then _white outline_ (bad), then blue background     |  Grey border, white outline     |
|    <img width="2760" height="3022" alt="Screenshot 2025-09-05 at 19 14 09" src="https://github.com/user-attachments/assets/a1c16d80-e3c1-467f-b199-63683e314c24" />    |    <img width="2762" height="3022" alt="Screenshot 2025-09-05 at 19 13 59" src="https://github.com/user-attachments/assets/a52fdb65-59a5-480a-b198-5d77c87ec3ab" />   |

