### PR TITLE
Fix: Unwrap strong/em tags surrounding images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Fix for no longer removing "bolded" images
+
 ## [3.25.0] - 2026-01-20
 
 ### Added

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1830,6 +1830,35 @@ def combine_consecutive_links(soup):
                 link.next_sibling.replace_with("")
 
 
+def unwrap_empty_elements(soup):
+    """
+    This function mutates the soup!
+
+    Unwraps empty or image-only span, strong, sup, a, and em tags from the BeautifulSoup `soup`.
+    """
+    elements = soup.find_all(["em", "span", "strong", "sup"])
+
+    for el in elements:
+        # Case 1: no text content
+        has_text = bool(el.get_text(strip=True))
+
+        # Case 2: contains images
+        has_img = el.find("img") is not None
+
+        # Case 3: any non-whitespace, non-img children?
+        meaningful_children = [
+            child
+            for child in el.contents
+            if getattr(child, "name", None)
+            and child.name != "img"
+            and child.get_text(strip=True)
+        ]
+
+        # Only formatting wrappers with no meaningful text
+        if not has_text and (has_img or not meaningful_children):
+            el.unwrap()
+
+
 def decompose_empty_tags(soup):
     """
     This function mutates the soup!
@@ -1859,19 +1888,6 @@ def decompose_empty_tags(soup):
     elements = soup.find_all(["li", "p"])
     for element in elements:
         _decompose_empty_elements(element)
-
-
-def unwrap_empty_elements(soup):
-    """
-    This function mutates the soup!
-
-    Unwraps empty span, strong, sup, a, and em tags from the BeautifulSoup `soup`.
-    """
-    elements = soup.find_all(
-        ["em", "span", "strong", "sup"], string=lambda t: not t or not t.strip()
-    )
-    for el in elements:
-        el.unwrap()
 
 
 def clean_table_cells(soup):

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -4358,6 +4358,43 @@ class UnwrapEmptyElementsTests(TestCase):
             str(soup), "<div> <strong>Text</strong><span>More text</span> </div>"
         )
 
+    def test_unwrap_strong_wrapping_image(self):
+        html = '<p><strong><img alt="example" src="img.png"></strong></p>'
+        soup = BeautifulSoup(html, "html.parser")
+        unwrap_empty_elements(soup)
+        self.assertEqual(
+            str(soup),
+            '<p><img alt="example" src="img.png"/></p>',
+        )
+
+    def test_unwrap_strong_em_wrapping_image(self):
+        html = '<p><strong><em><img alt="example" src="img.png"></em></strong></p>'
+        soup = BeautifulSoup(html, "html.parser")
+        unwrap_empty_elements(soup)
+        self.assertEqual(
+            str(soup),
+            '<p><img alt="example" src="img.png"/></p>',
+        )
+
+    def test_not_unwrap_em_with_image_and_text(self):
+        html = '<p><em><img alt="example" src="img.png"> Caption</em></p>'
+        soup = BeautifulSoup(html, "html.parser")
+        unwrap_empty_elements(soup)
+        # same as html but with a backslash "/" in img tag
+        self.assertEqual(
+            str(soup),
+            '<p><em><img alt="example" src="img.png"/> Caption</em></p>',
+        )
+
+    def test_unwrap_span_wrapping_image(self):
+        html = '<p><span><img alt="example" src="img.png"></span></p>'
+        soup = BeautifulSoup(html, "html.parser")
+        unwrap_empty_elements(soup)
+        self.assertEqual(
+            str(soup),
+            '<p><img alt="example" src="img.png"/></p>',
+        )
+
 
 class TestRemoveGoogleTrackingInfoFromLinks(TestCase):
     def test_remove_tracking_from_google_links(self):


### PR DESCRIPTION
## Summary

This PR adds a fix for no longer removing "bolded" images.

## Details

| before | after |
|--------|-------|
| image does NOT show up       |  image is there 😅     |
|   <img width="1006" height="631" alt="Screenshot 2026-02-03 at 13 40 44" src="https://github.com/user-attachments/assets/1013ef5c-180b-439a-920d-7ae35d95cda6" />     |     <img width="1006" height="631" alt="Screenshot 2026-02-03 at 13 40 31" src="https://github.com/user-attachments/assets/97483028-b832-448d-81ff-4e5b15a68af7" />  |



The previous behaviour of the `unwrap_empty_elements` was to leave in place `<strong>` or `<em>` tags that were wrapping images, which means they would then get later removed by the `decompose_empty_tags` function.

So basically this kind of thing:

- `<p><strong><img /></strong></p>`
- `<p><strong><em><img /></em></strong></p>`

So we were seeing that when images were bold or italics or something (which does not change how they look, but it _is_ something you can do in Word), that would result in the image not importing correctly into the NOFO builder.

This PR updates the unwrapping logic to also unwrap strong tags etc that surround images, and adds tests to confirm behaviour.