### PR TITLE
Hide first subsection in group if body is empty

### DIFF
--- a/nofos/composer/tests.py
+++ b/nofos/composer/tests.py
@@ -400,14 +400,14 @@ class GroupSubsectionsTests(TestCase):
         )
         self.view = ComposerSectionView()
 
-    def _make_subsection(self, name, tag=None, order=1):
+    def _make_subsection(self, name, tag=None, order=1, body="Generic body content"):
         """Helper to make a subsection instance (not saved content matters for grouping)."""
         return ContentGuideSubsection.objects.create(
             section=self.section,
             order=order,
             name=name,
             tag=tag or "",
-            body="",
+            body=body,
             enabled=True,
         )
 
@@ -490,6 +490,37 @@ class GroupSubsectionsTests(TestCase):
         self.assertEqual(len(groups), 1)
         self.assertEqual(groups[0]["heading"], "Funding details")
         self.assertEqual([x.pk for x in groups[0]["items"]], [s1.pk, s3.pk, s2.pk])
+
+    def test_header_item_with_empty_body_is_skipped(self):
+        # s1 is a header (preset name); its body is empty → should NOT appear in items
+        s1 = self._make_subsection("Funding details", tag="h4", order=1, body="")
+        # A normal subsection after the header
+        s2 = self._make_subsection(
+            "Budget breakdown", tag="h5", order=2, body="Some text"
+        )
+
+        groups = self.view.group_subsections([s1, s2])
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["heading"], "Funding details")
+        # Only s2 shows up because s1 (the header item) had no body
+        self.assertEqual([x.pk for x in groups[0]["items"]], [s2.pk])
+
+    def test_header_item_with_nonempty_body_is_included(self):
+        # s1 is a header (preset name) with real body → should appear in items
+        s1 = self._make_subsection(
+            "Funding details", tag="h4", order=1, body="<p>Hello</p>"
+        )
+        s2 = self._make_subsection(
+            "Budget breakdown", tag="h5", order=2, body="Some text"
+        )
+
+        groups = self.view.group_subsections([s1, s2])
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["heading"], "Funding details")
+        # s1 included first, then s2
+        self.assertEqual([x.pk for x in groups[0]["items"]], [s1.pk, s2.pk])
 
 
 class ComposerSectionViewTests(TestCase):

--- a/nofos/composer/views.py
+++ b/nofos/composer/views.py
@@ -239,6 +239,16 @@ class ComposerSectionView(GroupAccessObjectMixin, DetailView):
                 subsection_groups.append({"heading": subsection.name, "items": []})
                 current_idx = 0
 
+            # if first item
+            if len(subsection_groups[current_idx]["items"]) == 0:
+                # skip if subsection heading matches group name and subsection.body is empty
+                if (
+                    normalize_name(subsection.name)
+                    == normalize_name(subsection_groups[current_idx]["heading"])
+                    and not subsection.body
+                ):
+                    continue
+
             # Append the subsection to the current group
             subsection_groups[current_idx]["items"].append(subsection)
 


### PR DESCRIPTION
# Summary

This PR removes the first section in a grouping from the Composer's "section_view" page if it (a) has the same name as the grouping and (b) does not have a `subsection.body`.

It also adds a test for this new behaviour.

## Screenshots

| before | after |
|--------|-------|
|   2 duplicative subsections: same name as grouping, but no body. In practice, there is nothing to edit here.    |   first 2 subsections do not appear.    |
|   <img width="1458" height="1034" alt="Screenshot 2025-10-29 at 10 55 54" src="https://github.com/user-attachments/assets/510d3a08-ef1b-43e3-8d5f-feb6e9120517" />     |     <img width="1458" height="1034" alt="Screenshot 2025-10-29 at 10 57 08" src="https://github.com/user-attachments/assets/761c4ac0-cc45-4558-a7d2-2b3e146f1095" />  |


## Summary


This is an "off-piste" issue (no ticket) based on feedback from Ben and Annie yesterday when demoing the NOFO Composer.

To break up long sections on the Composer "section_view" page, we create heading groupings based on the heading level or some pre-identified heading titles.

Up to this point, there has been a certain duplicativeness. For example, for the "Program description" heading, the first subsection is "Program description".

This is fine if there is actual content to edit in this subsection, but when it is _just_ a heading with no body content, there is not a lot of value in showing it to users:

- we don't let them edit the titles (currently)
- we also don't expect them to add brand new text chunks under headings that currently don't have them

So, to reduce some of the duplicativeness, we are going to hide the first subsection in a group on the section page if

- it has the same name as the group
- it does not have a "subsection.body"