### PR TITLE
Add forgot-password help text to login page

### DIFF
--- a/nofos/users/templates/users/login.html
+++ b/nofos/users/templates/users/login.html
@@ -78,7 +78,10 @@
 
       <div class="margin-top-2">
           <small class="text-base-dark">
-              Forgot your password? Request a new password from your agency's grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">NOFO Builder Feedback Form</a>.
+              Forgot your password? Request a new password from your agency's grants policy office or submit a request using the
+              <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">
+                  NOFO Builder Feedback Form
+              </a>.
           </small>
       </div>
   </form>

--- a/nofos/users/templates/users/login.html
+++ b/nofos/users/templates/users/login.html
@@ -75,6 +75,12 @@
       </fieldset>
 
       <button class="usa-button margin-top-3" type="submit">Login</button>
+
+      <div class="margin-top-2">
+          <small class="text-base-dark">
+              Forgot your password? Request a new password from your grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">NOFO Builder Feedback Form</a>.
+          </small>
+      </div>
   </form>
 
   {% if LOGIN_GOV_ENABLED %}

--- a/nofos/users/templates/users/login.html
+++ b/nofos/users/templates/users/login.html
@@ -78,7 +78,7 @@
 
       <div class="margin-top-2">
           <small class="text-base-dark">
-              Forgot your password? Request a new password from your grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">NOFO Builder Feedback Form</a>.
+              Forgot your password? Request a new password from your agency's grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">NOFO Builder Feedback Form</a>.
           </small>
       </div>
   </form>


### PR DESCRIPTION
## Summary
- Adds help text directly below the Login button on the login page pointing users to their grants policy office or the NOFO Builder Feedback Form when they need a password reset, since there's currently no self-service reset flow.
- Matches existing USWDS classes/markup already used on the page (e.g. the `text-base-dark`/`small` pattern used for the Login.gov helper text).

## Test plan
- [ ] Visit `/users/login/` and confirm the help text renders directly below the Login button
- [ ] Confirm the "NOFO Builder Feedback Form" link opens in a new tab and points to the correct Microsoft Forms URL