### PR TITLE
521: detect presence of variables on content guide ingestion

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -400,6 +400,12 @@ def _build_document(document, sections, SectionModel, SubsectionModel):
                 subsection_fields["instructions"] = instructions_md_body
 
             subsection_obj = SubsectionModel(**subsection_fields)
+
+            if hasattr(SubsectionModel, "extract_variables"):
+                variables = subsection_obj.extract_variables()
+                if variables:
+                    subsection_obj.edit_mode = "variables"
+
             add_html_id_to_subsection(subsection_obj)
             try:
                 subsection_obj.full_clean()


### PR DESCRIPTION
The existing content guide, immediately after import:
<img width="1008" height="731" alt="Screenshot 2025-11-21 165654" src="https://github.com/user-attachments/assets/65de28ab-95d4-4c32-8b26-0501eb6bc16f" />
