### PR TITLE
Remove "required" validation for some NOFO attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versioning since version 1.0.0.
 
 ### Changed
 
+- Remove "required" validation for these NOFO attributes:
+  - Agency
+  - Subagency
+  - Subagency 2
+  - Tagline
 - The ByB page eRA variant now always says "eRA Commons Registration"
 
 ### Fixed

--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -45,7 +45,7 @@ NofoImportTitleForm = create_nofo_form_class(
 )
 NofoTitleForm = create_nofo_form_class(["title"])
 NofoShortNameForm = create_nofo_form_class(["short_name"])
-NofoAgencyForm = create_nofo_form_class(["agency"])
+NofoAgencyForm = create_nofo_form_class(["agency"], not_required_labels=["Agency"])
 NofoApplicationDeadlineForm = create_nofo_form_class(["application_deadline"])
 NofoNumberForm = create_nofo_form_class(["number"])
 NofoGroupForm = create_nofo_form_class(["group"])
@@ -56,7 +56,9 @@ NofoSubagencyForm = create_nofo_form_class(
 NofoSubagency2Form = create_nofo_form_class(
     ["subagency2"], not_required_labels=["Subagency 2"]
 )
-NofoTaglineForm = create_nofo_form_class(["tagline"])
+NofoTaglineForm = create_nofo_form_class(
+    ["tagline"], not_required_labels=["NOFO tagline"]
+)
 NofoBeforeYouBeginForm = create_nofo_form_class(["before_you_begin"])
 
 


### PR DESCRIPTION
## Summary

Previously, I would enforce `required` on these fields for NOFO Builder users, but not superadmins. But now we are letting them be empty for all NOFOS:

- Agency
- Subagency
- Subagency 2
- Tagline