### PR TITLE
fix: update contact email in NOFO deleted alert

### DIFF
--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -400,7 +400,7 @@ class NofosArchiveView(
 
         messages.error(
             request,
-            "You deleted NOFO: '{}'.<br/>If this was a mistake, get in touch with the NOFO Builder team at <a href='mailto:simplernofos@bloomworks.digital'>simplernofos@bloomworks.digital</a>.".format(
+            "You deleted NOFO: '{}'.<br/>If this was a mistake, get in touch with the NOFO Builder team at <a href='mailto:SimplerNOFOs@agile6.com'>SimplerNOFOs@agile6.com</a>.".format(
                 nofo.short_name or nofo.title
             ),
         )

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -400,8 +400,9 @@ class NofosArchiveView(
 
         messages.error(
             request,
-            "You deleted NOFO: '{}'.<br/>If this was a mistake, get in touch with the NOFO Builder team at <a href='mailto:SimplerNOFOs@agile6.com'>SimplerNOFOs@agile6.com</a>.".format(
-                nofo.short_name or nofo.title
+            format_html(
+                "You deleted NOFO: ‘{}’.<br/>If this was a mistake, get in touch with the NOFO Builder team at <a href='mailto:SimplerNOFOs@agile6.com'>SimplerNOFOs@agile6.com</a>.",
+                nofo.short_name or nofo.title,
             ),
         )
         return redirect(self.success_url)


### PR DESCRIPTION
## Summary

Updates the contact email address displayed in the success/error alert shown on the NOFO list page after a user confirms deleting a NOFO.

- **What changed:** The email in the "NOFO deleted" alert (`NofosArchiveView` in `nofos/nofos/views.py`) was updated from `simplernofos@bloomworks.digital` to `SimplerNOFOs@agile6.com`, rendered as a `mailto:` link.
- **Why:** The team's contact email has moved from the Bloomworks domain to Agile 6.
- No other alert email references were changed — the two similar alerts in the `composer` and `compare` apps were intentionally left untouched as they are separate flows.

## Test plan

- [ ] Delete a draft NOFO and confirm the deletion on the confirmation page.
- [ ] Verify the alert on the NOFO list page shows the heading "NOFO deleted" and the body text contains a `mailto:SimplerNOFOs@agile6.com` link rendering as `SimplerNOFOs@agile6.com`.
- [ ] Confirm clicking the link opens a new email addressed to `SimplerNOFOs@agile6.com`.