### PR TITLE
Add NIH group theme restrictions

### DIFF
--- a/nofos/nofos/api/api.py
+++ b/nofos/nofos/api/api.py
@@ -3,7 +3,7 @@ import uuid
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
-from ninja import NinjaAPI, Status
+from ninja import NinjaAPI
 from ninja.security import HttpBearer
 
 from nofos.models import Nofo, Section, Subsection
@@ -27,7 +27,7 @@ health_api = NinjaAPI(auth=None, urls_namespace=None)
 @health_api.api_operation(["GET", "HEAD"], "/health", auth=None)
 def health_check(request):
     """Health check endpoint that returns 200 OK."""
-    return Status(200, {"status": "ok"})
+    return {"status": "ok"}
 
 
 # Main API instance for other endpoints
@@ -68,11 +68,9 @@ def create_nofo(request, payload: NofoSchema):
         return return_response
 
     except ValidationError as e:
-        return Status(
-            400, {"message": "Model validation error", "details": e.message_dict}
-        )
+        return 400, {"message": "Model validation error", "details": e.message_dict}
     except Exception as e:
-        return Status(400, {"message": str(e)})
+        return 400, {"message": str(e)}
 
 
 @api.get("/nofos/{nofo_id}", response={200: dict, 404: ErrorSchema})
@@ -99,4 +97,4 @@ def get_nofo(request, nofo_id: uuid.UUID):
         return JsonResponse(nofo_dict, status=200)
 
     except Nofo.DoesNotExist:
-        return Status(404, {"message": "NOFO not found"})
+        return 404, {"message": "NOFO not found"}

--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -9,7 +9,7 @@ from .models import (
     Section,
     Subsection,
 )
-from .utils import get_icon_path_choices
+from .utils import get_icon_path_choices, user_is_nih_group
 
 
 def create_object_model_form(model_class):
@@ -139,6 +139,19 @@ class NofoCoachDesignerForm(forms.ModelForm):
         )
 
 
+NIH_THEME_DEFAULTS = {
+    "theme": "portrait-nih-white",
+    "cover": "nofo--cover-page--text",
+    "icon_style": "nofo--icons--solid",
+}
+
+NIH_ALLOWED_CHOICES = {
+    "theme": frozenset(["portrait-nih-white"]),
+    "cover": frozenset(["nofo--cover-page--text", "nofo--cover-page--medium"]),
+    "icon_style": frozenset(["nofo--icons--solid"]),
+}
+
+
 class NofoThemeOptionsForm(forms.ModelForm):
     class Meta:
         model = Nofo
@@ -147,30 +160,73 @@ class NofoThemeOptionsForm(forms.ModelForm):
     def __init__(self, *args, user=None, **kwargs):
         super(NofoThemeOptionsForm, self).__init__(*args, **kwargs)
 
-        # -------- Filter theme choices into optgroups by OpDiv
-        theme_categories_dict = {}
-        for value, label in THEME_CHOICES:
-            opdiv = label.split(" ")[0]
-            theme_categories_dict.setdefault(opdiv, []).append((value, label))
+        self.user = user
 
-        group_key = user.group.upper() if user and hasattr(user, "group") else None
-
-        if group_key and group_key != "BLOOM" and group_key in theme_categories_dict:
-            theme_categories = {group_key: theme_categories_dict[group_key]}
+        if user_is_nih_group(user):
+            # NIH users see a restricted set of choices for all three fields.
+            self.fields["theme"].choices = [
+                (
+                    "NIH",
+                    [
+                        (v, l)
+                        for v, l in THEME_CHOICES
+                        if v in NIH_ALLOWED_CHOICES["theme"]
+                    ],
+                )
+            ]
+            self.fields["cover"].choices = [
+                (v, l)
+                for v, l in Nofo.COVER_CHOICES
+                if v in NIH_ALLOWED_CHOICES["cover"]
+            ]
+            self.fields["icon_style"].choices = [
+                (v, l)
+                for v, l in Nofo.ICON_STYLE_CHOICES
+                if v in NIH_ALLOWED_CHOICES["icon_style"]
+            ]
         else:
-            theme_categories = theme_categories_dict
+            # -------- Filter theme choices into optgroups by OpDiv
+            theme_categories_dict = {}
+            for value, label in THEME_CHOICES:
+                opdiv = label.split(" ")[0]
+                theme_categories_dict.setdefault(opdiv, []).append((value, label))
 
-        # Convert optgroup dict into Django-style optgroup choices
-        optgroup_choices = [
-            (opdiv, options) for opdiv, options in theme_categories.items()
-        ]
-        self.fields["theme"].choices = optgroup_choices
+            group_key = user.group.upper() if user and hasattr(user, "group") else None
 
-        # -------- Filter icon_style choices based on selected theme
-        if self.instance and self.instance.theme:
-            self.fields["icon_style"].choices = get_icon_path_choices(
-                self.instance.theme
-            )
+            if (
+                group_key
+                and group_key != "BLOOM"
+                and group_key in theme_categories_dict
+            ):
+                theme_categories = {group_key: theme_categories_dict[group_key]}
+            else:
+                theme_categories = theme_categories_dict
+
+            # Convert optgroup dict into Django-style optgroup choices
+            optgroup_choices = [
+                (opdiv, options) for opdiv, options in theme_categories.items()
+            ]
+            self.fields["theme"].choices = optgroup_choices
+
+            # -------- Filter icon_style choices based on selected theme
+            if self.instance and self.instance.theme:
+                self.fields["icon_style"].choices = get_icon_path_choices(
+                    self.instance.theme
+                )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if user_is_nih_group(self.user):
+            for field, allowed in NIH_ALLOWED_CHOICES.items():
+                value = cleaned_data.get(field)
+                if value and value not in allowed:
+                    self.add_error(
+                        field,
+                        forms.ValidationError(
+                            "This choice is not permitted for NIH group users."
+                        ),
+                    )
+        return cleaned_data
 
 
 class NofoCoverImageForm(forms.ModelForm):

--- a/nofos/nofos/tests_nofos/test_theme_options.py
+++ b/nofos/nofos/tests_nofos/test_theme_options.py
@@ -1,0 +1,239 @@
+from django.test import Client, TestCase
+from django.urls import reverse
+from users.models import BloomUser
+
+from nofos.forms import NIH_ALLOWED_CHOICES, NIH_THEME_DEFAULTS, NofoThemeOptionsForm
+from nofos.models import Nofo
+
+
+def _make_nofo(group, **overrides):
+    defaults = dict(
+        title="Test NOFO",
+        short_name="test-nofo",
+        number="TEST-001",
+        opdiv="TEST",
+        group=group,
+        status="draft",
+    )
+    defaults.update(overrides)
+    return Nofo.objects.create(**defaults)
+
+
+def _make_user(group):
+    return BloomUser.objects.create_user(
+        email=f"{group}@example.com",
+        password="testpass123",
+        group=group,
+        force_password_reset=False,
+    )
+
+
+class NIHUserThemeOptionsFormTests(TestCase):
+    def setUp(self):
+        self.user = _make_user("nih")
+        self.nofo = _make_nofo("nih")
+
+    def test_theme_choices_restricted_to_nih_only(self):
+        form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
+        all_values = [v for _, opts in form.fields["theme"].choices for v, _ in opts]
+        self.assertEqual(all_values, ["portrait-nih-white"])
+
+    def test_cover_choices_exclude_hero(self):
+        form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
+        cover_values = [v for v, _ in form.fields["cover"].choices]
+        self.assertIn("nofo--cover-page--text", cover_values)
+        self.assertIn("nofo--cover-page--medium", cover_values)
+        self.assertNotIn("nofo--cover-page--hero", cover_values)
+
+    def test_icon_style_choices_restricted_to_outlined(self):
+        form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
+        icon_values = [v for v, _ in form.fields["icon_style"].choices]
+        self.assertEqual(icon_values, ["nofo--icons--solid"])
+
+    def test_valid_submission_with_nih_defaults(self):
+        data = {
+            "theme": "portrait-nih-white",
+            "cover": "nofo--cover-page--text",
+            "icon_style": "nofo--icons--solid",
+        }
+        form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_valid_submission_with_standard_image_cover(self):
+        data = {
+            "theme": "portrait-nih-white",
+            "cover": "nofo--cover-page--medium",
+            "icon_style": "nofo--icons--solid",
+        }
+        form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_disallowed_theme_rejected(self):
+        data = {
+            "theme": "portrait-hrsa-blue",
+            "cover": "nofo--cover-page--text",
+            "icon_style": "nofo--icons--solid",
+        }
+        form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("theme", form.errors)
+
+    def test_disallowed_cover_rejected(self):
+        data = {
+            "theme": "portrait-nih-white",
+            "cover": "nofo--cover-page--hero",
+            "icon_style": "nofo--icons--solid",
+        }
+        form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("cover", form.errors)
+
+    def test_disallowed_icon_style_rejected(self):
+        data = {
+            "theme": "portrait-nih-white",
+            "cover": "nofo--cover-page--text",
+            "icon_style": "nofo--icons--border",
+        }
+        form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("icon_style", form.errors)
+
+
+class NIHUserThemeOptionsViewTests(TestCase):
+    def setUp(self):
+        self.user = _make_user("nih")
+        self.nofo = _make_nofo(
+            "nih",
+            theme="portrait-hrsa-blue",
+            cover="nofo--cover-page--hero",
+            icon_style="nofo--icons--border",
+        )
+        self.client = Client()
+        self.client.login(email="nih@example.com", password="testpass123")
+        self.url = reverse("nofos:nofo_edit_theme_options", kwargs={"pk": self.nofo.id})
+
+    def test_get_auto_sets_nih_defaults(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.theme, NIH_THEME_DEFAULTS["theme"])
+        self.assertEqual(self.nofo.cover, NIH_THEME_DEFAULTS["cover"])
+        self.assertEqual(self.nofo.icon_style, NIH_THEME_DEFAULTS["icon_style"])
+
+    def test_get_does_not_resave_when_already_correct(self):
+        self.nofo.theme = NIH_THEME_DEFAULTS["theme"]
+        self.nofo.cover = NIH_THEME_DEFAULTS["cover"]
+        self.nofo.icon_style = NIH_THEME_DEFAULTS["icon_style"]
+        self.nofo.save()
+        original_updated = Nofo.objects.get(pk=self.nofo.pk).updated
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Nofo.objects.get(pk=self.nofo.pk).updated, original_updated)
+
+    def _set_nih_defaults(self):
+        for field, value in NIH_THEME_DEFAULTS.items():
+            setattr(self.nofo, field, value)
+        self.nofo.save()
+
+    def test_post_disallowed_theme_rejected(self):
+        self._set_nih_defaults()
+        response = self.client.post(
+            self.url,
+            {
+                "theme": "portrait-hrsa-blue",  # not in NIH_ALLOWED_CHOICES
+                "cover": "nofo--cover-page--text",
+                "icon_style": "nofo--icons--solid",
+            },
+        )
+        # Form invalid: re-renders, does not redirect
+        self.assertEqual(response.status_code, 200)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.theme, NIH_THEME_DEFAULTS["theme"])
+
+    def test_post_disallowed_cover_rejected(self):
+        self._set_nih_defaults()
+        response = self.client.post(
+            self.url,
+            {
+                "theme": "portrait-nih-white",
+                "cover": "nofo--cover-page--hero",  # not in NIH_ALLOWED_CHOICES
+                "icon_style": "nofo--icons--solid",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.cover, NIH_THEME_DEFAULTS["cover"])
+
+    def test_post_disallowed_icon_style_rejected(self):
+        self._set_nih_defaults()
+        response = self.client.post(
+            self.url,
+            {
+                "theme": "portrait-nih-white",
+                "cover": "nofo--cover-page--text",
+                "icon_style": "nofo--icons--border",  # not in NIH_ALLOWED_CHOICES
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.icon_style, NIH_THEME_DEFAULTS["icon_style"])
+
+    def test_post_valid_nih_values_saved(self):
+        response = self.client.post(
+            self.url,
+            {
+                "theme": "portrait-nih-white",
+                "cover": "nofo--cover-page--medium",
+                "icon_style": "nofo--icons--solid",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.theme, "portrait-nih-white")
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--medium")
+        self.assertEqual(self.nofo.icon_style, "nofo--icons--solid")
+
+
+class NonNIHUserThemeOptionsTests(TestCase):
+    def setUp(self):
+        self.user = _make_user("hrsa")
+        self.nofo = _make_nofo(
+            "hrsa",
+            theme="portrait-hrsa-blue",
+            cover="nofo--cover-page--hero",
+            icon_style="nofo--icons--border",
+        )
+        self.client = Client()
+        self.client.login(email="hrsa@example.com", password="testpass123")
+        self.url = reverse("nofos:nofo_edit_theme_options", kwargs={"pk": self.nofo.id})
+
+    def test_non_nih_user_sees_all_cover_choices(self):
+        form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
+        cover_values = [v for v, _ in form.fields["cover"].choices]
+        self.assertIn("nofo--cover-page--hero", cover_values)
+        self.assertIn("nofo--cover-page--medium", cover_values)
+        self.assertIn("nofo--cover-page--text", cover_values)
+
+    def test_non_nih_user_sees_multiple_icon_style_choices(self):
+        form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
+        icon_values = [v for v, _ in form.fields["icon_style"].choices]
+        # Non-NIH themes get at least the border and solid options
+        self.assertGreater(len(icon_values), 1)
+
+    def test_non_nih_user_get_does_not_change_nofo_fields(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--hero")
+        self.assertEqual(self.nofo.icon_style, "nofo--icons--border")
+
+    def test_non_nih_user_can_submit_any_valid_cover(self):
+        data = {
+            "theme": "portrait-hrsa-blue",
+            "cover": "nofo--cover-page--hero",
+            "icon_style": "nofo--icons--border",
+        }
+        form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
+        self.assertTrue(form.is_valid(), form.errors)

--- a/nofos/nofos/tests_nofos/test_theme_options.py
+++ b/nofos/nofos/tests_nofos/test_theme_options.py
@@ -120,6 +120,19 @@ class NIHUserThemeOptionsViewTests(TestCase):
         self.assertEqual(self.nofo.cover, NIH_THEME_DEFAULTS["cover"])
         self.assertEqual(self.nofo.icon_style, NIH_THEME_DEFAULTS["icon_style"])
 
+    def test_get_preserves_allowed_non_default_cover(self):
+        # nofo--cover-page--medium is allowed for NIH but is not the default;
+        # it must not be reset back to nofo--cover-page--text on page load.
+        self.nofo.theme = NIH_THEME_DEFAULTS["theme"]
+        self.nofo.cover = "nofo--cover-page--medium"
+        self.nofo.icon_style = NIH_THEME_DEFAULTS["icon_style"]
+        self.nofo.save()
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--medium")
+
     def test_get_does_not_resave_when_already_correct(self):
         self.nofo.theme = NIH_THEME_DEFAULTS["theme"]
         self.nofo.cover = NIH_THEME_DEFAULTS["cover"]

--- a/nofos/nofos/utils.py
+++ b/nofos/nofos/utils.py
@@ -14,6 +14,11 @@ def clean_string(string):
     return re.sub(r"\s+", " ", string.strip())
 
 
+def user_is_nih_group(user):
+    """Return True if the user belongs to the NIH group."""
+    return bool(user and hasattr(user, "group") and user.group == "nih")
+
+
 def create_nofo_audit_event(event_type, document, user, is_test_pdf=True):
     # Define allowed event types
     allowed_event_types = ["nofo_import", "nofo_print", "nofo_reimport"]

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -44,6 +44,7 @@ from .audits import (
     safe_get_changed_fields,
 )
 from .forms import (
+    NIH_ALLOWED_CHOICES,
     NIH_THEME_DEFAULTS,
     CheckNOFOLinkSingleForm,
     InsertOrderSpaceForm,
@@ -1145,8 +1146,8 @@ class NofoEditThemeOptionsView(BaseNofoEditView):
         if user_is_nih_group(request.user):
             fields_to_update = [
                 field
-                for field, default in NIH_THEME_DEFAULTS.items()
-                if getattr(self.object, field) != default
+                for field in NIH_THEME_DEFAULTS
+                if getattr(self.object, field) not in NIH_ALLOWED_CHOICES[field]
             ]
             if fields_to_update:
                 for field in fields_to_update:

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -1152,7 +1152,7 @@ class NofoEditThemeOptionsView(BaseNofoEditView):
             if fields_to_update:
                 for field in fields_to_update:
                     setattr(self.object, field, NIH_THEME_DEFAULTS[field])
-                self.object.save(update_fields=fields_to_update)
+                self.object.save()
         form = self.get_form()
         return self.render_to_response(self.get_context_data(form=form))
 

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -44,6 +44,7 @@ from .audits import (
     safe_get_changed_fields,
 )
 from .forms import (
+    NIH_THEME_DEFAULTS,
     CheckNOFOLinkSingleForm,
     InsertOrderSpaceForm,
     NofoAgencyForm,
@@ -114,7 +115,7 @@ from .nofo import (
     suggest_nofo_title,
     upload_cover_image_to_s3,
 )
-from .utils import create_nofo_audit_event, create_subsection_html_id
+from .utils import create_nofo_audit_event, create_subsection_html_id, user_is_nih_group
 
 GroupAccessObjectMixin = GroupAccessObjectMixinFactory(Nofo)
 
@@ -1138,6 +1139,21 @@ class NofoEditThemeOptionsView(BaseNofoEditView):
         kwargs = super().get_form_kwargs()
         kwargs["user"] = self.request.user  # pass user to form
         return kwargs
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if user_is_nih_group(request.user):
+            fields_to_update = [
+                field
+                for field, default in NIH_THEME_DEFAULTS.items()
+                if getattr(self.object, field) != default
+            ]
+            if fields_to_update:
+                for field in fields_to_update:
+                    setattr(self.object, field, NIH_THEME_DEFAULTS[field])
+                self.object.save(update_fields=fields_to_update)
+        form = self.get_form()
+        return self.render_to_response(self.get_context_data(form=form))
 
 
 class NofoEditCoverImageView(BaseNofoEditView):


### PR DESCRIPTION
## Summary

- NIH group users are now restricted to a fixed set of choices on the NOFO theme options page: \`portrait-nih-white\` for theme, \`nofo--cover-page--text\` or \`nofo--cover-page--medium\` for cover, and \`nofo--icons--solid\` (outlined) for icon style
- On page load, any field whose current value is **outside the NIH-allowed set** is auto-corrected to its NIH default and saved. Fields already set to an allowed value (including non-default allowed choices like \`nofo--cover-page--medium\`) are left unchanged.
- Server-side \`clean()\` in the form rejects any disallowed value even if submitted via direct POST manipulation
- Also fixes a pre-existing \`ImportError\` (\`Status\` was removed in django-ninja 1.x) that was blocking the entire test suite

## Changes

- \`nofos/nofos/utils.py\` — add \`user_is_nih_group()\` helper
- \`nofos/nofos/forms.py\` — add \`NIH_THEME_DEFAULTS\` / \`NIH_ALLOWED_CHOICES\` constants; filter form choices for NIH users; add \`clean()\` server-side validation
- \`nofos/nofos/views.py\` — override \`NofoEditThemeOptionsView.get()\` to auto-save NIH defaults for any field whose current value is not in the NIH-allowed set; uses plain \`save()\` so \`BaseNofo.save()\` correctly updates \`updated\` / \`updated_by\`
- \`nofos/nofos/tests_nofos/test_theme_options.py\` — 19 new tests (NIH choice restrictions, auto-defaults, preservation of allowed non-default cover, POST bypass rejection, non-NIH user unaffected)
- \`nofos/nofos/api/api.py\` — replace \`Status(code, data)\` with tuple syntax \`(code, data)\` for django-ninja 1.x compatibility

## Test plan

- [ ] NIH group user opens theme options page with a non-NIH theme — all three fields are auto-corrected to NIH defaults
- [ ] NIH group user opens theme options page with \`cover="nofo--cover-page--medium"\` — cover is **not** reset (it is an allowed NIH choice)
- [ ] NIH group user sees only NIH (Light) in the theme dropdown, only Text only / Standard image in cover, only Outlined in icon style
- [ ] NIH group user cannot save a disallowed value via direct POST (form returns 200, DB unchanged)
- [ ] Non-NIH group user sees all choices and can save any valid value
- [ ] \`make test\` passes (1439 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)