### PR TITLE
Add Dependabot config with cooldown and grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      docker-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` to enable automated dependency updates with sensible defaults for this repo.

### What's configured

- **Ecosystems:** `pip` (Poetry), `github-actions`, `docker`
- **Schedule:** weekly per ecosystem
- **Cooldown:** 14 days — delays brand-new releases from being PR'd until they've had time to bake
- **Major bumps:** ignored — Dependabot won't open PRs for major version updates; we'll handle those manually
- **Grouping:** minor + patch updates roll up into one PR per ecosystem per week to cut noise
- **PR limit:** 5 open PRs per ecosystem

### Notes

- Security advisories still open PRs immediately (cooldown and grouping don't apply to security updates).
- Reference: [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)

## Test plan

- [ ] Merge and confirm Dependabot picks up the config (check the **Insights → Dependency graph → Dependabot** tab)
- [ ] Wait for the first scheduled run and verify grouped PRs are opened (no individual major-bump PRs)