### PR TITLE
Update Django to 5.2.8

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -555,13 +555,13 @@ files = [
 
 [[package]]
 name = "django"
-version = "5.2.7"
+version = "5.2.8"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "django-5.2.7-py3-none-any.whl", hash = "sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b"},
-    {file = "django-5.2.7.tar.gz", hash = "sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd"},
+    {file = "django-5.2.8-py3-none-any.whl", hash = "sha256:37e687f7bd73ddf043e2b6b97cfe02fcbb11f2dbb3adccc6a2b18c6daa054d7f"},
+    {file = "django-5.2.8.tar.gz", hash = "sha256:23254866a5bb9a2cfa6004e8b809ec6246eba4b58a7589bc2772f1bcc8456c7f"},
 ]
 
 [package.dependencies]
@@ -1804,4 +1804,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "7a00fbc8b7c800c78bc9bec9081738bae705334f8089f48fa2dd96476fecf637"
+content-hash = "e9b9190d460649a3321e9a9142f70d0e2f1dfb6333003357b3789a714153bf01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "~3.12"
-django = "~5.2.7"
+django = "~5.2.8"
 beautifulsoup4 = "^4.13.5"
 markdownify = "1.2.0"
 django-easy-audit = "^1.3.5"


### PR DESCRIPTION
## Summary

This PR does what it says on the tin: upgrades to the latest version of Django.

The previous version of Django (`5.2.7`) was getting [flagged by our vulnerability scans](https://github.com/HHS/simpler-grants-gov/actions/runs/19270838431), so this resolves that and unblocks our release pipeline.