### PR TITLE
Improve callout box header sizing, add "retry link check" button, make "Search NOFOs" available for all users.

### DIFF
--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -942,6 +942,18 @@ section.section .section--title-page::before {
   margin: 0 0 10px 0;
 }
 
+.callout-box .callout-box--contents h4 {
+  font-size: 13pt;
+}
+
+.callout-box .callout-box--contents h5 {
+  font-size: 12.25pt;
+}
+
+.callout-box .callout-box--contents h6 {
+  font-size: 11.5pt;
+}
+
 .callout-box--contents {
   font-size: 10pt;
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-acf-white.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-acf-white.css
@@ -139,6 +139,12 @@ h5 {
   color: var(--color--black);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--black);
+}
+
 .callout-box--icon {
   background-color: var(--color-white);
   border: 2px solid var(--color--light-black);

--- a/nofos/bloom_nofos/static/theme-opdiv-aspr-white.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-aspr-white.css
@@ -139,6 +139,12 @@
   color: var(--color--black);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--black);
+}
+
 .callout-box--icon {
   background-color: var(--color-white);
   border: 2px solid var(--color--aspr-navy);

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-blue.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-blue.css
@@ -185,6 +185,12 @@ h1 {
   color: var(--color--white);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box--contents a {
   color: var(--color--white);
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-dghp.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-dghp.css
@@ -225,6 +225,12 @@ h4 {
   color: var(--color--white);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box--icon {
   background-color: var(--color--dghp-oxford-blue);
   color: var(--color--white);

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-dhp.css
@@ -247,6 +247,12 @@ h4 {
   color: var(--color--white);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box--contents a {
   color: var(--color--white);
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-iod.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-iod.css
@@ -223,6 +223,12 @@ h4 {
   color: var(--color--white);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box--contents a {
   color: var(--color--white);
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc1.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc1.css
@@ -222,6 +222,12 @@ h4 {
   color: var(--color--white);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box--icon {
   background-color: var(--color--ncipc-blue);
   color: var(--color--white);

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc2.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-ncipc2.css
@@ -223,6 +223,12 @@ h4 {
   color: var(--color--black);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--black);
+}
+
 .callout-box a {
   color: var(--color--ncipc-blue);
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-orr.css
@@ -212,6 +212,12 @@ section.nofo--cover-page.nofo--cover-page--hero {
   color: var(--color--white);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box--contents a {
   color: var(--color--white);
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-cdc-white.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cdc-white.css
@@ -139,6 +139,12 @@
   color: var(--color--black);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--black);
+}
+
 .callout-box--icon {
   background-color: var(--color-white);
   border: 2px solid var(--color--dark-blue);

--- a/nofos/bloom_nofos/static/theme-opdiv-cms-blue.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-cms-blue.css
@@ -171,6 +171,12 @@ section.before-you-begin h2 {
   color: var(--color--cms-blue);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box:not(.callout-box--icon) {
   background-color: var(--color--cms-blue);
   color: var(--color--white);

--- a/nofos/bloom_nofos/static/theme-opdiv-hrsa-blue.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-hrsa-blue.css
@@ -169,6 +169,12 @@ h4 {
   color: var(--color--white);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--white);
+}
+
 .callout-box--contents a {
   color: var(--color--white);
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-hrsa-white.css
@@ -122,6 +122,12 @@ h4 {
   color: var(--color--black);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--black);
+}
+
 .callout-box--icon .callout-box--contents svg {
   fill: var(--color--white);
 }

--- a/nofos/bloom_nofos/static/theme-opdiv-samhsa.css
+++ b/nofos/bloom_nofos/static/theme-opdiv-samhsa.css
@@ -193,6 +193,12 @@ section.nofo--cover-page.nofo--cover-page--hero {
   color: var(--color--samhsa-blue);
 }
 
+.callout-box .callout-box--contents h4,
+.callout-box .callout-box--contents h5,
+.callout-box .callout-box--contents h6 {
+  color: var(--color--samhsa-blue);
+}
+
 .section--content--right-col .callout-box--contents p {
   color: var(--color--samhsa-blue);
 }

--- a/nofos/nofos/templates/nofos/nofo_check_links.html
+++ b/nofos/nofos/templates/nofos/nofo_check_links.html
@@ -77,6 +77,11 @@
       <p>Learn more about <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status" target="_blank">HTTP response status codes</a>.</p>
     </div>
   </details>
+    <p>
+      <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' object.id %}?with_status=True">
+        Refresh link statuses
+      </a>
+    </p>
   {% else %}
     <p>
       <a class="usa-button usa-button--accent-warm" href="{% url 'nofos:nofo_check_links' object.id %}?with_status=True">

--- a/nofos/nofos/templates/nofos/nofo_index.html
+++ b/nofos/nofos/templates/nofos/nofo_index.html
@@ -18,11 +18,9 @@
 		<h1 class="font-heading-xl margin-y-0">
 			{% if nofo_group == 'bloom' or nofo_group == 'all' %}{{ nofo_group|title }}{% else %}{{ nofo_group|upper }}{% endif %}{% if nofo_status and nofo_status != 'all' %} {{ nofo_status }}{% endif %} NOFOs
 		</h1>
-		{% if user.is_superuser %}
-			<div class="nofo_index--header--view font-sans-md">
-				<a href="{% url 'nofos:nofo_search' %}">Search NOFOs</a>
-			</div>
-		{% endif %}
+		<div class="nofo_index--header--view font-sans-md">
+			<a class="search-nofos-link" href="{% url 'nofos:nofo_search' %}">Search NOFOs</a>
+		</div>
 	</div>
 
 


### PR DESCRIPTION
## Summary

This PR closes some long-standing tickets that @benbrasso-agile6 has been fretting about for months now:

- #613 
- #528 
- #611

### Improve callout box header sizing

Our callout boxes are usually small bits of free text with an H4 heading. The H4 heading is smaller than the typical heading in the body text of a NOFO because we don't want the contrast between the heading and the body text of the callout box to be so dramatic. 

This means that in the rare instance that there is also an h5 in the body of a callout box, the size of it is calibrated to
the regular sizing of the rest of the document, not to the h4 in the title of the callout box. This creates a strange visual heirarchy because the h4 is much smaller than the h5.

This commit adds CSS to specify the size of h4s, h5s, and h6s inside of callout boxes, and also sets their colour to the same colour as the title of the callout box. 

No fancy design flourishes here, just making sure everything is legible.

If someone is adding an h3 or higher to a callout box, they are doing something very wrong, so I am not adding CSS for h3s and above.

| before | after |
|--------|-------|
|  <img width="668" height="707" alt="Screenshot 2026-06-05 at 18 04 14" src="https://github.com/user-attachments/assets/6350b097-4cab-4d22-a9fb-dea38c01af74" />      |   <img width="668" height="677" alt="Screenshot 2026-06-05 at 18 03 42" src="https://github.com/user-attachments/assets/3dfd969a-d51c-4cb8-8a9a-9ef032668189" />    |
|    <img width="668" height="707" alt="Screenshot 2026-06-05 at 18 04 38" src="https://github.com/user-attachments/assets/c5c3926f-b44f-4d13-be20-062d56667acd" />    |   <img width="668" height="681" alt="Screenshot 2026-06-05 at 18 05 10" src="https://github.com/user-attachments/assets/b37fe76e-96c7-452a-8021-0fbc1b7b16aa" />    |


### Add a retry button to the link statuses page

When you first get to the link statuses page, there is a button you can press to try and get all link statuses. Once you have them, there is no more action for you to take.

Reloading the page will refresh all the link statuses, but that is not immediately obvious, so I added a button you can click to do that.

| before | after |
|--------|-------|
|    <img width="932" height="356" alt="Screenshot 2026-06-05 at 18 28 37" src="https://github.com/user-attachments/assets/40beee11-631f-4146-83c0-c67f3e3283b6" />    |    <img width="932" height="411" alt="Screenshot 2026-06-05 at 18 27 58" src="https://github.com/user-attachments/assets/ea0d7255-9352-4e29-b9e8-0c3a9ffd037d" />   |


### Reveal "Search NOFOs" link for all users

Previously only superusers could see this, now everyone can. 

I think that only superusers really have enough NOFOs to need to search for them, but even if that is true, why not just add this? 
