### PR TITLE
Make {variables} regex stricter to fix custom attributes

### DIFF
--- a/nofos/bloom_nofos/markdown_extensions/curly_variables.py
+++ b/nofos/bloom_nofos/markdown_extensions/curly_variables.py
@@ -11,15 +11,29 @@ in a <span> element so they can be styled in the rendered HTML.
 
 ----------------------------------------------------------------
 Regex pattern used:
-    (?<!\\)\{([^{}]*\S[^{}]*)\}
+    (?<!\\)\{(?![:.#])([^{}]*\S[^{}]*)\}
 
 Explanation:
-    (?<!\\)     Negative lookbehind — ensure the "{" is not escaped (e.g., "\{" is ignored)
-    \{          Match literal opening brace
-    [^{}]*      Allow any number of non-brace characters
-    \S          Require at least one non-whitespace character (prevents matching "{   }")
-    [^{}]*      Allow more non-brace characters after that
-    \}          Match literal closing brace
+    (?<!\\)        Negative lookbehind — ensure the "{" is not escaped
+                   (e.g., "\{" is ignored)
+
+    \{             Match literal opening brace
+
+    (?![:.#])      Negative lookahead — do NOT match if the very next
+                   character is ':', '.', or '#'.
+                   This lets us ignore attribute list syntax like:
+                     {: #an_id .a_class }
+                     {.a_class}
+                     {#an_id}
+
+    [^{}]*         Allow any number of non-brace characters
+
+    \S             Require at least one non-whitespace character
+                   (prevents matching "{   }")
+
+    [^{}]*         Allow more non-brace characters after that
+
+    \}             Match literal closing brace
 
 Matches:
     {variable}
@@ -28,19 +42,23 @@ Matches:
     {Prompt text here}
 
 Ignores:
-    \{escaped\}         ← escaped braces
-    {   }               ← only whitespace inside
-    {nested {braces} ignored}   ← nested braces are not supported (variable is "{nested {braces}")
+    \{escaped\}                ← escaped braces
+    {   }                      ← only whitespace inside
+    {: #an_id .a_class }       ← attribute lists (start with "{:")
+    {.class}                   ← attribute lists (start with "{.")
+    {#id}                      ← attribute lists (start with "{#")
+    {nested {braces}}          ← nested braces are not supported
 
 The same regex is also reused in Django model logic for variable extraction.
 
-We also have a JavaScript file at `nofos/bloom_nofos/static/js/composer/martor-curly-variables.js`
-that implements this same Regex logic in JS (used for highlighting in the Ace markdown editor)
+We also have a JavaScript file at
+`nofos/bloom_nofos/static/js/composer/martor-curly-variables.js`
+that implements this same regex logic in JS (used for highlighting in
+the Ace markdown editor). Keep them in sync.
 ----------------------------------------------------------------
 """
 
-
-CURLY_VARIABLE_PATTERN = r"(?<!\\)\{([^{}]*\S[^{}]*)\}"
+CURLY_VARIABLE_PATTERN = r"(?<!\\)\{(?![:.#])([^{}]*\S[^{}]*)\}"
 
 
 class CurlyVarInlineProcessor(InlineProcessor):

--- a/nofos/bloom_nofos/static/js/composer/martor-curly-variables.js
+++ b/nofos/bloom_nofos/static/js/composer/martor-curly-variables.js
@@ -11,8 +11,8 @@
   // SHARED CONFIG / HELPERS
   // ===========================================================================
 
-  // Keep in sync with Python: r"(?<!\\)\{([^{}]*\S[^{}]*)\}"
-  const CURLY_VARIABLE_PATTERN_JS = /(?<!\\)\{[^{}]*\S[^{}]*\}/g;
+  // Keep in sync with Python: r"(?<!\\)\{(?![:.#])([^{}]*\S[^{}]*)\}"
+  const CURLY_VARIABLE_PATTERN_JS = /(?<!\\)\{(?![:.#])[^{}]*\S[^{}]*\}/g;
 
   // Token types from Ace's Markdown mode we consider "textual" (safe to split)
   const TEXT_TOKEN_TYPES = [

--- a/nofos/composer/tests/test_markdown_curly_variables.py
+++ b/nofos/composer/tests/test_markdown_curly_variables.py
@@ -116,6 +116,26 @@ class CurlyVariableMarkdownTests(SimpleTestCase):
             html,
         )
 
+    def test_attr_list_block_not_wrapped_colon(self):
+        """Attribute list starting with '{:' is not treated as a variable."""
+        text = "This is a paragraph.\n{: #an_id .a_class }"
+        html = markdownify(text)
+        self.assertEqual(
+            '<p class="a_class" id="an_id">This is a paragraph.<br></p>', html
+        )
+
+    def test_attr_list_block_not_wrapped_class(self):
+        """Attribute list starting with '{.' is not treated as a variable."""
+        text = "This is a paragraph.\n{.lead}"
+        html = markdownify(text)
+        self.assertEqual('<p class="lead">This is a paragraph.<br></p>', html)
+
+    def test_attr_list_block_not_wrapped_id(self):
+        """Attribute list starting with '{#' is not treated as a variable."""
+        text = "This is a paragraph.\n{#section-id}"
+        html = markdownify(text)
+        self.assertEqual('<p id="section-id">This is a paragraph.<br></p>', html)
+
 
 class CurlyVariablePatternTests(SimpleTestCase):
     """Test that the regex pattern correctly matches curly variables."""
@@ -167,5 +187,23 @@ class CurlyVariablePatternTests(SimpleTestCase):
     def test_extraction_no_matches(self):
         """Text without variables returns empty list."""
         text = "This has no variables at all."
+        vars = self._find_curly_variables(text)
+        self.assertEqual(vars, [])
+
+    def test_extraction_ignores_attr_list_colon(self):
+        """Attribute lists starting with '{:' should be ignored."""
+        text = "This is a paragraph.\n{: #an_id .a_class }"
+        vars = self._find_curly_variables(text)
+        self.assertEqual(vars, [])
+
+    def test_extraction_ignores_attr_list_class(self):
+        """Attribute lists starting with '{.' should be ignored."""
+        text = "This {.lead} should not be a variable."
+        vars = self._find_curly_variables(text)
+        self.assertEqual(vars, [])
+
+    def test_extraction_ignores_attr_list_id(self):
+        """Attribute lists starting with '{#' should be ignored."""
+        text = "This {#section-id} should not be a variable."
         vars = self._find_curly_variables(text)
         self.assertEqual(vars, [])

--- a/nofos/composer/tests/test_models.py
+++ b/nofos/composer/tests/test_models.py
@@ -150,6 +150,21 @@ class ExtractVariablesTests(TestCase):
             [{"key": "variable", "type": "string", "label": "variable"}],
         )
 
+    def test_attr_list_block_not_wrapped_colon(self):
+        subsection = self._mk("This is a paragraph.\n{: #an_id .a_class }")
+        variables = subsection.extract_variables()
+        self.assertEqual(variables, [])
+
+    def test_attr_list_block_not_wrapped_class(self):
+        subsection = self._mk("This is a paragraph.\n{.lead}")
+        variables = subsection.extract_variables()
+        self.assertEqual(variables, [])
+
+    def test_attr_list_block_not_wrapped_id(self):
+        subsection = self._mk("This is a paragraph.\n{#section-id}")
+        variables = subsection.extract_variables()
+        self.assertEqual(variables, [])
+
     def test_text_override_parameter_is_used_instead_of_instance_body(self):
         subsection = self._mk("Old body without vars")
         override = "New body with a {Fresh var}"


### PR DESCRIPTION
## Summary

This PR fixes markdown [attribute lists](https://python-markdown.github.io/extensions/attr_list/) my making our "variable" regex more strict. 

Specifically, we no longer consider something a variable if it starts with: `{:`, `{.`, or `{#`.

### Screenshots

With markdown attribute lists, we could add classnames to table headings like this: `{: .w-33}`, but our new extension messed this up.

| present (bug) | after (fixed) |
|--------|-------|
|  classname string is visible, not actually being applied (tables are varying widths)      |  classname string is gone and applied correctly (table columns are equal width)     |
|   <img width="684" height="189" alt="Screenshot 2025-11-14 at 18 45 36" src="https://github.com/user-attachments/assets/cb7c6a3e-9aea-46c3-8442-45dcbc68f288" />     |    <img width="684" height="189" alt="Screenshot 2025-11-14 at 18 44 46" src="https://github.com/user-attachments/assets/1afb5d07-b0f9-4076-997c-2403e8192602" />   |


### Details

In a recent previous PR (#502), we added a new markdown extension that looks for variables, which are wrapped in curly braces.

However, we also sometimes use our "[markdown attribute lists](https://python-markdown.github.io/extensions/attr_list/)" extension, which allows us to add classes, ids, etc into markdown with a custom syntax that _also_ uses curly braces.

So, for example, here is some of that syntax:

- `{: #someid .someclass somekey='some value' }`
- `{: #id1 .class1 id=id2 class="class2 class3" .class4 }`

Our new extension was messing up parsing custom attributes, so I made the regex stricter.

Now, we _no longer_ consider something a custom variable if it starts with either of these strings:

- `{:`
- `{.`
- `{#`

So that should restore functionality of custom attributes, although it _requires_ that we add the colon, period, or hash, which is not strictly required in the custom attribute documentation.