### PR TITLE
Revert deadline text to 11:59 p.m. Eastern Time for non-eRA BYB templates

### DIFF
--- a/nofos/bloom_nofos/templates/includes/byb_page.html
+++ b/nofos/bloom_nofos/templates/includes/byb_page.html
@@ -59,7 +59,7 @@
       {% endfor %}
       </ul>
     {% else %}
-      <p>Applications are due by {% if nofo.number == 'PAR-26-032' %}5:00 p.m. local time{% else %}5:00 p.m. local time{% endif %} on {{ nofo.application_deadline|split_char_and_remove:"-" }}.</p>
+      <p>Applications are due by {% if nofo.before_you_begin == 'era' %}5:00 p.m. local time{% else %}11:59 p.m. Eastern Time{% endif %} on {{ nofo.application_deadline|split_char_and_remove:"-" }}.</p>
     {% endif %}
 
     <div class="callout-box callout-box--icon callout-box--keyboard">


### PR DESCRIPTION
## Summary

- The deadline conditional in `byb_page.html` was keyed off a hardcoded NOFO number (`PAR-26-032`) rather than the BYB page variant type
- This change switches the condition to `nofo.before_you_begin == 'era'` so the correct text is applied by variant across all NOFOs:
  - **eRA variant** → `5:00 p.m. local time` (unchanged)
  - **Full BYB page, Sole Source Justification, No BYB Page** → `11:59 p.m. Eastern Time` (reverted)
- The eRA-specific BYB template is not touched

## Test plan

- [ ] Verify a NOFO with `before_you_begin = 'era'` shows "Applications are due by 5:00 p.m. local time on …"
- [ ] Verify a NOFO with `before_you_begin = 'full'` shows "Applications are due by 11:59 p.m. Eastern Time on …"
- [ ] Verify a NOFO with `before_you_begin = 'sole_source'` shows "Applications are due by 11:59 p.m. Eastern Time on …"

🤖 Generated with [Claude Code](https://claude.com/claude-code)