### PR TITLE
Avoid double-adding strong tags in Key Facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning since version 1.0.0.
 
 ### Fixed
 
+- Don't double up on strong tags in callout boxes
+
 ## [3.30.0] - 2026-04-15
 
 ### Added

--- a/nofos/nofos/templatetags/utils/__init__.py
+++ b/nofos/nofos/templatetags/utils/__init__.py
@@ -426,6 +426,10 @@ def truncate_anchor_links(html_string):
 
 
 def wrap_text_before_colon_in_strong(p, soup):
+    # return early if we find an existing strong tag
+    if p.find("strong"):
+        return p
+
     def _first_colon_in_text_node(p):
         for node in p.contents:
             if isinstance(node, NavigableString) and ":" in node:

--- a/nofos/nofos/tests_nofos/test_templatetags.py
+++ b/nofos/nofos/tests_nofos/test_templatetags.py
@@ -1282,5 +1282,5 @@ class WrapTextBeforeColonInStrongTests(TestCase):
 
         wrap_text_before_colon_in_strong(paragraph, soup)
 
-        expected_html = "<p><strong><strong>Opportunity</strong> Name: </strong><span> NOFO 100</span></p>"
+        expected_html = "<p><strong>Opportunity</strong> Name: NOFO 100</p>"
         self.assertEqual(str(paragraph), expected_html)


### PR DESCRIPTION
## Summary

This PR fixes a bug where sometimes we would re-wrap a sentence in a `<strong>` tag even if it already had a `<strong>` tag.

### Screenshots 

| before | after |
|--------|-------|
|  Unwanted bolding of half of the opportunity name      |   Only the lead-in (`Opportunity name:`) is bolded    |
|   <img width="236" height="294" alt="Screenshot 2026-04-28 at 13 31 44" src="https://github.com/user-attachments/assets/63841a72-ec1d-40ef-af74-309503c89c1c" />     |   <img width="236" height="294" alt="Screenshot 2026-04-28 at 13 31 05" src="https://github.com/user-attachments/assets/9eafed75-e5b4-4e86-bb6a-060f5396f821" />    |




### Details

The logic we had would sometimes add 2 strong tags if it found a colon outside of a `<strong>` tag. This becomes an issue when the name of the grant has a colon in it. 

For example:

- `<p><strong>Name:</strong> HRSA grant: The best grant</p>`

would become

- `<p><strong><strong>Name:</strong> HRSA grant:</strong> The best grant</p>`

So now we added a simple rule to return early if there is already a strong tag in the paragraph.