### PR TITLE
Update BYB eRA page deadline time to 5:00 p.m. local time

### DIFF
--- a/nofos/bloom_nofos/templates/includes/byb_page.html
+++ b/nofos/bloom_nofos/templates/includes/byb_page.html
@@ -59,7 +59,7 @@
       {% endfor %}
       </ul>
     {% else %}
-      <p>Applications are due by {% if nofo.number == 'PAR-26-032' %}5:00 p.m. local time{% else %}11:59 p.m. Eastern Time{% endif %} on {{ nofo.application_deadline|split_char_and_remove:"-" }}.</p>
+      <p>Applications are due by {% if nofo.number == 'PAR-26-032' %}5:00 p.m. local time{% else %}5:00 p.m. local time{% endif %} on {{ nofo.application_deadline|split_char_and_remove:"-" }}.</p>
     {% endif %}
 
     <div class="callout-box callout-box--icon callout-box--keyboard">


### PR DESCRIPTION
## Summary
- In `byb_page.html` (the BYB page with the eRA Commons template), changes the application deadline time from \"11:59 p.m. Eastern Time\" to \"5:00 p.m. local time\"

## Test plan
- [ ] Verify the BYB page renders \"Applications are due by 5:00 p.m. local time on [date].\" for all NOFOs using this template

🤖 Generated with [Claude Code](https://claude.com/claude-code)