### PR TITLE
Change subheading on eRA ByB page to "eRA Commons Registration"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- The ByB page eRA variant now always says "eRA Commons Registration"
+
 ### Fixed
 
 ## [3.31.0] - 2026-04-28

--- a/nofos/bloom_nofos/templates/includes/byb_page.html
+++ b/nofos/bloom_nofos/templates/includes/byb_page.html
@@ -41,7 +41,7 @@
 
     {% if nofo.before_you_begin == 'era' %}
       <!-- eRA.NIH.gov registration section moved above Apply by the application due date -->
-      <p class="section--before-you-begin--psuedo-header">{% if nofo.number == 'PAR-26-032' %}eRA Commons registration{% else %}eRA.NIH.gov registration{% endif %}</p>
+      <p class="section--before-you-begin--psuedo-header">eRA Commons registration</p>
       <p>Once an organization has established its unique organization identifier, organizations can <a href="https://grants.nih.gov/grants/guide/url_redirect.htm?id=11123" target="_blank">register with eRA Commons</a> in tandem with completing Grants.gov registration. You must have all registrations in place at the time of submission. eRA Commons requires organizations to identify at least one Signing Official (SO) and at least one Program Director/Principal Investigator (PD/PI) account in order to submit an application.</p>
       {% if step_2_section %}
         <a href="#{{ step_2_section.html_id }}">See Step 2: Get Ready to Apply</a>


### PR DESCRIPTION
## Summary

This PR makes sure the ByB page eRA variant always says "eRA Commons Registration"

Before: `eRA.NIH.giv registration`
Now: `eRA Commons registration`

This is a Jana-approved change