### PR TITLE
Add styles for edit_mode = variables or full to section, subsection_edit markdown preview, and preview mode

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -2393,3 +2393,12 @@ del + ins > br {
   background-color: var(--color--yellow);
   padding: 0 2px;
 }
+
+.styled-subsection-body--variables .md-curly-variable {
+  background-color: var(--color--yellow);
+  padding: 0 2px;
+}
+
+.styled-subsection-body--full {
+  color: var(--color--green-dark);
+}

--- a/nofos/composer/templates/composer/composer_preview.html
+++ b/nofos/composer/templates/composer/composer_preview.html
@@ -64,15 +64,15 @@
 
             <div class="section--content">
               {% for subsection in section.ordered_subsections %}
-                  {% if subsection.instructions %}
-                    <div>
-                      {{ subsection.instructions|safe_markdown|add_classes_to_paragraphs|add_classes_to_lists|convert_paragraphs_to_hrs }}
-                    </div>
-                  {% endif %}
                   {% with tag=subsection.tag content=subsection.name id=subsection.html_id class=subsection.html_class %}
                     {% include "includes/heading.html" with tag=tag content=content id=id class=class only %}
                   {% endwith %}
-                  <div>
+                  {% if subsection.instructions %}
+                    <div class="bg-primary-lighter padding-2">
+                      {{ subsection.instructions|safe_markdown|add_classes_to_paragraphs|add_classes_to_lists|convert_paragraphs_to_hrs }}
+                    </div>
+                  {% endif %}
+                  <div class="styled-subsection-body{% if subsection.edit_mode == 'variables' %}--variables{% elif subsection.edit_mode == 'full' %}--full{% endif %}">
                     {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs }}
                   </div>
               {% endfor %}

--- a/nofos/composer/templates/composer/composer_section.html
+++ b/nofos/composer/templates/composer/composer_section.html
@@ -99,7 +99,7 @@
                   href="{% url 'composer:subsection_edit' document.pk current_section.pk subsection.pk %}">
                     Edit
                 </a>
-                <div class="usa-prose">
+                <div class="usa-prose styled-subsection-body{% if subsection.edit_mode == 'variables' %}--variables{% elif subsection.edit_mode == 'full' %}--full{% endif %}">
                   {{ subsection.body|safe_markdown|add_classes_to_tables|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs }}
                 </div>
               </div>

--- a/nofos/composer/templates/composer/subsection_edit.html
+++ b/nofos/composer/templates/composer/subsection_edit.html
@@ -110,7 +110,7 @@
           <div class="usa-error-message margin-bottom-1">{{ form.body.errors.0 }}</div>
         {% endif %}
 
-        <div class="main-martor--container {% if form.body.errors %}main-martor--container--error{% endif %}">
+        <div class="main-martor--container {% if form.body.errors %}main-martor--container--error{% endif %} {% if form.edit_mode.value == 'full' %}styled-subsection-body--full{% endif %}">
           {{ form.body }}
         </div>
 


### PR DESCRIPTION
- applies yellow highlighting to `.md-curly-variable` in `.styled-subsection-body--variables`
- applies green text color to all content in `.styled-subsection-body--full`
- on section view
- on preview view (also added blue styling to instructions, and moved them below the subsection heading)
- on the markdown preview panel in subsection edit
    - this is a little tricky, because it doesn't update when the user toggles edit_mode, only on save. Could do more here, would require javascript, thoughts on if worth it?

closes #486 

| | variables styling | full text styling |
| --- | --- | --- | 
| section view | <img width="1052" height="871" alt="Screenshot 2025-11-12 140412" src="https://github.com/user-attachments/assets/9e6f3422-7dbb-4318-b2ae-54c7b5ea0932" /> | <img width="1059" height="870" alt="Screenshot 2025-11-12 140423" src="https://github.com/user-attachments/assets/f25c26ca-3de0-4c31-acee-5ea25cc4ec7f" />|
| preview view | <img width="1135" height="877" alt="Screenshot 2025-11-12 140319" src="https://github.com/user-attachments/assets/f5853913-b086-4ada-900f-267e5554a314" /> | <img width="1041" height="878" alt="Screenshot 2025-11-12 140342" src="https://github.com/user-attachments/assets/62178df8-179c-4dee-a40e-cee8ac3b1d8e" /> |
| subsection edit markdown preview | (pre-existing before this change) <img width="1056" height="877" alt="Screenshot 2025-11-12 140505" src="https://github.com/user-attachments/assets/565f839f-6561-46a2-a0c8-968dd0d0caef" /> | <img width="1032" height="877" alt="Screenshot 2025-11-12 140441" src="https://github.com/user-attachments/assets/69c914e4-4c64-422c-9700-b6e913b961e1" /> |
