### PR TITLE
Fix forgot-password help text styling

### DIFF
--- a/nofos/users/templates/users/login.html
+++ b/nofos/users/templates/users/login.html
@@ -77,12 +77,11 @@
       <button class="usa-button margin-top-3" type="submit">Login</button>
 
       <div class="margin-top-2">
-          <small class="text-base-dark">
+          <p class="text-base-dark">
               Forgot your password? Request a new password from your agency's grants policy office or submit a request using the
               <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">
-                  NOFO Builder Feedback Form
-              </a>.
-          </small>
+                  NOFO Builder Feedback Form</a>.
+          </p>
       </div>
   </form>
 

--- a/nofos/users/templates/users/login.html
+++ b/nofos/users/templates/users/login.html
@@ -78,7 +78,7 @@
 
       <div class="margin-top-2">
           <p class="text-base-dark">
-              Forgot your password? Request a new password from your agency's grants policy office or submit a request using the
+              <strong>Forgot your password?</strong> Request a new password from your agency's grants policy office or submit a request using the
               <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">
                   NOFO Builder Feedback Form</a>.
           </p>


### PR DESCRIPTION
## Summary
- Change the forgot-password help text on the login page from a `<small>` tag to a standard `<p>` tag so it renders at normal text size
- Remove the stray space before the closing period so it reads "...NOFO Builder Feedback Form." with no space before the period

## Test plan
- [ ] Load the login page and confirm the forgot-password help text renders at normal font size
- [ ] Confirm the sentence ends "...NOFO Builder Feedback Form." with no space before the period