### PR TITLE
DOCRAPTOR_LIVE_MODE is a boolean so that it defaults to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Docraptor live mode should be a boolean, otherwise it is always true
+
 ## [3.15.0] - 2025-10-15
 
 ### Added

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -570,9 +570,9 @@ CONSTANCE_CONFIG = {
         str,
     ),
     "DOCRAPTOR_LIVE_MODE": (
-        now(),
+        False,
         "Whether to print PDFs with watermarks. If timestamp is older than 5 mins, documents will be watermarked.",
-        datetime,
+        bool,
     ),
     "WORD_IMPORT_STRICT_MODE": (
         False,


### PR DESCRIPTION
## Summary

This PR changes the config option `DOCRAPTOR_LIVE_MODE` back into a boolean. Right now it is a datetime, which means it always returns `True` when we use it for truthy checking.

This PR solves #478 

I removed most of the DOCRAPTOR_LIVE_MODE code back here: https://github.com/HHS/simpler-grants-pdf-builder/pull/477

So leaving `DOCRAPTOR_LIVE_MODE` as a datetime was an oversight.