### PR TITLE
Remove Bloomworks Digital link from footer

### DIFF
--- a/nofos/bloom_nofos/templates/base.html
+++ b/nofos/bloom_nofos/templates/base.html
@@ -125,13 +125,6 @@
               {% include "includes/feedback_link.html" with html_class="usa-footer__primary-link usa-link--external" link_text="Submit a support ticket" only %}
             </li>
           {% endif %}
-          {% if request.path == "/" %}
-            <li class="mobile-lg:grid-col-4 desktop:grid-col-auto usa-footer__primary-content">
-              <a class="usa-footer__primary-link" href="https://bloomworks.digital/" target="_blank">
-                A Bloomworks Digital product
-              </a>
-            </li>
-          {% endif %}
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
Removes the "A Bloomworks Digital product" link from the footer. The link no longer reflects the current state of the project and doesn't need to appear in the app.