### PR TITLE
Rename 'Download PDF (live)' button to 'Download PDF'

### DIFF
--- a/documentation/DECISIONS.md
+++ b/documentation/DECISIONS.md
@@ -4,6 +4,14 @@ This file records significant architectural, product, and implementation decisio
 
 ---
 
+## 2026-06-11 — Renamed "Download PDF (live)" button to "Download PDF"
+
+**Context:** Users expressed confusion about what "live" meant in the "Download PDF (live)" button label. The term was originally used to distinguish the final, unwatermarked PDF from the watermarked "Preview PDF".
+
+**Decision:** Simplified the label to "Download PDF". The distinction from Preview PDF is already clear from context. File changed: `nofos/bloom_nofos/templates/includes/print_button.html`
+
+---
+
 ## 2026-05-21 — Backlog OpDiv Admin multi-group assignment
 
 **Context:** A question was raised about whether OpDiv Admin users could be assigned to more than one OpDiv group (e.g., CDC DGHT and CDC DGHP). The two implementation paths identified were: (1) allowing users to belong to more than one group, or (2) introducing a parent-child group hierarchy — both considered complex. The Bloom group already provides all-or-nothing visibility across all users and NOFOs but offers no granular control.

--- a/nofos/bloom_nofos/templates/includes/print_button.html
+++ b/nofos/bloom_nofos/templates/includes/print_button.html
@@ -16,7 +16,7 @@
     <form method="post" action="{% url 'nofos:print_pdf' nofo.id %}?mode=attachment&is_test_pdf=false">
       {% csrf_token %}
       <button type="submit" class="usa-button usa-button--outline font-sans-xs text-normal" {% if 'localhost' in request.get_host %}disabled{% endif %}>
-        Download<span class="hide-on-tablet"> PDF (live)</span>
+        Download PDF
       </button>
     </form>
   </li>


### PR DESCRIPTION
## Summary

- Removes the `(live)` qualifier and `hide-on-tablet` span from the Download button in `print_button.html`, so it reads "Download PDF" consistently on all screen sizes
- Logs the decision in a new `documentation/DECISIONS.md` file

The `hide-on-tablet` spans on "View HTML" (same file) and "Download Word" (`download_docx_button.html`) are intentional and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)