### PR TITLE
Remove curl from the final Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,10 @@ RUN poetry run python nofos/manage.py collectstatic --noinput --verbosity 0
 
 # FINAL CLEANUP: Remove ALL pip 25.2 artifacts before copying to final stage
 USER root
-RUN find / -name "*pip-25.2*" -type f -delete 2>/dev/null || true && \
+RUN apt-get purge -y --auto-remove curl && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  find / -name "*pip-25.2*" -type f -delete 2>/dev/null || true && \
   find / -path "*/pip-25.2*.dist-info" -type d -exec rm -rf {} + 2>/dev/null || true && \
   echo "Final pip artifact scan:" && \
   find / -name "*pip-25.2*" 2>/dev/null || echo "No pip 25.2 artifacts found"


### PR DESCRIPTION
## Summary

This is a very small PR that removes the `curl` package from the Dockerfile 

We use curl to download poetry when we first create the Dockerfile, but then it is not used again or relevant to the application later.

It is also causing a vulnerability alert in our container scan so if we don't need it, we should pitch it out.