### PR TITLE
Make it possible to add a subsection to the beginning of a section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Allow adding a new subsection as the first subsection in a NOFO
 - Add an export view for a ContentGuide (not a ContentGuideInstance)
 - Add export functionality to "Download" cells on composer index table
 
@@ -22,6 +23,7 @@ Versioning since version 1.0.0.
 ### Fixed
 
 - Fix the ASPR logo
+- Prevent adding subsections to NOFOs other than the one you are looking at
 - Remove unneeded margin under application date
 - Add titles for "export" views
 - Stronger sanitization for NOFO metadata on document import

--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -1489,6 +1489,32 @@ main .back-link a::before,
   scroll-margin-top: 64px;
 }
 
+.section_edit table.usa-table .nofo-edit-table--subsection--add-subsection {
+  padding: 0.15rem;
+  text-align: center;
+}
+
+.section_edit
+  table.usa-table
+  .nofo-edit-table--subsection--add-subsection
+  .usa-button--icon--table-stretch {
+  position: initial;
+  transform: none;
+  width: 100%;
+  box-shadow: none;
+}
+
+.section_edit
+  table.usa-table
+  .nofo-edit-table--subsection--add-subsection
+  .usa-button--icon--table-stretch:hover,
+.section_edit
+  table.usa-table
+  .nofo-edit-table--subsection--add-subsection
+  .usa-button--icon--table-stretch:focus {
+  background-color: var(--color--table-blue);
+}
+
 /* NOFO section_details add button */
 
 .section_edit .usa-button--add {

--- a/nofos/nofos/templates/nofos/section_detail.html
+++ b/nofos/nofos/templates/nofos/section_detail.html
@@ -88,6 +88,13 @@
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td class="nofo-edit-table--subsection--add-subsection" colspan="4">
+        <a class="usa-button usa-button--outline usa-button--light text-primary usa-button--icon--before usa-button--icon--usa-blue usa-button--icon--usa-blue--hover usa-button--add usa-button--icon--table-stretch" type="button" href="{% url 'nofos:subsection_create' section.nofo.id section.id %}?insert_order=1&return_to=section_detail">
+          Add subsection
+        </a>
+      </td>
+    </tr>
     {% for subsection in section.subsections.all|dictsort:"order" %}
     <tr>
       <th scope="row"

--- a/nofos/nofos/templates/nofos/section_detail.html
+++ b/nofos/nofos/templates/nofos/section_detail.html
@@ -12,6 +12,8 @@
 {% block body_class %}section_edit{% endblock %}
 
 {% block content %}
+{% include "includes/alerts.html" with messages=messages success_heading=success_heading error_heading=error_heading stick_to_bottom=True only %}
+
 <div class="back-link font-body-md margin-bottom-105">
   <a class="usa-button--icon--before usa-button--icon--usa-blue usa-button--arrow_back" href="{% url 'nofos:nofo_edit' nofo.id %}">Edit “{{ nofo|nofo_name }}”</a>
 </div>
@@ -116,7 +118,7 @@
           </a>
         </span>
 
-        <a class="usa-button usa-button--outline usa-button--light text-primary usa-button--icon--before usa-button--icon--usa-blue usa-button--icon--usa-blue--hover usa-button--add" type="button" href="{% url 'nofos:subsection_create' section.nofo.id subsection.section.id %}?prev_subsection={{ subsection.id }}&return_to=section_detail">
+        <a class="usa-button usa-button--outline usa-button--light text-primary usa-button--icon--before usa-button--icon--usa-blue usa-button--icon--usa-blue--hover usa-button--add" type="button" href="{% url 'nofos:subsection_create' section.nofo.id section.id %}?section_id={{ section.id }}&insert_order={{ subsection.order|add:"1" }}&prev_subsection_id={{ subsection.id }}&return_to=section_detail">
           Add subsection
         </a>
       </td>

--- a/nofos/nofos/templates/nofos/subsection_create.html
+++ b/nofos/nofos/templates/nofos/subsection_create.html
@@ -30,7 +30,7 @@
   <div class="previous-subsection-widget outline-box">
     <p class="outline-box--heading text-base-dark">{{ prev_subsection_with_tag.section.name }}</p>
     <p class="outline-box--content">
-      <a href="{% url 'nofos:subsection_edit' nofo.id prev_subsection_with_tag.section.id prev_subsection_with_tag.id %}" class="usa-link usa-link--external" target="blank" title="{{ prev_subsection_with_tag.name }} (Opens in a new tab)">
+      <a href="{% url 'nofos:subsection_edit' nofo.id prev_subsection_with_tag.section.id prev_subsection_with_tag.id %}" class="usa-link usa-link--external" target="_blank" title="{{ prev_subsection_with_tag.name }} (Opens in a new tab)">
         {{ prev_subsection_with_tag.name }}
         (<span class="small-caps">{{ prev_subsection_with_tag.tag }}</span>)
       </a>
@@ -42,8 +42,8 @@
 
   <form class="form" method="post">
     {% csrf_token %}
-    <input type="hidden" name="return_to" value="{{ return_to }}">
-    <input type="hidden" name="prev_subsection" value="{{ prev_subsection.id }}">
+    <input type="hidden" name="return_to" value="{{ return_to }}" />
+    <input type="hidden" name="prev_subsection" value="{{ prev_subsection.id }}" />
 
     <fieldset class="usa-fieldset">
 
@@ -60,6 +60,7 @@
         {% with id="name" label=form.name.label value=form.name.value hint=form.name.help_text error=form.name.errors.0 input_type=form.name|input_type %}
           {% include "includes/_text_input.html" with id=id label=label value=value error=error input_type=input_type safe_hint=True only %}
         {% endwith %}
+      </div>
 
       <!-- tag -->
       <div class="form-group width-mobile">
@@ -80,7 +81,7 @@
                     border-secondary-dark
                   {% endif %}
               "
-        {% endwhitespaceless %} class="usa-select border-2px" name="tag" id="tag" aria-describedby="tag--hint-1">
+        {% endwhitespaceless %} name="tag" id="tag" aria-describedby="tag--hint-1">
           <option value="">---------</option>
           <option value="h3" {% if form.tag.value == 'h3' %}selected{% endif %}>Heading 3</option>
           <option value="h4" {% if form.tag.value == 'h4' %}selected{% endif %}>Heading 4</option>
@@ -93,7 +94,7 @@
       <!-- callout_box -->
       <div class="form-group margin-top-4 width-mobile">
         <div class="usa-checkbox">
-          <input class="usa-checkbox__input usa-checkbox__input--tile" id="callout_box" type="checkbox" name="callout_box">
+          <input class="usa-checkbox__input usa-checkbox__input--tile" id="callout_box" type="checkbox" name="callout_box" {% if form.callout_box.value %}checked{% endif %}>
           <label class="usa-checkbox__label" for="callout_box">Is callout box?
             <span class="usa-checkbox__label-description">Callout boxes <span aria-hidden="true">(📦)</span> use an accent color to call attention to important content.</span>
           </label>

--- a/nofos/nofos/templates/nofos/subsection_create.html
+++ b/nofos/nofos/templates/nofos/subsection_create.html
@@ -23,7 +23,19 @@
     </div>
   {% endwith %}
 
-  <p>Create a new subsection after {% if prev_subsection.name %}“{{ prev_subsection.name }}”{% else %}(#{{ prev_subsection.order }}){% endif %} in “{{ prev_subsection.section.name }}”.</p>
+  {% if prev_subsection %}
+    <p>
+      Create a new subsection after
+      {% if prev_subsection.name %}
+        “{{ prev_subsection.name }}”
+      {% else %}
+        (#{{ prev_subsection.order }})
+      {% endif %}
+      in “{{ section.name }}”.
+    </p>
+  {% else %}
+    <p>Create a new subsection at the top of “{{ section.name }}”.</p>
+  {% endif %}
 
   {% if prev_subsection_with_tag %}
   <h2 class="font-serif-md margin-top-4">Previous subsection{% if prev_subsection_with_tag.name != prev_subsection.name %} with a heading{% endif %}</h2>
@@ -42,8 +54,11 @@
 
   <form class="form" method="post">
     {% csrf_token %}
-    <input type="hidden" name="return_to" value="{{ return_to }}" />
-    <input type="hidden" name="prev_subsection" value="{{ prev_subsection.id }}" />
+    <input type="hidden" name="return_to" value="{{ return_to }}">
+    <input type="hidden" name="insert_order" value="{{ insert_order }}">
+    {% if prev_subsection %}
+      <input type="hidden" name="prev_subsection" value="{{ prev_subsection.id }}">
+    {% endif %}
 
     <fieldset class="usa-fieldset">
 

--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -189,7 +189,7 @@
     <div class="usa-accordion__content usa-prose">
       <ul class="usa-list usa-list--unstyled">
         <li>
-          <a class="usa-button usa-button--green" href="{% url 'nofos:subsection_create' nofo.id subsection.section.id %}?prev_subsection={{ subsection.id }}&return_to=subsection_edit">
+          <a class="usa-button usa-button--green" href="{% url 'nofos:subsection_create' nofo.id subsection.section.id %}?insert_order={{ subsection.order|add:"1" }}&prev_subsection_id={{ subsection.id }}&return_to=subsection_edit">
             Add subsection
           </a> — add a new subsection after this one
         </li>

--- a/nofos/nofos/tests_nofos/test_subsection_create.py
+++ b/nofos/nofos/tests_nofos/test_subsection_create.py
@@ -20,82 +20,208 @@ class NofoSubsectionCreateViewTests(TestCase):
         self.client.login(email="test@example.com", password="testpass123")
 
         self.nofo = Nofo.objects.create(
-            title="Test NOFO", short_name="test", group="bloom", opdiv="ACF"
+            title="Test NOFO",
+            short_name="test",
+            group="bloom",
+            opdiv="ACF",
         )
-        self.section = Section.objects.create(nofo=self.nofo, name="Section", order=1)
+
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Section",
+            order=1,
+        )
 
         self.sub_with_tag = Subsection.objects.create(
-            section=self.section, name="Subsection 1", order=1, tag="h2"
+            section=self.section,
+            name="Subsection 1",
+            order=1,
+            tag="h2",
         )
         # subsection 2 does not have a name or a tag
         self.sub_no_tag = Subsection.objects.create(
-            section=self.section, order=2, body="Hello, I am subsection 2"
+            section=self.section,
+            order=2,
+            body="Hello, I am subsection 2",
         )
 
-    def test_missing_prev_subsection_returns_400(self):
-        url = reverse(
+        self.url = reverse(
             "nofos:subsection_create",
             kwargs={
                 "pk": self.nofo.id,
-                "section_pk": self.nofo.sections.first().id,
+                "section_pk": self.section.id,
             },
         )
 
+    def test_missing_insert_order_returns_400(self):
         with self.assertLogs("django.request", level="WARNING"):
-            response = self.client.get(url)
+            response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "No insert order provided.", status_code=400)
+
+    def test_non_integer_insert_order_returns_400(self):
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.get(f"{self.url}?insert_order=abc")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "Invalid insert order.", status_code=400)
+
+    def test_zero_insert_order_returns_400(self):
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.get(f"{self.url}?insert_order=0")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response,
+            "Insert order must be 1 or greater.",
+            status_code=400,
+        )
+
+    def test_negative_insert_order_returns_400(self):
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.get(f"{self.url}?insert_order=-5")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response,
+            "Insert order must be 1 or greater.",
+            status_code=400,
+        )
 
     def test_valid_get_request_renders_template(self):
-        url = reverse(
-            "nofos:subsection_create",
-            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
+        response = self.client.get(
+            f"{self.url}?insert_order=2&prev_subsection_id={self.sub_with_tag.id}"
         )
-        url += f"?prev_subsection={self.sub_with_tag.id}"
-        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "nofos/subsection_create.html")
 
     def test_finds_previous_subsection(self):
-        url = reverse(
-            "nofos:subsection_create",
-            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
+        response = self.client.get(
+            f"{self.url}?insert_order=2&prev_subsection_id={self.sub_with_tag.id}"
         )
-        url += f"?prev_subsection={self.sub_with_tag.id}"
-        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        # includes "with a heading"
         self.assertNotContains(response, "Previous subsection with a heading")
-        self.assertContains(response, "Subsection 1")  # Subsection 1 is previous
+        self.assertContains(response, "Subsection 1")
 
     def test_finds_previous_subsection_with_tag(self):
-        url = reverse(
-            "nofos:subsection_create",
-            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
+        response = self.client.get(
+            f"{self.url}?insert_order=3&prev_subsection_id={self.sub_no_tag.id}"
         )
-        url += f"?prev_subsection={self.sub_no_tag.id}"
-        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        # includes "with a heading"
         self.assertContains(response, "Previous subsection with a heading")
-        self.assertContains(response, "Subsection 1")  # Subsection 1 is previous
+        self.assertContains(response, "Subsection 1")
 
     def test_successfully_creates_subsection(self):
-        url = reverse(
-            "nofos:subsection_create",
-            kwargs={"pk": self.nofo.id, "section_pk": self.nofo.sections.first().id},
-        )
-        url += f"?prev_subsection={self.sub_with_tag.id}"
         response = self.client.post(
-            url,
+            f"{self.url}?insert_order=2&prev_subsection_id={self.sub_with_tag.id}",
             {
                 "name": "New Subsection",
                 "tag": "h3",
                 "body": "Test content",
                 "html_class": "",
+                "insert_order": "2",
+                "prev_subsection_id": str(self.sub_with_tag.id),
             },
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Created new subsection:")
         self.assertEqual(Subsection.objects.filter(section=self.section).count(), 3)
+
+        new_subsection = Subsection.objects.get(name="New Subsection")
+        self.assertEqual(new_subsection.order, 2)
+
+    def test_successfully_creates_first_subsection_at_order_1(self):
+        # Clear existing subsections so we can test the first position cleanly
+        self.section.subsections.all().delete()
+
+        response = self.client.post(
+            f"{self.url}?insert_order=1",
+            {
+                "name": "First Subsection",
+                "tag": "h3",
+                "body": "First content",
+                "html_class": "",
+                "insert_order": "1",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        new_subsection = Subsection.objects.get(name="First Subsection")
+        self.assertEqual(new_subsection.order, 1)
+
+    def test_successfully_creates_subsection_at_large_order(self):
+        response = self.client.post(
+            f"{self.url}?insert_order=1000",
+            {
+                "name": "Late Subsection",
+                "tag": "h3",
+                "body": "Late content",
+                "html_class": "",
+                "insert_order": "1000",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        new_subsection = Subsection.objects.get(name="Late Subsection")
+        self.assertEqual(new_subsection.order, 1000)
+
+    def test_inserting_at_existing_order_pushes_existing_subsections_forward(self):
+        response = self.client.post(
+            f"{self.url}?insert_order=2",
+            {
+                "name": "Inserted Subsection",
+                "tag": "h3",
+                "body": "Inserted content",
+                "html_class": "",
+                "insert_order": "2",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        inserted = Subsection.objects.get(name="Inserted Subsection")
+        original_second = Subsection.objects.get(pk=self.sub_no_tag.pk)
+
+        self.assertEqual(inserted.order, 2)
+        self.assertGreater(original_second.order, 2)
+
+    def test_sparse_orders_are_supported(self):
+        self.section.subsections.all().delete()
+
+        first = Subsection.objects.create(
+            section=self.section,
+            name="First",
+            order=1,
+            tag="h2",
+        )
+        second = Subsection.objects.create(
+            section=self.section,
+            name="Second",
+            order=100,
+            tag="h3",
+        )
+
+        response = self.client.post(
+            f"{self.url}?insert_order=50&prev_subsection_id={first.id}",
+            {
+                "name": "Middle",
+                "tag": "h4",
+                "body": "Middle content",
+                "html_class": "",
+                "insert_order": "50",
+                "prev_subsection_id": str(first.id),
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        middle = Subsection.objects.get(name="Middle")
+        second.refresh_from_db()
+
+        self.assertEqual(middle.order, 50)
+        # All future subsection orders are bumped by 1
+        self.assertEqual(second.order, 101)

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1898,7 +1898,11 @@ class NofoSubsectionCreateView(
             return HttpResponseBadRequest("No subsection provided.")
 
         # Fetch previous subsection
-        self.prev_subsection = get_object_or_404(Subsection, pk=self.prev_subsection_id)
+        self.prev_subsection = get_object_or_404(
+            Subsection,
+            pk=self.prev_subsection_id,
+            section__nofo=self.nofo,
+        )
 
         # loop until you find the next previous subsection with a tag
         self.prev_subsection_with_tag = self.prev_subsection

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1799,6 +1799,8 @@ class NofoSectionDetailView(GroupAccessObjectMixin, DetailView):
         context = super().get_context_data(**kwargs)
         context["section"] = self.object
         context["nofo"] = self.nofo
+        context["error_heading"] = self.request.session.pop("error_heading", "Error")
+        context["success_heading"] = self.request.session.pop("success_heading", "")
         return context
 
     def get_object(self):
@@ -1887,38 +1889,59 @@ class NofoSubsectionCreateView(
 
     def dispatch(self, request, *args, **kwargs):
         self.nofo_id = kwargs.get("pk")
+        self.section_pk = kwargs.get("section_pk")
         self.nofo = get_object_or_404(Nofo, pk=self.nofo_id)
         self.return_to = self.get_return_to()
 
-        # Check if prev_subsection is provided
-        self.prev_subsection_id = self.request.GET.get(
-            "prev_subsection"
-        ) or self.request.POST.get("prev_subsection")
-        if not self.prev_subsection_id:
-            return HttpResponseBadRequest("No subsection provided.")
-
-        # Fetch previous subsection
-        self.prev_subsection = get_object_or_404(
-            Subsection,
-            pk=self.prev_subsection_id,
-            section__nofo=self.nofo,
+        self.section = get_object_or_404(
+            Section,
+            pk=self.section_pk,
+            nofo=self.nofo,
         )
 
-        # loop until you find the next previous subsection with a tag
-        self.prev_subsection_with_tag = self.prev_subsection
-        while (
-            self.prev_subsection_with_tag is not None
-            and not self.prev_subsection_with_tag.tag
-        ):
-            self.prev_subsection_with_tag = (
-                self.prev_subsection_with_tag.get_previous_subsection()
+        self.insert_order = request.POST.get("insert_order") or request.GET.get(
+            "insert_order"
+        )
+
+        if self.insert_order is None:
+            return HttpResponseBadRequest("No insert order provided.")
+
+        try:
+            self.insert_order = int(self.insert_order)
+        except (TypeError, ValueError):
+            return HttpResponseBadRequest("Invalid insert order.")
+
+        if self.insert_order < 1:
+            return HttpResponseBadRequest("Insert order must be 1 or greater.")
+
+        # Optional: only for UI context / copy
+        self.prev_subsection_id = request.POST.get(
+            "prev_subsection_id"
+        ) or request.GET.get("prev_subsection_id")
+        self.prev_subsection = None
+        self.prev_subsection_with_tag = None
+
+        if self.prev_subsection_id:
+            self.prev_subsection = get_object_or_404(
+                Subsection,
+                pk=self.prev_subsection_id,
+                section=self.section,
             )
+
+            self.prev_subsection_with_tag = self.prev_subsection
+            while (
+                self.prev_subsection_with_tag is not None
+                and not self.prev_subsection_with_tag.tag
+            ):
+                self.prev_subsection_with_tag = (
+                    self.prev_subsection_with_tag.get_previous_subsection()
+                )
 
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
-        section = self.prev_subsection.section
-        order = self.prev_subsection.order + 1
+        section = self.section
+        order = self.insert_order
 
         # create a gap in the "order" count to insert this new subsection
         section.insert_order_space(order)
@@ -1931,6 +1954,8 @@ class NofoSubsectionCreateView(
         )
 
         response = super().form_valid(form)
+
+        self.request.session["success_heading"] = "New subsection created"
 
         messages.success(
             self.request,
@@ -1948,7 +1973,7 @@ class NofoSubsectionCreateView(
                 "nofos:section_detail",
                 kwargs={
                     "pk": self.nofo.id,
-                    "section_pk": self.prev_subsection.section.id,
+                    "section_pk": self.section.id,
                 },
             )
         else:
@@ -1962,26 +1987,31 @@ class NofoSubsectionCreateView(
                 "nofos:section_detail",
                 kwargs={
                     "pk": self.nofo.id,
-                    "section_pk": self.prev_subsection.section.id,
+                    "section_pk": self.section.id,
                 },
             )
-            if self.prev_subsection.html_id:
+            if self.prev_subsection and self.prev_subsection.html_id:
                 return "{}#{}".format(url, self.prev_subsection.html_id)
             return url
 
-        return reverse_lazy(
-            "nofos:subsection_edit",
-            kwargs={
-                "pk": self.nofo.id,
-                "section_pk": self.prev_subsection.section.id,
-                "subsection_pk": self.prev_subsection.id,
-            },
-        )
+        if self.prev_subsection:
+            return reverse_lazy(
+                "nofos:subsection_edit",
+                kwargs={
+                    "pk": self.nofo.id,
+                    "section_pk": self.section.id,
+                    "subsection_pk": self.prev_subsection.id,
+                },
+            )
+
+        return reverse_lazy("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["subsection"] = self.object
         context["nofo"] = self.nofo
+        context["section"] = self.section
+        context["insert_order"] = self.insert_order
         context["prev_subsection"] = self.prev_subsection
         context["prev_subsection_with_tag"] = self.prev_subsection_with_tag
         context["cancel_url"] = self.get_cancel_url()


### PR DESCRIPTION
## Summary

This PR makes it possible to use the UI to add a subsection to the beginning of a section.

### Screenshot 

| before | after |
|--------|-------|
|   no way to add a new subsection before this one     |    added a new full-width "add" button for new subsections at the beginning of a subsection   |
|   <img width="1063" height="621" alt="Screenshot 2026-04-14 at 13 58 22" src="https://github.com/user-attachments/assets/7140654c-00d3-4f66-b0fb-3e3a59885e55" />     |    <img width="1063" height="621" alt="Screenshot 2026-04-14 at 13 57 59" src="https://github.com/user-attachments/assets/b54ef63a-ba7a-43e9-a7af-48dd629f9553" />   |



### Details  

Not being able to add a subsection at the beginning of a section has long been a weird implementation detail of the NOFO Builder.

The reason for this is that I implemented it with logic to use the previous subsection ID to decide where the new subsection should go. This works generally okay, but if there _isn't_ a previous subsection then there was no way to do it.

This PR changes how this logic is implemented so that new subsections are added in by passing in an `order` variable, rather than the `previous_subsection_id` variable. Now, we can just manually set the order if we need to, or we can use the "order + 1" of the previous subsection if we want to put it behind a particular subsection.

