### PR TITLE
Add a "Search NOFOS" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add a "search NOFOs" page for superusers
 - Add an "OpDiv" column to the admin view for a NOFO
 - Add functionality for adding/deleting a Content Guide subsection
 - Add "preview" page for Composer

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -517,6 +517,7 @@ label.usa-label {
   text-decoration: none;
 }
 
+.nofo_index--header,
 .nofo_edit--header,
 .section_edit--header,
 .subsection_edit--header {
@@ -613,11 +614,13 @@ label.usa-label {
   margin-left: -1px;
 }
 
+.nofo_index--header h1,
 .section_edit--header h1,
 .subsection_edit--header h1 {
   width: 65%;
 }
 
+.nofo_index--header--view,
 .section_edit--header--view,
 .subsection_edit--header--view {
   position: absolute;
@@ -627,6 +630,10 @@ label.usa-label {
   display: flex;
   align-items: baseline;
   gap: 20px;
+}
+
+.nofo_index--header--view {
+  top: 10px;
 }
 
 .nofo_edit--audit-widget {

--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -230,6 +230,20 @@ class CheckNOFOLinkSingleForm(forms.Form):
     url = forms.URLField(label="Check this URL", max_length=2048, required=True)
 
 
+# Simple form for searching for a NOFO
+class NofoSearchForm(forms.Form):
+    query = forms.CharField(
+        label="Search NOFOs",
+        required=False,
+        help_text="Enter any part of a NOFO name, number, or OpDiv.",
+        widget=forms.TextInput(
+            attrs={
+                "class": "usa-input usa-input border-2px",
+            }
+        ),
+    )
+
+
 class InsertOrderSpaceForm(forms.Form):
     section = forms.ModelChoiceField(
         queryset=Section.objects.all(), required=True, label="Section", disabled=False

--- a/nofos/nofos/templates/nofos/nofo_index.html
+++ b/nofos/nofos/templates/nofos/nofo_index.html
@@ -14,7 +14,15 @@
 {% block content %}
 	{% include "includes/alerts.html" with messages=messages success_heading="NOFO imported successfully" error_heading="NOFO deleted" only %}
 
-	<h1 class="font-heading-xl margin-y-0">{{ nofo_group|title }}{% if nofo_status and nofo_status != 'all' %} {{ nofo_status }}{% endif %} NOFOs</h1>
+	<div class="nofo_index--header">
+		<h1 class="font-heading-xl margin-y-0">{{ nofo_group|title }}{% if nofo_status and nofo_status != 'all' %} {{ nofo_status }}{% endif %} NOFOs</h1>
+		{% if user.is_superuser %}
+			<div class="nofo_index--header--view font-sans-md">
+				<a href="{% url 'nofos:nofo_search' %}">Search NOFOs</a>
+			</div>
+		{% endif %}
+	</div>
+
 
 	<p class="nofo_index--filter">
 		<a href="{% url 'nofos:nofo_index' %}?group={{ nofo_group }}" {% if not nofo_status or nofo_status == 'in progress' %}aria-current="page"{% endif %}>In progress NOFOs</a> |

--- a/nofos/nofos/templates/nofos/nofo_search.html
+++ b/nofos/nofos/templates/nofos/nofo_search.html
@@ -1,0 +1,77 @@
+{% extends 'base.html' %}
+{% load static tz %}
+
+{% block title %}Search NOFOs{% endblock %}
+
+{% block body_class %}nofo_search{% endblock %}
+
+{% block content %}
+  {% url 'nofos:nofo_index' as back_href %}
+  {% include "includes/page_heading.html" with title="Search NOFOs" back_text="Back to “All NOFOs”" back_href=back_href only %}
+
+  <form id="nofo-search-nofos--form" method="get">
+    {% csrf_token %}
+
+    {% include "includes/form_macro.html" %}
+
+    <button class="usa-button margin-top-3" type="submit">Search</button>
+  </form>
+
+  {% if query %}
+    <br>
+    <hr>
+    {% if nofo_list %}
+      <div class="usa-table-container">
+        <table class="usa-table usa-table--borderless width-full">
+          <caption>
+            {{ nofo_list|length }} results for “{{ query }}”
+          </caption>
+          <thead>
+            <tr>
+              <th data-sortable scope="col" role="columnheader">Short name</th>
+              <th data-sortable scope="col" role="columnheader">NOFO Number</th>
+              <th scope="col">OpDiv</th>
+              <th scope="col" class="nofo-group-col">Group</th>
+              <th scope="col">Status</th>
+              <th data-sortable scope="col" role="columnheader">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for nofo in nofo_list %}
+              <tr {% if nofo.status == 'ready-for-qa' %}class="ready-for-qa"{% endif %}>
+                <th scope="row">
+                  <a href="{% url 'nofos:nofo_edit' nofo.id %}">
+                    {% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}
+                  </a>
+                </th>
+                <td>
+                  {% if nofo.number %}{{ nofo.number }}{% else %}—{% endif %}
+                </td>
+                <td>
+                  {{ nofo.opdiv }}
+                </td>
+                <td>
+                  <span class="usa-tag bg-group bg-group--{{ nofo.group }}">{{ nofo.group }}</span>
+                </td>
+                <td>{{ nofo.get_status_display }}</td>
+                {% timezone "America/New_York" %}
+                  <td data-sort-value="{{ nofo.updated|date:"YmdHM" }}">
+                    <a href="{% url 'nofos:nofo_history' nofo.id %}" title="View audit history">
+                      {{ nofo.updated|date:'M j' }}{% if nofo.updated|date:'M j' == today_m_j %},<br>{{ nofo.updated|date:'g:i A' }}{% endif %}
+                      <span class="usa-sr-only">
+                        - View audit history for
+                        {% if nofo.short_name %}{{ nofo.short_name }}{% else %}{{ nofo.title }}{% endif %}
+                      </span>
+                    </a>
+                  </td>
+                {% endtimezone %}
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p>No NOFOs found with “{{ query }}” as part of their name, number, or OpDiv.</p>
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/nofos/nofos/urls.py
+++ b/nofos/nofos/urls.py
@@ -166,6 +166,7 @@ urlpatterns = [
         views.CheckNOFOLinksDetailView.as_view(),
         name="nofo_check_links",
     ),
+    path("search", views.NofoSearchView.as_view(), name="nofo_search"),
     path(
         "check-link",
         views.CheckNOFOLinkSingleView.as_view(),


### PR DESCRIPTION
## Summary

This adds a new "search NOFOs" page to the NOFO Builder, but only for superusers. 

The reason we are building this is because @benbrasso-agile6 asked for it in #513; he keeps opening issues and I keep not doing anything about them so I figure we owe him one.

### Screenshots 

#### NOFO index page 

| before | after |
|--------|-------|
|        |  New link for "Search NOFOs". Link is only visible to superusers (which is a subset of Bloom users).     |
|  <img width="1101" height="643" alt="Screenshot 2025-11-19 at 11 02 44" src="https://github.com/user-attachments/assets/3972378f-a34d-4313-b921-fa0539005251" />      |   <img width="1101" height="643" alt="Screenshot 2025-11-19 at 10 59 53" src="https://github.com/user-attachments/assets/fc13c3ad-b8ed-4e61-8fed-f1d4f77ddc66" />    |

#### NOFO search page

| found NOFOs | not found NOFOs |
|--------|-------|
|    4 results for a NOFO    |   No NOFOs found (and no XSS)    |
|    <img width="1101" height="701" alt="Screenshot 2025-11-19 at 11 08 12" src="https://github.com/user-attachments/assets/4755dc63-cb30-4e0b-9c79-7bcd9fc5e5ce" />    |   <img width="1101" height="427" alt="Screenshot 2025-11-19 at 11 09 58" src="https://github.com/user-attachments/assets/bf976dfc-c0f3-4023-952e-054c0c571efa" />    |

### Details

This is a fairly simple implementation of a search page for looking for a NOFO.

The search works by doing a lowercase partial string match for any of these fields:

- title
- short_name
- number
- opdiv

This meets Ben's requirement for #513, of being able to search through NOFOs by OpDiv. 

The basic idea is that superusers get a new search link on the index page, and then they can search for a NOFO they are looking for, and _then_ they can sort their results in a sortable usa-table. 

This is just something cheap and fast, so there are some non-enterprise decisions here:

- you can search with an empty string (no results though)
- you can search with 1 character
- no pagination
- no "group" filter: the assumption is that superusers are only ever Bloom users

And then, finally, this kind of slips between the cracks of our testing philosophy, which is: we don't test "views" in the "nofos" app and there is no logic outside of "views.py", so there are no tests. I'm okay with this, just calling it out.