### PR TITLE
Fix DEPLOYMENT.md link in UPDATING_PYTHON_DEPENDENCIES.md

### DIFF
--- a/documentation/UPDATING_PYTHON_DEPENDENCIES.md
+++ b/documentation/UPDATING_PYTHON_DEPENDENCIES.md
@@ -96,4 +96,4 @@ If any of these checks fail, either resolve the issue before merging or revert t
 
 ## Contributing
 
-Once your dependency updates are ready and the checklist above is complete, open a pull request targeting main. For details on the contribution workflow, CI requirements, and how changes get deployed to production, see [DEPLOYMENT.md](documentation/DEPLOYMENT.md).
+Once your dependency updates are ready and the checklist above is complete, open a pull request targeting main. For details on the contribution workflow, CI requirements, and how changes get deployed to production, see [DEPLOYMENT.md](../DEPLOYMENT.md).


### PR DESCRIPTION
## Summary

- Fixes a broken relative link in `documentation/UPDATING_PYTHON_DEPENDENCIES.md`
- The Contributing section linked to `documentation/DEPLOYMENT.md` (incorrect path from within the `documentation/` directory); corrected to `../DEPLOYMENT.md`

## Test plan

- [ ] Confirm link in rendered GitHub markdown resolves to the correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)