### PR TITLE
Update Dockerfile to clear vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 # CHANGED: add an alias so we can copy from this stage later
-FROM python:3.14-slim AS builder
+FROM python:3.14.5-slim-trixie AS builder
 
 # set work directory
 WORKDIR /app
 
-# Install system dependencies (Debian-based)
-RUN apt-get update && \
+# Update installed Debian packages first, then install build dependencies.
+RUN set -eux; \
+  apt-get update; \
+  apt-get upgrade -y; \
   apt-get install -y --no-install-recommends \
   build-essential \
   curl \
@@ -13,7 +15,9 @@ RUN apt-get update && \
   libffi-dev \
   libpq-dev \
   libsqlite3-0 \
-  && rm -rf /var/lib/apt/lists/*
+  ; \
+  apt-get clean; \
+  rm -rf /var/lib/apt/lists/*
 
 # Install Poetry and create user
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local python3 - && \


### PR DESCRIPTION
## Summary

This PR makes some changes to our Docker container to fix sole vulnerabilities flagged by Anchore.

[Here is what is being flagged](https://github.com/HHS/simpler-grants-gov/actions/runs/26101105131/job/76753128890):

```
NAME         INSTALLED        FIXED IN           TYPE  VULNERABILITY   SEVERITY  EPSS           RISK
libsystemd0  257.9-1~deb13u1  257.13-1~deb13u1   deb   https://github.com/advisories/GHSA-396h-m3pm-fpm5  Medium    < 0.1% (13th)  < 0.1
libudev1     257.9-1~deb13u1  257.13-1~deb13u1   deb   https://github.com/advisories/GHSA-396h-m3pm-fpm5  Medium    < 0.1% (13th)  < 0.1
libsystemd0  257.9-1~deb13u1  257.13-1~deb13u1   deb   CVE-2026-29111  Medium    < 0.1% (6th)   < 0.1
libudev1     257.9-1~deb13u1  257.13-1~deb13u1   deb   CVE-2026-29111  Medium    < 0.1% (6th)   < 0.1
libcap2      1:2.75-10+b8     1:2.75-10+deb13u1  deb   CVE-2026-4878   High      < 0.1% (1st)   < 0.1
libsystemd0  257.9-1~deb13u1  257.13-1~deb13u1   deb   https://github.com/advisories/GHSA-hc7r-6254-88w5  Medium    < 0.1% (1st)   < 0.1
libudev1     257.9-1~deb13u1  257.13-1~deb13u1   deb   https://github.com/advisories/GHSA-hc7r-6254-88w5  Medium    < 0.1% (1st)   < 0.1
libsystemd0  257.9-1~deb13u1  257.13-1~deb13u1   deb   CVE-2026-4105   Medium    < 0.1% (0th)   < 0.1
libudev1     257.9-1~deb13u1  257.13-1~deb13u1   deb   CVE-2026-4105   Medium    < 0.1% (0th)   < 0.1
sed          4.9-2            4.9-2+deb13u1      deb   https://github.com/advisories/GHSA-9r7w-j29g-xqx8   Low       < 0.1% (0th)   < 0.1
```

So let's hope this fixes it.
