### PR TITLE
Bring preview more into alignment with doc templates

### DIFF
--- a/nofos/composer/templates/composer/composer_preview.html
+++ b/nofos/composer/templates/composer/composer_preview.html
@@ -112,17 +112,21 @@
               {% for subsection in section.ordered_subsections %}
                 {# skip "hidden" subsections #}
                 {% if not subsection.hidden %}
-                  {% with tag=subsection.tag content=subsection.name id=subsection.html_id class=subsection.html_class %}
-                    {% include "includes/heading.html" with tag=tag content=content id=id class=class only %}
-                  {% endwith %}
+                <div class="margin-top-4 margin-bottom-2">
                   {% if subsection.instructions %}
                     <div class="bg-primary-lighter padding-2">
                       {{ subsection.instructions|safe_markdown|add_classes_to_paragraphs|add_classes_to_lists|convert_paragraphs_to_hrs }}
                     </div>
                   {% endif %}
-                  <div class="styled-subsection-body{% if subsection.edit_mode == 'variables' %}--variables{% elif subsection.edit_mode == 'full' %}--full{% endif %}">
-                    {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|replace_variable_keys_with_values:subsection.get_variables }}
+                  <div class="{% if subsection.callout_box%}border margin-top-1 padding-x-2 padding-bottom-2 {%if not subsection.name %} padding-top-2{% endif %} {% endif %}">
+                    {% with tag=subsection.tag content=subsection.name id=subsection.html_id class=subsection.html_class %}
+                      {% include "includes/heading.html" with tag=tag content=content id=id class=class only %}
+                    {% endwith %}
+                    <div class="{% if not subsection.name and not subsection.callout_box %}margin-top-2{% endif %} styled-subsection-body{% if subsection.edit_mode == 'variables' %}--variables{% elif subsection.edit_mode == 'full' %}--full{% endif %}">
+                      {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|replace_variable_keys_with_values:subsection.get_variables }}
+                    </div>
                   </div>
+                </div>
                 {% endif %}
               {% endfor %}
             </div>


### PR DESCRIPTION
|  | before | after | 
| -- | -- | -- |
| composer | <img width="1198" height="876" alt="Screenshot 2026-01-22 154803" src="https://github.com/user-attachments/assets/db862510-6fc3-4671-bd48-01b9e3b6826b" /> | <img width="1138" height="816" alt="Screenshot 2026-01-22 154027" src="https://github.com/user-attachments/assets/87771d27-7336-4d48-a6ff-88dc583baaa7" /> |
| writer |  <img width="1180" height="868" alt="Screenshot 2026-01-22 154737" src="https://github.com/user-attachments/assets/4d38b04d-aff1-4826-9aa7-51cf15d4f64b" />| <img width="670" height="863" alt="Screenshot 2026-01-22 153944" src="https://github.com/user-attachments/assets/00111b8b-f940-4ff9-89ba-562b1b6f7c03" /> | 
