### PR TITLE
Look for 'insert' in subsection body and instructions to determine if subsection is edit_mode = 'full'

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -433,8 +433,10 @@ def _build_document(document, sections, SectionModel, SubsectionModel):
                         key: var.to_dict() for key, var in variables.items()
                     }
                     subsection_obj.variables = json.dumps(serializable_variables)
-                # If no variables, and subsection is optional or the word "insert" is present in the
-                # subsection body or instructions, then edit_mode = "full"
+                # Subsection edit_mode = "full" if no variables, and:
+                #   - subsection is optional OR
+                #   - the word "insert" is present in the subsection body OR
+                #   - the word "insert" is present in the instructions
                 elif (
                     subsection_obj.optional
                     or body_contains_insert


### PR DESCRIPTION
closes #616 

Updates content guide ingestion to check for the presence of the word 'insert' in the subsections body and instructions, and uses its presence to flag a subsection as edit_mode = "full" if there are not any variables