### PR TITLE
[Bugfix] Fix for importing content guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Show a title derived from subsection.body for subsections with no name on Composer pages
 - Prefill "key facts" variables with values from the NOFO Writer "details" page
 - Add new style for variables with filled-in values
 - Add "optional" and "hidden" labels to the "Guide to tags"
@@ -24,6 +25,7 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Add a fix for importing ContentGuides
 - "Admin" link for superusers now works as expected for ContentGuideInstances
 - Don't show the "hidden" field on subsection edit page for "variables" subsections
 - NOFO Composer header links to admin/writer index depending on current url

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -417,7 +417,10 @@ def _build_document(document, sections, SectionModel, SubsectionModel):
                 variables = subsection_obj.extract_variables()
                 if variables:
                     subsection_obj.edit_mode = "variables"
-                    subsection_obj.variables = json.dumps(variables)
+                    serializable_variables = {
+                        key: var.to_dict() for key, var in variables.items()
+                    }
+                    subsection_obj.variables = json.dumps(serializable_variables)
 
             add_html_id_to_subsection(subsection_obj)
             try:


### PR DESCRIPTION
## Summary

Now that we have VariableInfo, we have to be more explicit about serializing and deserializing it.

This solves a problem we were running into, that is preventing us from importing new Content Guides.