### PR TITLE
Resolve pip vulnerabilities flagged by Anchore scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,21 +14,6 @@ RUN apt-get update && \
   libpq-dev \
   && rm -rf /var/lib/apt/lists/*
 
-# Patch system libraries to address known CVEs
-# - libcap2: CVE-2025-1390
-# - login, passwd: CVE-2023-4641, CVE-2023-29383,
-# - libsystemd0, libudev1: CVE-2025-4598
-# - libgnutls30: CVE-2025-32990
-RUN apt-get update && \
-  apt-get install -y --only-upgrade \
-  libcap2 \
-  login \
-  passwd \
-  libsystemd0 \
-  libudev1 \
-  libgnutls30 && \
-  rm -rf /var/lib/apt/lists/*
-
 # Install Poetry and create user
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local python3 - && \
   useradd --create-home --shell /bin/bash appuser && \


### PR DESCRIPTION
# Summary

Earlier today, our deploys started failing because of a flagged CVE in an older version of `pip`.  This PR upgrades the version(s) of `pip` used in the Dockerfile and gets us working again.

## Details

`pip` is not specifically installed by the project, but it is part of Python and it is bundled with poetry. After much trial and error, I managed to get both of these updated and delete the left-behind bits of the older `pip`. 

Now we can deploy again, thank goodness.

The second thing this PR does is that it removes some of the CVE-related upgrades we had in the past. Those packages had all, at one point or another, been flagged by one of the vuln scanners, but today are no longer needed, so we can save some LoC and make the Dockerfile a tiny bit shorter.