### PR TITLE
docs: add DECISIONS.md with initial backlog entry

### DIFF
--- a/documentation/DECISIONS.md
+++ b/documentation/DECISIONS.md
@@ -1,0 +1,11 @@
+# Decision Log
+
+This file records significant architectural, product, and implementation decisions made on the NOFO Builder project. Entries are ordered newest-first.
+
+---
+
+## 2026-05-21 — Backlog OpDiv Admin multi-group assignment
+
+**Context:** A question was raised about whether OpDiv Admin users could be assigned to more than one OpDiv group (e.g., CDC DGHT and CDC DGHP). The two implementation paths identified were: (1) allowing users to belong to more than one group, or (2) introducing a parent-child group hierarchy — both considered complex. The Bloom group already provides all-or-nothing visibility across all users and NOFOs but offers no granular control.
+
+**Decision:** Backlogged. The feature is not a hard requirement, the implementation complexity is high, and NOFO Builder is being sunset in favor of similar functionality on SGM. Not worth investing in at this time.


### PR DESCRIPTION
## Summary

This PR introduces a `documentation/DECISIONS.md` file to serve as a running decision log for the project. The first entry documents the decision to backlog OpDiv Admin multi-group assignment — the ability for OpDiv Admin users to belong to more than one OpDiv group. The feature was backlogged due to high implementation complexity (both identified paths — multi-group membership and parent-child group hierarchy — were non-trivial) and because NOFO Builder is being sunset in favor of similar functionality on SGM, making the investment not worthwhile at this time.

## Test plan

- [ ] Confirm `documentation/DECISIONS.md` renders correctly on GitHub
- [ ] Confirm entry date, context, and decision text are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)