### PR TITLE
Add a "Using this guide" page for HRSA's content guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning since version 1.0.0.
 
 ### Added
 
+- Add a "Using this Guide" variant of the BYB page for HRSA's content guide
+
 ### Changed
 
 ### Fixed

--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -1243,3 +1243,39 @@ https://www.smashingmagazine.com/2015/01/designing-for-print-with-css/#footnotes
 .section--tables-full-width table {
   margin-top: 10px;
 }
+
+/* HRSA application guide */
+
+.hrsa-application-guide .nofo--cover-page--title--subheading-intro,
+.hrsa-application-guide
+  .nofo--cover-page--header--intro
+  .nofo--cover-page--header--nofo,
+.hrsa-application-guide
+  .nofo--cover-page--header--intro
+  .nofo--cover-page--header--app-date--label {
+  display: none;
+}
+
+.hrsa-application-guide
+  .nofo--cover-page--header
+  .nofo--cover-page--header--intro
+  span:last-of-type {
+  font-size: 16pt;
+  font-weight: 500;
+}
+
+.hrsa-application-guide p.with-box {
+  border: 1px solid var(--color--dark-blue);
+  border-radius: 2px;
+  padding: 2px 5px;
+}
+
+.hrsa-application-guide
+  .before-you-begin--using-this-guide
+  .before-you-begin--using-this-guide--heading-red {
+  font-size: 20pt;
+  font-weight: 600;
+  margin-top: 15px;
+  line-height: 1.4;
+  color: #940200;
+}

--- a/nofos/bloom_nofos/templates/includes/byb_page_guide.html
+++ b/nofos/bloom_nofos/templates/includes/byb_page_guide.html
@@ -1,0 +1,35 @@
+{% load split_char_and_remove %}
+
+<section id="section--before-you-begin" class="before-you-begin before-you-begin--using-this-guide">
+  <h2 id="section--before-you-begin--heading">Introduction</h2>
+  <div class="before-you-begin--content">
+    <p>The new How to Apply - Application Guide replaces the existing HRSA Standard and Research & Related (R&R) Application Guides, merging them into one, easy-to-navigate document.</p>
+
+    <p>Key improvements designed to better synchronize the Guide with HRSA Notices of Funding Opportunity (NOFOs) include:</p>
+
+    <ul>
+      <li>Restructured Guide layout and contents to align with the NOFOs.</li>
+      <li>Removal of sections already covered in the NOFOs.</li>
+    </ul>
+
+    <h3>Using this Guide</h2>
+
+    <p>
+      The How to Apply - Application Guide is a companion to the NOFO. Both follow the same 6-step process ensuring applicants can easily access relevant guidance as they navigate each step of the application process. The Guide provides supplemental information to help you.
+    </p>
+
+    <ul>
+      <li>This Application Guide provides information that is consistent for single-tier HRSA NOFOs. It provides additional knowledge that you may want.</li>
+      <li>The NOFO provides information specific to the funding program.</li>
+    </ul>
+
+    <h3 class="before-you-begin--using-this-guide--heading-red">Updates to this guide</h3>
+    <p>
+      We periodically update this guide to align with statutory, regulatory, and policy changes. To see what’s changed, <a href="#appendix-c-changes-to-this-guide">see the guide updates in the appendix</a>.
+    </p>
+
+    <p class="with-box">
+      <strong>Learn more</strong> <a href="https://www.hrsa.gov/about" target="_blank">about HRSA</a> and <a href="https://data.hrsa.gov/" target="_blank">explore data and maps</a> on our health care programs.
+    </p>
+  </div>
+</section>

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -186,7 +186,11 @@
     {% spaceless %}
     <ol class="usa-list usa-list--unstyled">
 
-      {% if nofo.before_you_begin == 'full' or nofo.before_you_begin == 'sole_source' %}
+      {% if nofo.number == 'hrsa-application-guide' %}
+        <li class="toc--section-name toc--no-icon toc--before-you-begin">
+          <a href="#section--before-you-begin">Introduction</a>
+        </li>
+      {% elif nofo.before_you_begin == 'full' or nofo.before_you_begin == 'sole_source' %}
         <li class="toc--section-name toc--no-icon toc--before-you-begin">
           <a href="#section--before-you-begin">Before you begin</a>
         </li>
@@ -225,10 +229,13 @@
   </section>
 
   <!-- BEFORE YOU BEGIN PAGE -->
-  {% if nofo.before_you_begin != 'none' %}
+  {% if nofo.number == 'hrsa-application-guide' %}
+    {% include "includes/byb_page_guide.html" %}
+  {% elif nofo.before_you_begin != 'none' %}
     {% include "includes/byb_page.html" with nofo=nofo step_2_section=step_2_section only %}
   {% endif %}
 
+  <!-- NOFO CONTENT -->
   {% for section in nofo.sections.all|dictsort:"order" %}
     <section id="section--{{ section.html_id }}" class="section section--{{ forloop.counter }} {% if forloop.counter > 7 %}section--appendix {% endif %}section--{{ section.html_id }}{% if section.html_class %} {{ section.html_class }}{% endif %}{% if not section.has_section_page %} section--no-section-page{% endif %}">
       <!-- SECTION TITLE PAGE -->


### PR DESCRIPTION
## Summary

This PR introduces a variant of the "Before you Begin" page that is just for one document: the HRSA application guide.

### Screenshots

| before | after |
|--------|-------|
|  regular "Before you begin" page     |   New "Using this guide" page for HRSA application guide    |
|    <img width="806" height="747" alt="Screenshot 2026-04-17 at 12 29 58" src="https://github.com/user-attachments/assets/9fe8cece-c73f-49c1-b391-f2397a72bc97" />    |      <img width="806" height="747" alt="Screenshot 2026-04-17 at 12 29 02" src="https://github.com/user-attachments/assets/cbaf6b68-b6f0-48ba-adf5-7219021eb6b2" /> |
 
### Details

The HRSA application guide is not a NOFO, but it is a document that is referred to in a bunch of NOFOs. Because it is not a NOFO, it doesn't need a Before you Begin page, and in the Word doc there is this other intro about how to use the guide. 

What I have done is to add this new page in that is triggered by the `nofo.number`. If you have the right one, you get this new introduction page, not the ByB one that is in all the other NOFOs. Note that this PR does not use the "byb_page" variable because this is a one-off change and I didn't want to introduce a new DB value for this.

