### PR TITLE
Fix for auto-bolding rules in callout box content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning since version 1.0.0.
 - Fixed how instructions are associated with subsections when creating a ContentGuideInstance
 - Explicitly mark "Style Bold" text as bold on import
 - Don't duplicate sections and subsections by repeatedly confirming a draft NOFO
+- Fix how callout box phrases with a colon ":" are bolded if they already have bold styling
 
 ## [3.23.0] - 2025-12-10
 

--- a/nofos/nofos/tests_nofos/test_templatetags.py
+++ b/nofos/nofos/tests_nofos/test_templatetags.py
@@ -1220,3 +1220,25 @@ class WrapTextBeforeColonInStrongTests(TestCase):
 
         expected_html = "<p><strong>: </strong><span></span></p>"
         self.assertEqual(str(paragraph), expected_html)
+
+    def test_strong_with_colon_already(self):
+        """Test a paragraph with a strong tag in a colon already."""
+        html = "<p><strong>Opportunity Name:</strong> NOFO 100</p>"
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        expected_html = "<p><strong>Opportunity Name:</strong> NOFO 100</p>"
+        self.assertEqual(str(paragraph), expected_html)
+
+    def test_strong_with_NO_colon_already(self):
+        """Test a paragraph with a strong tag in a colon already."""
+        html = "<p><strong>Opportunity</strong> Name: NOFO 100</p>"
+        soup = BeautifulSoup(html, "html.parser")
+        paragraph = soup.find("p")
+
+        wrap_text_before_colon_in_strong(paragraph, soup)
+
+        expected_html = "<p><strong><strong>Opportunity</strong> Name: </strong><span> NOFO 100</span></p>"
+        self.assertEqual(str(paragraph), expected_html)


### PR DESCRIPTION
## Summary

This is a very small PR that updates our `wrap_text_before_colon_in_strong` function which does more or less what it sounds like. It is now more robust and can handle strings that already have bold formatting.

### Screenshot

| source text | callout box before | callout box after |
|--------|-------|-------|
| different ways of formatting callout box text      |   2 & 4 are good. 1 & 3 are not good.     |   All are good.    |
|   <img width="410" height="211" alt="Screenshot 2025-12-25 at 00 06 43" src="https://github.com/user-attachments/assets/c7c8b689-ab7e-4269-8f58-5637c37b135e" />     | <img width="227" height="225" alt="Screenshot 2025-12-25 at 00 06 59" src="https://github.com/user-attachments/assets/f38a7315-7f75-4084-9270-a0ab0269e02e" />      | <img width="227" height="225" alt="Screenshot 2025-12-25 at 00 07 22" src="https://github.com/user-attachments/assets/d6ac1884-0b84-498f-90e1-f680c02c5aaa" />     |

### Details

We have some auto-formatting happening to the callout boxes, specifically for the "Key dates" and "Key facts" boxes, which usually have lines like:

- `Opportunity Name: NOFO 100`

When we see those, we bold everything from the start of the phrase until the first colon (also including the first colon).

So we would get this:

- `<strong>Opportunity Name:</strong><span> NOFO 100</span>`

However, if the string was already bolded, the logic would not actually find the colon and would end up bolding the whole paragraph.

So if we started with this text:

- `**Opportunity Name:** NOFO 100`

We would get this:

- `<strong><strong>Opportunity Name:</strong> NOFO 100</strong><span></span>`

That is very wrong obviously so we don't want to be doing that.

The new logic will find colons that are in other tags and do a better job of wrapping `<strong>` tags.