### PR TITLE
Change suggest_nofo_theme fallback to NIH (Light)

### DIFF
--- a/nofos/nofos/api/api.py
+++ b/nofos/nofos/api/api.py
@@ -70,7 +70,8 @@ def create_nofo(request, payload: NofoSchema):
     except ValidationError as e:
         return 400, {"message": "Model validation error", "details": e.message_dict}
     except Exception as e:
-        return 400, {"message": str(e)}
+        message = str(e) if settings.DEBUG else "An unexpected error occurred."
+        return 400, {"message": message}
 
 
 @api.get("/nofos/{nofo_id}", response={200: dict, 404: ErrorSchema})

--- a/nofos/nofos/api/api.py
+++ b/nofos/nofos/api/api.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from django.conf import settings
@@ -5,6 +6,8 @@ from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from ninja import NinjaAPI
 from ninja.security import HttpBearer
+
+logger = logging.getLogger(__name__)
 
 from nofos.models import Nofo, Section, Subsection
 from nofos.nofo import _build_document
@@ -70,6 +73,7 @@ def create_nofo(request, payload: NofoSchema):
     except ValidationError as e:
         return 400, {"message": "Model validation error", "details": e.message_dict}
     except Exception as e:
+        logger.exception("Unexpected error in create_nofo")
         message = str(e) if settings.DEBUG else "An unexpected error occurred."
         return 400, {"message": message}
 

--- a/nofos/nofos/api/tests.py
+++ b/nofos/nofos/api/tests.py
@@ -273,7 +273,7 @@ class NofoAPITest(TestCase):
 
         self.assertEqual(response.status_code, 400)
         response_json = json.loads(response.content)
-        self.assertEqual(response_json["message"], "'NoneType' object is not iterable")
+        self.assertIn("message", response_json)
 
     def test_import_nofo_with_id(self):
         """Test that providing an ID is ignored during import"""

--- a/nofos/nofos/api/tests.py
+++ b/nofos/nofos/api/tests.py
@@ -273,7 +273,7 @@ class NofoAPITest(TestCase):
 
         self.assertEqual(response.status_code, 400)
         response_json = json.loads(response.content)
-        self.assertIn("message", response_json)
+        self.assertEqual(response_json["message"], "An unexpected error occurred.")
 
     def test_import_nofo_with_id(self):
         """Test that providing an ID is ignored during import"""

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1567,7 +1567,7 @@ def suggest_nofo_theme(nofo_number):
     if "rfa-" in nofo_number.lower():
         return "portrait-cdc-blue"
 
-    return "portrait-hrsa-blue"
+    return "portrait-nih-white"
 
 
 def suggest_nofo_title(soup):

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1541,7 +1541,9 @@ def suggest_nofo_application_deadline(soup):
 
 
 def suggest_nofo_cover(nofo_theme):
-    if any(prefix in nofo_theme.lower() for prefix in ["acf-", "acl-", "hrsa-"]):
+    if any(
+        prefix in nofo_theme.lower() for prefix in ["acf-", "acl-", "hrsa-", "nih-"]
+    ):
         return "nofo--cover-page--text"
 
     return "nofo--cover-page--medium"
@@ -1566,6 +1568,9 @@ def suggest_nofo_theme(nofo_number):
     # NOFO numbers with "RFA" are also CDC, but do this check last
     if "rfa-" in nofo_number.lower():
         return "portrait-cdc-blue"
+
+    if "hrsa-" in nofo_number.lower():
+        return "portrait-hrsa-blue"
 
     return "portrait-nih-white"
 

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3644,9 +3644,9 @@ class HTMLSuggestDeadlineTests(TestCase):
 
 
 class HTMLSuggestThemeTests(TestCase):
-    def test_suggest_nofo_number_hrsa_returns_hrsa_theme(self):
+    def test_suggest_nofo_number_hrsa_returns_nih_theme(self):
         nofo_number = "HRSA-24-019"
-        nofo_theme = "portrait-hrsa-blue"
+        nofo_theme = "portrait-nih-white"
         self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
 
     def test_suggest_nofo_number_cdc_returns_cdc_theme(self):
@@ -3684,14 +3684,14 @@ class HTMLSuggestThemeTests(TestCase):
         nofo_theme = "portrait-ihs-white"
         self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
 
-    def test_suggest_nofo_number_no_match_returns_hrsa_theme(self):
+    def test_suggest_nofo_number_no_match_returns_nih_theme(self):
         nofo_number = "abc-def-ghi"
-        nofo_theme = "portrait-hrsa-blue"
+        nofo_theme = "portrait-nih-white"
         self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
 
-    def test_suggest_nofo_number_empty_returns_hrsa_theme(self):
+    def test_suggest_nofo_number_empty_returns_nih_theme(self):
         nofo_number = ""
-        nofo_theme = "portrait-hrsa-blue"
+        nofo_theme = "portrait-nih-white"
         self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
 
 
@@ -3997,8 +3997,8 @@ class SuggestNofoFieldsTests(TestCase):
             self.nofo.keywords,
             "cowpolk, wild west, economic development, training, cattle ranching",
         )
-        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
-        self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
+        self.assertEqual(self.nofo.theme, "portrait-nih-white")
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--medium")
 
     def test_suggest_all_nofo_fields_with_missing_data(self):
         # HTML content with some missing fields
@@ -4027,8 +4027,8 @@ class SuggestNofoFieldsTests(TestCase):
         self.assertEqual(self.nofo.keywords, "")
 
         # still get set
-        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
-        self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
+        self.assertEqual(self.nofo.theme, "portrait-nih-white")
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--medium")
 
     def test_suggest_all_nofo_fields_overwrite_empty_fields(self):
         suggest_all_nofo_fields(self.nofo, self.soup)

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3644,8 +3644,13 @@ class HTMLSuggestDeadlineTests(TestCase):
 
 
 class HTMLSuggestThemeTests(TestCase):
-    def test_suggest_nofo_number_hrsa_returns_nih_theme(self):
+    def test_suggest_nofo_number_hrsa_returns_hrsa_theme(self):
         nofo_number = "HRSA-24-019"
+        nofo_theme = "portrait-hrsa-blue"
+        self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
+
+    def test_suggest_nofo_number_nih_returns_nih_theme(self):
+        nofo_number = "NIH-25-001"
         nofo_theme = "portrait-nih-white"
         self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
 
@@ -3719,6 +3724,10 @@ class HTMLSuggestCoverTests(TestCase):
     def test_suggest_nofo_cover_acl_returns_text(self):
         nofo_cover = "nofo--cover-page--text"
         self.assertEqual(suggest_nofo_cover("portrait-acl-white"), nofo_cover)
+
+    def test_suggest_nofo_cover_nih_returns_text(self):
+        nofo_cover = "nofo--cover-page--text"
+        self.assertEqual(suggest_nofo_cover("portrait-nih-white"), nofo_cover)
 
     def test_suggest_nofo_cover_empty_string_returns_medium(self):
         nofo_cover = "nofo--cover-page--medium"
@@ -3997,8 +4006,8 @@ class SuggestNofoFieldsTests(TestCase):
             self.nofo.keywords,
             "cowpolk, wild west, economic development, training, cattle ranching",
         )
-        self.assertEqual(self.nofo.theme, "portrait-nih-white")
-        self.assertEqual(self.nofo.cover, "nofo--cover-page--medium")
+        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
 
     def test_suggest_all_nofo_fields_with_missing_data(self):
         # HTML content with some missing fields
@@ -4027,8 +4036,8 @@ class SuggestNofoFieldsTests(TestCase):
         self.assertEqual(self.nofo.keywords, "")
 
         # still get set
-        self.assertEqual(self.nofo.theme, "portrait-nih-white")
-        self.assertEqual(self.nofo.cover, "nofo--cover-page--medium")
+        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
 
     def test_suggest_all_nofo_fields_overwrite_empty_fields(self):
         suggest_all_nofo_fields(self.nofo, self.soup)


### PR DESCRIPTION
## Summary

Updates \`suggest_nofo_theme()\` and \`suggest_nofo_cover()\` in \`nofos/nofos/nofo.py\` with two related changes:

1. **Explicit HRSA pattern** — adds an \`"hrsa-"\` check so HRSA-prefixed NOFO numbers (e.g. \`HRSA-24-019\`) continue to return \`portrait-hrsa-blue\`, rather than hitting the fallback.
2. **New fallback** — changes the catch-all \`return\` from \`portrait-hrsa-blue\` to \`portrait-nih-white\`, so NOFO numbers that don't match any known prefix (CDC, ACF, ACL, CMS, IHS, RFA, HRSA) now suggest NIH (Light) instead of HRSA (Default).
3. **NIH cover mapping** — adds \`"nih-"\` to \`suggest_nofo_cover()\`'s prefix list so \`portrait-nih-white\` correctly maps to \`nofo--cover-page--text\`.

## Changes

- \`nofos/nofos/nofo.py\`
  - \`suggest_nofo_theme()\`: add explicit \`"hrsa-"\` branch before the fallback; change fallback from \`portrait-hrsa-blue\` → \`portrait-nih-white\`
  - \`suggest_nofo_cover()\`: add \`"nih-"\` to the prefix list
- \`nofos/nofos/test_nofo.py\`
  - \`test_suggest_nofo_number_hrsa_returns_hrsa_theme\`: restored (HRSA now has explicit pattern, still returns \`portrait-hrsa-blue\`)
  - Added \`test_suggest_nofo_number_nih_returns_nih_theme\`
  - Added \`test_suggest_nofo_cover_nih_returns_text\`
  - \`test_suggest_nofo_number_no_match_returns_nih_theme\` / \`…_empty_…\`: updated expected value to \`portrait-nih-white\`
  - \`test_suggest_all_nofo_fields\` / \`…_with_missing_data\`: reverted to \`portrait-hrsa-blue\` / \`nofo--cover-page--text\` (HRSA NOFO numbers in those fixtures now match the explicit \`"hrsa-"\` branch)
- \`nofos/nofos/api/api.py\`
  - DEBUG-gate the generic exception handler: return raw error in \`DEBUG=True\`, generic message in production
  - Add \`logger.exception()\` so production failures remain diagnosable server-side
- \`nofos/nofos/api/tests.py\`
  - Assert exact expected message (\`"An unexpected error occurred."\`) for the non-array subsections test, since \`DEBUG=False\` in the test runner

## Hardcoded \`portrait-hrsa-blue\` audit — remaining occurrences

After this change, all remaining occurrences of \`portrait-hrsa-blue\` outside test files and migration history are:

| File | Line | Context | Action needed? |
|------|------|---------|----------------|
| \`nofos/nofos/models.py\` | 102 | Choice tuple \`("portrait-hrsa-blue", "HRSA (Default)")\` in \`THEME_CHOICES\` | No — this is a valid, selectable theme value, not a default |
| \`nofos/nofos/models.py\` | 367 | \`default="portrait-hrsa-blue"\` on the \`theme\` field | Addressed by PR #720 |

## Test plan

- [ ] \`make test\` passes
- [ ] Importing a NOFO whose number doesn't match CDC / ACF / ACL / CMS / IHS / RFA / HRSA results in \`theme = "portrait-nih-white"\`
- [ ] HRSA-prefixed NOFO numbers (e.g. \`HRSA-24-019\`) still suggest \`portrait-hrsa-blue\`
- [ ] \`portrait-nih-white\` theme maps to \`nofo--cover-page--text\` cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)