### PR TITLE
Add "OpDiv" column to the admin interface for NOFOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add an "OpDiv" column to the admin view for a NOFO
 - Add functionality for adding/deleting a Content Guide subsection
 - Add "preview" page for Composer
 - Added syntax highlighting to Ace editor for {variables}
@@ -16,6 +17,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Change Composer tags to new format
+- Scroll-to-top button now on multiple composer pages
 - Allow "instructions" to be edited like a subsection body
 
 ### Fixed

--- a/nofos/nofos/admin.py
+++ b/nofos/nofos/admin.py
@@ -106,6 +106,7 @@ class NofoAdmin(MirrorAdmin, admin.ModelAdmin):
     list_display = [
         "title",
         "number",
+        "opdiv",
         "group",
         "status",
         "designer",


### PR DESCRIPTION
## Summary

This is a very small change so that we can more easily see which NOFOs are from which OpDivs.

| before | after |
|--------|-------|
|  No OpDiv column      |   "OpDiv" column is after "Opportunity number"    |
|    <img width="1101" height="607" alt="Screenshot 2025-11-18 at 12 32 13" src="https://github.com/user-attachments/assets/49895e82-4da2-4569-adbf-812fab8bb809" />    |   <img width="1101" height="622" alt="Screenshot 2025-11-18 at 12 31 49" src="https://github.com/user-attachments/assets/94b29286-e385-4946-98c2-3de5fe836395" />  |

