### PR TITLE
Move "Top" button to bottom-right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add "Nofo actions" dropdown menu, align with NOFO title
+  - Move print buttons down below
+  - Remove NOFO action buttons in blue box
+- Add name of user who last updated a NOFO for more transparency
+
 ### Changed
+
+- Remove "status" table on nofo_edit page, in favour of status picker in blue box.
+- Move "↑ Top" button on NOFO Edit page to bottom right
+- Rearrange print buttons, so that "Download PDF" always prints a 'live' NOFO
 
 ### Fixed
 

--- a/nofos/bloom_nofos/static/js/nofos/nofo_edit.js
+++ b/nofos/bloom_nofos/static/js/nofos/nofo_edit.js
@@ -1,9 +1,12 @@
-// This JS file does 3 things:
+// This JS file does 4 things:
 // 1. Operates the "NOFO actions" open/close menu
-// 1. Copies the heading ids for sections and subsections (those link buttons you see)
-// 2. Copies all the flagged internal links to clipboard
+// 2. Copies the heading ids for sections and subsections (those link buttons you see)
+// 3. Copies all the flagged internal links to clipboard
+// 4. Controls when the "Top" link appears on the bottom right as you scroll
 document.addEventListener("DOMContentLoaded", function () {
-  // JS to get the NOFO actions widget to open and close
+  // ------------------------------------------------------------
+  // 1. Operates the "NOFO actions" open/close menu
+  // ------------------------------------------------------------
   function nofoActionsInit(root) {
     const btn = root.querySelector("button[aria-controls]");
     const panel = document.getElementById(btn.getAttribute("aria-controls"));
@@ -43,7 +46,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
   document.querySelectorAll("[data-disclosure]").forEach(nofoActionsInit);
 
-  // Copy buttons for the heading ids
+  // ------------------------------------------------------------
+  // 2. Copies the heading ids for sections and subsections (those link buttons you see)
+  // ------------------------------------------------------------
   const tableButtons = document.querySelectorAll(
     ".table--section .usa-button--content_copy"
   );
@@ -67,7 +72,9 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 
-  // Copy buttons inside of the alert boxes (eg, copy broken links)
+  // ------------------------------------------------------------
+  // 3. Copies all the flagged internal links to clipboard
+  // ------------------------------------------------------------
   const alertButtons = document.querySelectorAll(
     ".usa-site-alert .usa-button--content_copy"
   );
@@ -100,6 +107,27 @@ document.addEventListener("DOMContentLoaded", function () {
       if (wasClosed) detailsElement.open = false;
     });
   });
+
+  // ------------------------------------------------------------
+  // 4. Controls when the "Top" link appears on the bottom right as you scroll
+  // ------------------------------------------------------------
+  const btn = document.querySelector(".back-to-top--container a");
+  const sentinel = document.getElementById("back-to-top--sentinel");
+  if (!btn || !sentinel) return;
+
+  const io = new IntersectionObserver(([entry]) => {
+    // Above top? (passed) boundingClientRect.top < 0
+    const passed = entry.boundingClientRect.top < 0;
+
+    if (entry.isIntersecting || passed) {
+      btn.classList.add("is-visible");
+    } else {
+      // below bottom (not reached yet)
+      btn.classList.remove("is-visible");
+    }
+  });
+
+  io.observe(sentinel);
 });
 
 window.addEventListener("load", function () {

--- a/nofos/bloom_nofos/static/shared.css
+++ b/nofos/bloom_nofos/static/shared.css
@@ -324,6 +324,10 @@ ul ul ul ul ul ul:not([type]):not(.usa-list--unstyled) {
     display: inline-block;
   }
 
+  .usa-button-group--segmented .usa-button:focus {
+    outline-offset: 0;
+  }
+
   .usa-button-group.usa-button-group--segmented
     .usa-button-group__item:first-of-type
     button {

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -271,12 +271,6 @@ a.back-to-top::before {
   color: var(--color--text-default);
 }
 
-caption a.back-to-top::before {
-  margin-right: 2px;
-  filter: invert(100%) sepia(0%) saturate(2%) hue-rotate(331deg)
-    brightness(102%) contrast(101%);
-}
-
 .usa-logo {
   display: flex;
   align-items: center;
@@ -875,18 +869,6 @@ label.usa-label {
   text-decoration: underline;
 }
 
-.nofo_edit caption a.back-to-top,
-.nofo_edit caption a.back-to-top:visited {
-  color: var(--color--white);
-  outline-offset: 3px;
-}
-
-.nofo_edit caption a.back-to-top {
-  padding: 3px 14px 3px 8px;
-  background-color: var(--color--usa-link);
-  border-radius: 0.25rem;
-}
-
 .back-to-top--container {
   display: inline-block;
 }
@@ -913,6 +895,10 @@ label.usa-label {
   /* smooth fade */
   transition: opacity 0.3s ease, transform 0.3s ease, visibility 0s linear 0.3s;
   transform: translateY(25px);
+}
+
+.back-to-top--container a:hover {
+  text-decoration: underline;
 }
 
 .back-to-top--container a.is-visible {

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -887,6 +887,43 @@ label.usa-label {
   border-radius: 0.25rem;
 }
 
+.back-to-top--container {
+  display: inline-block;
+}
+
+.back-to-top--container a {
+  position: fixed;
+  bottom: 2rem;
+  right: 1rem;
+  z-index: 1000;
+
+  text-decoration: none;
+  padding: 10px 14px 10px 10px;
+  background-color: var(--color--usa-link);
+  border-radius: 0.25rem;
+
+  color: var(--color--white);
+  outline-offset: 3px;
+
+  /* start hidden */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  /* smooth fade */
+  transition: opacity 0.3s ease, transform 0.3s ease, visibility 0s linear 0.3s;
+  transform: translateY(25px);
+}
+
+.back-to-top--container a.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition: opacity 0.3s ease, visibility 0s;
+
+  transform: translateY(0);
+}
+
 .nofo_edit .page-break--hr--container {
   position: relative;
 }

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1072,7 +1072,7 @@ label.usa-label {
   display: inline-block;
   margin: 1em 0;
   position: sticky;
-  top: 186px;
+  top: 182px;
 }
 
 .nofo_edit main table.usa-table > tbody > tr:first-of-type > th {

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -525,9 +525,6 @@ Edit “{{ nofo|nofo_name }}”
       {% endif %}
 
       <span class="add-or-remove-subsections"><a href="{% url 'nofos:section_detail' nofo.id section.id %}">Configure section</a></span>
-      <span>
-        <a class="back-to-top usa-button--icon usa-button--icon--before usa-button--arrow_upward" href="#back-to-top">Top</a>
-      </span>
     </div>
   </caption>
   <thead class="usa-sr-only">

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -501,6 +501,8 @@ Edit “{{ nofo|nofo_name }}”
   </tbody>
 </table>
 
+<div id="back-to-top--sentinel" aria-hidden="true"></div>
+
 {% for section in nofo.sections.all|dictsort:"order" %}
 <table class="usa-table usa-table--borderless width-full table--hide-edit-if-published table--hide-edit-if-archived table--section">
   <caption aria-label="{{ section.name|strip_br }}">
@@ -598,4 +600,7 @@ Edit “{{ nofo|nofo_name }}”
 </table>
 {% endfor %}
 
+<div class="back-to-top--container">
+  <a class="back-to-top usa-button--icon usa-button--icon--before usa-button--arrow_upward" href="#back-to-top">Top</a>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary

This PR moves the "Top" button to the bottom-right of the screen instead of in the sticky table headers we hav had them in so far.

It also updates the CHANGELOG to detail what we have shipped so far as part of the Header UI updates.

This is a continuation of #460 

## Details 

In the `nofo_edit` page, we previously had all the "back to top" buttons in the right hand side of the sticky headings of the NOFO section table headings.

This was kind of a weird place for them, as their placement would slightly change as you were editing (there could be 2 "top" links on the same screen, for example).

New top link is stuck to the bottom. It will:

- float on the bottom-right of the screen
- appear after you scroll past the (visually hidden) "back-to-top--sentinel" element
- disappear when you scroll up and it goes below the bottom of the viewport

### Screenshot

| before | after |
|--------|-------|
|  Two "back to top" links, one in each section heading.      |  One floating "back to top" link, always in the same place.     |
|  <img width="1263" height="1005" alt="Screenshot 2025-09-15 at 12 07 34" src="https://github.com/user-attachments/assets/656c825f-0434-4ce4-a844-249556d7c3ce" />      |   <img width="1403" height="1005" alt="Screenshot 2025-09-15 at 12 41 05" src="https://github.com/user-attachments/assets/5bc41c6c-b331-4ae9-b5ae-e3a30e49e79a" />    |



Here is a gif of the link appearing and disappearing:

![Screen Recording 2025-09-15 at 12 09 08](https://github.com/user-attachments/assets/627f1b9e-c0da-4b4a-93cc-82b8c64103e0)


