### PR TITLE
Use OpDiv to detect NIH theme during NOFO import

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1550,7 +1550,7 @@ def suggest_nofo_cover(nofo_theme):
 
 
 def suggest_nofo_theme(nofo_number, opdiv=""):
-    opdiv_lower = opdiv.lower()
+    opdiv_lower = (opdiv or "").lower()
     if any(v in opdiv_lower for v in ["national institutes of health", "nih"]):
         return "portrait-nih-white"
 

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1551,7 +1551,9 @@ def suggest_nofo_cover(nofo_theme):
 
 def suggest_nofo_theme(nofo_number, opdiv=""):
     opdiv_lower = (opdiv or "").lower()
-    if any(v in opdiv_lower for v in ["national institutes of health", "nih"]):
+    if "national institutes of health" in opdiv_lower or re.search(
+        r"\bnih\b", opdiv_lower
+    ):
         return "portrait-nih-white"
 
     if "cdc-" in nofo_number.lower():

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1549,7 +1549,11 @@ def suggest_nofo_cover(nofo_theme):
     return "nofo--cover-page--medium"
 
 
-def suggest_nofo_theme(nofo_number):
+def suggest_nofo_theme(nofo_number, opdiv=""):
+    opdiv_lower = opdiv.lower()
+    if any(v in opdiv_lower for v in ["national institutes of health", "nih"]):
+        return "portrait-nih-white"
+
     if "cdc-" in nofo_number.lower():
         return "portrait-cdc-blue"
 
@@ -1665,7 +1669,9 @@ def suggest_all_nofo_fields(nofo, soup):
 
     # do not reset these during import
     if first_time_import:
-        nofo.theme = suggest_nofo_theme(nofo.number)  # guess the NOFO theme
+        nofo.theme = suggest_nofo_theme(
+            nofo.number, opdiv=nofo.opdiv
+        )  # guess the NOFO theme
     if first_time_import:
         nofo.cover = suggest_nofo_cover(nofo.theme)  # guess the NOFO cover
 

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3718,11 +3718,11 @@ class HTMLSuggestThemeTests(TestCase):
         )
 
     def test_suggest_opdiv_nih_takes_precedence_over_number(self):
-        # PAR-27-032 has no matching prefix and would fall through to NIH anyway,
-        # but this confirms OpDiv drives the result when present
+        # CDC-prefixed number would normally return portrait-cdc-blue,
+        # but the NIH OpDiv check runs first and wins
         self.assertEqual(
             suggest_nofo_theme(
-                "PAR-27-032", opdiv="National Institutes of Health (NIH)"
+                "CDC-RFA-DP-25-001", opdiv="National Institutes of Health (NIH)"
             ),
             "portrait-nih-white",
         )

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3734,6 +3734,13 @@ class HTMLSuggestThemeTests(TestCase):
             "portrait-nih-white",
         )
 
+    def test_suggest_opdiv_containing_nih_substring_does_not_match(self):
+        # "nih" inside a word (e.g. "zenith") must not trigger NIH detection
+        self.assertEqual(
+            suggest_nofo_theme("CDC-RFA-DP-25-001", opdiv="Zenith Health Institute"),
+            "portrait-cdc-blue",
+        )
+
     def test_suggest_no_opdiv_cdc_number_returns_cdc_theme(self):
         # Existing CDC behaviour unaffected when no OpDiv is supplied
         self.assertEqual(

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3699,6 +3699,48 @@ class HTMLSuggestThemeTests(TestCase):
         nofo_theme = "portrait-nih-white"
         self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
 
+    def test_suggest_opdiv_nih_full_name_returns_nih_theme(self):
+        self.assertEqual(
+            suggest_nofo_theme("", opdiv="National Institutes of Health (NIH)"),
+            "portrait-nih-white",
+        )
+
+    def test_suggest_opdiv_nih_abbreviation_returns_nih_theme(self):
+        self.assertEqual(
+            suggest_nofo_theme("", opdiv="NIH"),
+            "portrait-nih-white",
+        )
+
+    def test_suggest_opdiv_nih_without_abbreviation_returns_nih_theme(self):
+        self.assertEqual(
+            suggest_nofo_theme("", opdiv="National Institutes of Health"),
+            "portrait-nih-white",
+        )
+
+    def test_suggest_opdiv_nih_takes_precedence_over_number(self):
+        # PAR-27-032 has no matching prefix and would fall through to NIH anyway,
+        # but this confirms OpDiv drives the result when present
+        self.assertEqual(
+            suggest_nofo_theme(
+                "PAR-27-032", opdiv="National Institutes of Health (NIH)"
+            ),
+            "portrait-nih-white",
+        )
+
+    def test_suggest_no_opdiv_par_number_falls_to_nih_theme(self):
+        # No known prefix → catch-all NIH fallback
+        self.assertEqual(
+            suggest_nofo_theme("PAR-27-032", opdiv=""),
+            "portrait-nih-white",
+        )
+
+    def test_suggest_no_opdiv_cdc_number_returns_cdc_theme(self):
+        # Existing CDC behaviour unaffected when no OpDiv is supplied
+        self.assertEqual(
+            suggest_nofo_theme("CDC-RFA-DP-25-001", opdiv=""),
+            "portrait-cdc-blue",
+        )
+
 
 class HTMLSuggestCoverTests(TestCase):
     def test_suggest_nofo_cover_cdc_returns_medium(self):


### PR DESCRIPTION
## Summary

\`suggest_nofo_theme()\` previously relied on pattern-matching the opportunity number to identify NIH NOFOs, but NIH uses a wide variety of number formats (e.g. \`NIH-RFA-JG-26-0172\`, \`PAR-27-032\`, \`RFA-AI-25-010\`) that don't share a consistent prefix. The OpDiv field in the Word document is unambiguous and is already parsed before the theme is guessed.

## Changes

- \`nofos/nofos/nofo.py\` — \`suggest_nofo_theme(nofo_number)\` → \`suggest_nofo_theme(nofo_number, opdiv="")\`
  - New OpDiv check at the top: case-insensitive match on \`"national institutes of health"\` or \`"nih"\` returns \`portrait-nih-white\` before any number-pattern checks
  - All existing number-pattern branches (CDC, ACF, ACL, CMS, IHS, RFA, HRSA) and the NIH catch-all fallback are unchanged
  - Call site updated to pass \`opdiv=nofo.opdiv\` (already set earlier in the same block)

## Test plan

- [ ] \`make test\` passes
- [ ] Importing a NOFO with OpDiv \`"National Institutes of Health (NIH)"\` → \`theme = "portrait-nih-white"\`
- [ ] Importing a NOFO with OpDiv \`"NIH"\` → \`theme = "portrait-nih-white"\`
- [ ] Importing a NOFO with number \`"PAR-27-032"\` and no OpDiv → \`theme = "portrait-nih-white"\` (falls through to catch-all)
- [ ] Importing a NOFO with number \`"CDC-RFA-DP-25-001"\` and no OpDiv → \`theme = "portrait-cdc-blue"\` (existing behaviour unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)