### PR TITLE
Add a paragraph on the preview page for NOFO writers

### DIFF
--- a/nofos/composer/templates/composer/composer_preview.html
+++ b/nofos/composer/templates/composer/composer_preview.html
@@ -38,6 +38,12 @@
         <p><em>Last updated on <strong>{{ document.updated|date:'F j' }} at {{ document.updated|date:'g:i A' }}</strong></em>.</p>
       {% endtimezone %}
 
+      {% if document_is_instance %}
+        <p class="margin-y-2">
+          Review your draft. You can download the NOFO as a Word document for offline editing, or save your progress and return to Composer anytime.
+        </p>
+      {% endif %}
+
       <hr>
 
       {% if show_unpublish_button or show_save_exit_button or show_publish_button or show_download_button %}

--- a/nofos/composer/templates/composer/composer_section.html
+++ b/nofos/composer/templates/composer/composer_section.html
@@ -178,6 +178,10 @@
                 href="{{ next_sec_url }}">
                 {% if document_is_instance == False %}{{ next_sec.name }} →{% else %}Save and continue{% endif %}
             </a>
+          {% else %}
+            {% if document_is_instance %}
+              <a href="{% url 'composer:writer_preview' document.pk %}" class="usa-button">Preview draft NOFO</a>
+            {% endif %}
           {% endif %}
         </div>
       </nav>


### PR DESCRIPTION
## Summary

Simple PR with some small changes requested by Annie

- Add a button on the Contacts and Support page at the bottom
- Add some help text on the preview page

# Add a button on the Contacts and Support page at the bottom

| before | after |
|--------|-------|
|  nowhere to go from here     |  new button!     |
|     <img width="763" height="250" alt="Screenshot 2025-12-12 at 11 16 38" src="https://github.com/user-attachments/assets/28be468a-a0d7-427a-9d99-5b19c6061cc1" />   |    <img width="763" height="250" alt="Screenshot 2025-12-12 at 11 16 22" src="https://github.com/user-attachments/assets/8866b731-1ef2-4c30-ad18-6b4c843c100a" />   |
 
# Add some help text on the preview page

Maybe this will help people understand better what the preview page is for.

| before | after |
|--------|-------|
|   <img width="763" height="187" alt="Screenshot 2025-12-12 at 11 17 26" src="https://github.com/user-attachments/assets/f3b79110-47f3-4f4b-aba6-8dfea2166f1a" />     |    <img width="763" height="250" alt="Screenshot 2025-12-12 at 11 14 13" src="https://github.com/user-attachments/assets/3a0f98aa-5af6-4b3c-a21d-29a5926864cf" />   |



