### PR TITLE
Allow the 035 RFA NOFO to display agency and subagency on cover

### DIFF
--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -87,7 +87,7 @@
             <p>{{ nofo.agency }}</p>
             <p>{% if nofo.subagency %}{{ nofo.subagency }}{% endif %}</p>
           {% else %}
-            {% if nofo.number == 'RFA-CK-26-036' %}
+            {% if nofo.number == 'RFA-CK-26-036' or nofo.number == 'RFA-CK-26-035' %}
               <p>{{ nofo.agency }}</p>
               {% if nofo.subagency %}
                 <p>{{ nofo.subagency }}</p>


### PR DESCRIPTION
## Summary

Extremely small PR to add the agency and subagency on the cover page for `RFA-CK-26-035`.

This is obviously not a sustainable way to do this but we don't know enough yet how widely to apply this rule.