### PR TITLE
Use a pencil icon in ToC for "Build your application"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Use pencil icon for "Build your application" step
+- Automatically assign "optional" to ContentGuideInstance subsections based on instructions
 - Allow title casing for "Key Facts" and "Key Dates" subsections
 
 ### Fixed
 
+- Fixed how instructions are associated with subsections when creating a ContentGuideInstance
 - Explicitly mark "Style Bold" text as bold on import
 - Don't duplicate sections and subsections by repeatedly confirming a draft NOFO
 

--- a/nofos/bloom_nofos/templates/includes/_icon_macro.html
+++ b/nofos/bloom_nofos/templates/includes/_icon_macro.html
@@ -2,7 +2,7 @@
   {% include icon_path|add:"1-review.svg" %}
 {% elif "ready" in section_name %}
   {% include icon_path|add:"2-get-ready.svg" %}
-{% elif "write your" in section_name or "prepare your application" in section_name %}
+{% elif "write your" in section_name or "prepare your application" in section_name or "build your application" in section_name %}
   {% include icon_path|add:"3-write.svg" %}
 {% elif "learn about review" in section_name or "understand review" in section_name %}
   {% include icon_path|add:"4-learn.svg" %}


### PR DESCRIPTION
## Summary

This is a very small update: we now use a pencil icon on the ToC and Section page for "Build your application"

Essentially, some of the step names have changed and now we need to update our icon macro.

### Screenshot 

| before | after |
|--------|-------|
|  Magnifying glass icon is wrong here (Step 1 already uses it)      |    Pencil icon is good ✏️    |
|    <img width="374" height="350" alt="Screenshot 2025-12-16 at 18 26 21" src="https://github.com/user-attachments/assets/d881453a-c965-457b-a337-b14ba6fc0cfa" />    |    <img width="374" height="350" alt="Screenshot 2025-12-16 at 18 25 39" src="https://github.com/user-attachments/assets/5f5b04a7-5689-4947-986a-d897080a537d" />   |

