### PR TITLE
Guard against re-confirming an already-confirmed draft NOFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning since version 1.0.0.
 ### Fixed
 
 - Explicitly mark "Style Bold" text as bold on import
+- Don't duplicate sections and subsections by repeatedly confirming a draft NOFO
 
 ## [3.23.0] - 2025-12-10
 


### PR DESCRIPTION
## Summary

This  is a small PR that fixes a bug. Basically, if you keep returning to the confirmation screen as part of creating your draft NOFO, you can keep reconfirming the same draft and duplicating all the Sections and Subsections.

This bug is also described here: https://github.com/HHS/simpler-grants-pdf-builder/issues/579

Merging this closes #579 