### PR TITLE
Add warning for incomplete PDF metadata

### DIFF
--- a/nofos/bloom_nofos/templates/includes/_text_input.html
+++ b/nofos/bloom_nofos/templates/includes/_text_input.html
@@ -16,7 +16,6 @@
     name="{{ id }}"
     aria-describedby="{% if hint %}{{ id }}--hint-1 {% endif %}{% if hint2 %}{{ id }}--hint-2{% endif %}{% if error %} {{ id }}--error{% endif %}"
     {% if disabled == "disabled" %}disabled{% endif %}
-    {% if required %}required{% endif %}
   >{{ value|default_if_none:'' }}</textarea>
 {% else %}
   <input
@@ -26,7 +25,6 @@
     type="{% if input_type == 'PasswordInput' %}password{% else %}text{% endif %}"
     aria-describedby="{% if hint %}{{ id }}--hint-1 {% endif %}{% if hint2 %}{{ id }}--hint-2{% endif %}{% if error %} {{ id }}--error{% endif %}"
     {% if disabled == "disabled" %}disabled{% endif %}
-    {% if required %}required{% endif %}
     value="{{ value|default_if_none:'' }}"
     />
 {% endif %}

--- a/nofos/bloom_nofos/templates/includes/_text_input.html
+++ b/nofos/bloom_nofos/templates/includes/_text_input.html
@@ -16,6 +16,7 @@
     name="{{ id }}"
     aria-describedby="{% if hint %}{{ id }}--hint-1 {% endif %}{% if hint2 %}{{ id }}--hint-2{% endif %}{% if error %} {{ id }}--error{% endif %}"
     {% if disabled == "disabled" %}disabled{% endif %}
+    {% if required %}required{% endif %}
   >{{ value|default_if_none:'' }}</textarea>
 {% else %}
   <input
@@ -25,6 +26,7 @@
     type="{% if input_type == 'PasswordInput' %}password{% else %}text{% endif %}"
     aria-describedby="{% if hint %}{{ id }}--hint-1 {% endif %}{% if hint2 %}{{ id }}--hint-2{% endif %}{% if error %} {{ id }}--error{% endif %}"
     {% if disabled == "disabled" %}disabled{% endif %}
+    {% if required %}required{% endif %}
     value="{{ value|default_if_none:'' }}"
     />
 {% endif %}

--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -237,6 +237,11 @@ class NofoCoverImageForm(forms.ModelForm):
 
 # this one needs a custom field and a custom widget so don't use the factory function
 class NofoMetadataForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.required = True
+
     class Meta:
         model = Nofo
         fields = ["author", "subject", "keywords"]

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -255,6 +255,19 @@ Edit “{{ nofo|nofo_name }}”
           </span>
         </button>
       {% endif %}
+      {% if has_missing_metadata %}
+        <button id="tab-3"
+                type="button"
+                role="tab"
+                class="secondary-darker"
+                aria-selected="false"
+                aria-controls="tabpanel-3"
+                tabindex="-1">
+          <span class="focus">
+            Check PDF metadata ({{ missing_metadata_fields|length }})
+          </span>
+        </button>
+      {% endif %}
     </div>
     {% if has_broken_links %}
       <div id="tabpanel-1" role="tabpanel" class="accent-warm-dark" tabindex="0" aria-labelledby="tab-1">
@@ -306,6 +319,38 @@ Edit “{{ nofo|nofo_name }}”
                     <li><a href="#{{ heading_error.subsection.html_id }}">{{ heading_error.subsection|subsection_name_or_order }} ({{ heading_error.subsection.tag }})</a>: {{ heading_error.error }}</li>
                     {% endfor %}
                   </ol>
+                </div>
+              </details>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    {% if has_missing_metadata %}
+      <div id="tabpanel-3" role="tabpanel" class="secondary-darker is-hidden" tabindex="0" aria-labelledby="tab-3">
+        <div class="usa-alert">
+          <div class="usa-alert__body">
+            <h3 class="usa-alert__heading">Warning: PDF metadata is incomplete</h3>
+            <div>
+              <details>
+                <summary>
+                  {% if missing_metadata_fields|length == 1 %}
+                    <span>There is 1 missing metadata field</span>
+                  {% else %}
+                    <span>There are {{ missing_metadata_fields|length }} missing metadata fields</span>
+                  {% endif %}
+                </summary>
+                <div>
+                  <ol class="usa-list usa-list--no-max-width">
+                    {% for field_label in missing_metadata_fields %}
+                      <li>{{ field_label }}</li>
+                    {% endfor %}
+                  </ol>
+                  <p>
+                    <a href="{% url 'nofos:nofo_edit_metadata' nofo.id %}">Edit NOFO metadata</a>
+                    before publishing this PDF to Grants.gov. You can still preview or download the PDF while this warning is present.
+                  </p>
                 </div>
               </details>
             </div>

--- a/nofos/nofos/templates/nofos/nofo_edit_metadata.html
+++ b/nofos/nofos/templates/nofos/nofo_edit_metadata.html
@@ -19,7 +19,7 @@
   <form id="nofo-metadata--form" method="post">
     {% csrf_token %}
 
-    {% include "includes/form_macro.html" %}
+    {% include "includes/form_macro.html" with show_required_asterisk=True %}
 
     <button class="usa-button margin-top-3" type="submit">Save metadata</button>
   </form>

--- a/nofos/nofos/tests_nofos/test_metadata_warning.py
+++ b/nofos/nofos/tests_nofos/test_metadata_warning.py
@@ -1,0 +1,166 @@
+from bs4 import BeautifulSoup
+from django.test import Client, TestCase
+from django.urls import reverse
+from users.models import BloomUser
+
+from nofos.models import Nofo
+
+
+class NofoMetadataWarningTests(TestCase):
+    def setUp(self):
+        self.user = BloomUser.objects.create_user(
+            email="metadata-warning@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.nofo = Nofo.objects.create(
+            title="Metadata warning test NOFO",
+            short_name="metadata-warning-test",
+            number="TEST-726",
+            opdiv="TEST",
+            group="bloom",
+            status="draft",
+        )
+        self.edit_url = reverse("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
+        self.metadata_url = reverse(
+            "nofos:nofo_edit_metadata", kwargs={"pk": self.nofo.id}
+        )
+
+    def _get_metadata_tab(self, response):
+        soup = BeautifulSoup(response.content, "html.parser")
+        return soup.find(id="tab-3")
+
+    def _get_metadata_panel(self, response):
+        soup = BeautifulSoup(response.content, "html.parser")
+        return soup.find(id="tabpanel-3")
+
+    def test_warning_lists_all_empty_metadata_fields(self):
+        response = self.client.get(self.edit_url)
+
+        tab = self._get_metadata_tab(response)
+        panel = self._get_metadata_panel(response)
+        self.assertIsNotNone(tab)
+        self.assertEqual(tab.get("role"), "tab")
+        self.assertEqual(tab.get("aria-controls"), "tabpanel-3")
+        self.assertIn("Check PDF metadata (3)", tab.get_text(" ", strip=True))
+        self.assertIsNotNone(panel)
+        self.assertEqual(panel.get("role"), "tabpanel")
+        self.assertEqual(panel.get("aria-labelledby"), "tab-3")
+        self.assertEqual(
+            [item.get_text(strip=True) for item in panel.select("li")],
+            ["Author", "Subject", "Keywords"],
+        )
+        self.assertIn(
+            "There are 3 missing metadata fields",
+            panel.get_text(" ", strip=True),
+        )
+        self.assertEqual(
+            panel.find("a").get("href"),
+            self.metadata_url,
+        )
+        self.assertTrue(response.context["has_warnings"])
+
+    def test_warning_only_lists_fields_that_are_missing(self):
+        self.nofo.author = "HHS"
+        self.nofo.keywords = "grants, funding"
+        self.nofo.save()
+
+        response = self.client.get(self.edit_url)
+
+        tab = self._get_metadata_tab(response)
+        panel = self._get_metadata_panel(response)
+        self.assertIn("Check PDF metadata (1)", tab.get_text(" ", strip=True))
+        self.assertEqual(
+            [item.get_text(strip=True) for item in panel.select("li")],
+            ["Subject"],
+        )
+        panel_text = panel.get_text(" ", strip=True)
+        self.assertIn("There is 1 missing metadata field", panel_text)
+        self.assertNotIn("There are 1 missing metadata fields", panel_text)
+
+    def test_whitespace_only_metadata_is_treated_as_missing(self):
+        self.nofo.author = "  "
+        self.nofo.subject = "Accessible funding opportunity"
+        self.nofo.keywords = "\n\t"
+        self.nofo.save()
+
+        response = self.client.get(self.edit_url)
+
+        panel = self._get_metadata_panel(response)
+        self.assertEqual(
+            [item.get_text(strip=True) for item in panel.select("li")],
+            ["Author", "Keywords"],
+        )
+
+    def test_warning_is_hidden_when_all_metadata_is_present(self):
+        self.nofo.author = "HHS"
+        self.nofo.subject = "Accessible funding opportunity"
+        self.nofo.keywords = "grants, funding"
+        self.nofo.save()
+
+        response = self.client.get(self.edit_url)
+
+        self.assertIsNone(self._get_metadata_tab(response))
+        self.assertIsNone(self._get_metadata_panel(response))
+        self.assertFalse(response.context["has_warnings"])
+
+    def test_saving_complete_metadata_clears_the_warning(self):
+        response = self.client.post(
+            self.metadata_url,
+            {
+                "author": "HHS",
+                "subject": "Accessible funding opportunity",
+                "keywords": "grants, funding",
+            },
+            follow=True,
+        )
+
+        self.assertRedirects(response, self.edit_url)
+        self.assertIsNone(self._get_metadata_tab(response))
+        self.assertIsNone(self._get_metadata_panel(response))
+
+    def test_metadata_edit_form_requires_all_fields(self):
+        response = self.client.get(self.metadata_url)
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        self.assertTrue(
+            all(field.required for field in response.context["form"].fields.values())
+        )
+        self.assertEqual(
+            [field.get("name") for field in soup.select("[required]")],
+            ["author", "subject", "keywords"],
+        )
+
+    def test_incomplete_metadata_cannot_be_saved(self):
+        response = self.client.post(
+            self.metadata_url,
+            {
+                "author": "HHS",
+                "subject": "",
+                "keywords": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(
+            response.context["form"], "subject", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "keywords", "This field is required."
+        )
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.author, "")
+
+    def test_warning_does_not_disable_pdf_actions(self):
+        response = self.client.get(self.edit_url)
+        soup = BeautifulSoup(response.content, "html.parser")
+        buttons = {
+            button.get_text(strip=True): button
+            for button in soup.select(".usa-button-group--print-buttons button")
+        }
+
+        self.assertNotIn("disabled", buttons["Preview PDF"].attrs)
+        self.assertNotIn("disabled", buttons["Download PDF"].attrs)

--- a/nofos/nofos/tests_nofos/test_metadata_warning.py
+++ b/nofos/nofos/tests_nofos/test_metadata_warning.py
@@ -130,9 +130,13 @@ class NofoMetadataWarningTests(TestCase):
             all(field.required for field in response.context["form"].fields.values())
         )
         self.assertEqual(
-            [field.get("name") for field in soup.select("[required]")],
-            ["author", "subject", "keywords"],
+            [
+                asterisk.get("aria-label")
+                for asterisk in soup.select(".label--required")
+            ],
+            ["(required)", "(required)", "(required)"],
         )
+        self.assertFalse(soup.select("[required]"))
 
     def test_incomplete_metadata_cannot_be_saved(self):
         response = self.client.post(
@@ -141,6 +145,39 @@ class NofoMetadataWarningTests(TestCase):
                 "author": "HHS",
                 "subject": "",
                 "keywords": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFormError(
+            response.context["form"], "subject", "This field is required."
+        )
+        self.assertFormError(
+            response.context["form"], "keywords", "This field is required."
+        )
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        for field_name in ("subject", "keywords"):
+            error = soup.find(id=f"{field_name}--error")
+            field = soup.find(attrs={"name": field_name})
+            self.assertEqual(
+                error.get_text(" ", strip=True), "Error: This field is required."
+            )
+            self.assertIn("border-secondary-dark", field.get("class", []))
+            self.assertIn(
+                f"{field_name}--error", field.get("aria-describedby", "").split()
+            )
+
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.author, "")
+
+    def test_whitespace_only_metadata_cannot_be_saved(self):
+        response = self.client.post(
+            self.metadata_url,
+            {
+                "author": "HHS",
+                "subject": "   ",
+                "keywords": "\n\t",
             },
         )
 

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -356,14 +356,27 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
         # latest audit event (to show latest editor/user)
         context["updated_by"] = self.object.updated_by
 
+        metadata_fields = (
+            ("author", "Author"),
+            ("subject", "Subject"),
+            ("keywords", "Keywords"),
+        )
+        context["missing_metadata_fields"] = [
+            label
+            for field_name, label in metadata_fields
+            if not (getattr(self.object, field_name, "") or "").strip()
+        ]
+
         # booleans to show/hide our various warning messages
+        context["has_missing_metadata"] = len(context["missing_metadata_fields"])
         context["has_broken_links"] = len(context["broken_links"])
         context["has_heading_errors"] = len(context["heading_errors"])
         context["has_external_links"] = len(
             context["external_links"]
         ) and self.object.status in ("draft", "active", "ready-for-qa", "paused")
         context["has_warnings"] = (
-            context["has_broken_links"]
+            context["has_missing_metadata"]
+            or context["has_broken_links"]
             or context["has_heading_errors"]
             or context["has_external_links"]
         )


### PR DESCRIPTION
## Summary

- add a PDF metadata warning tab to the existing “Before publishing” warnings component
- list only missing Author, Subject, and Keywords fields while keeping PDF preview and download available
- require all three fields when saving the metadata edit form, with native browser and Django validation
- cover empty, partial, whitespace-only, resolved, validation, and non-blocking PDF-action states

## Why

Imported Word documents can leave PDF metadata empty, which risks publishing a PDF to Grants.gov without the metadata needed for accessibility compliance. The warning uses the editor’s existing tabbed warning pattern and disappears once the metadata is complete.

## Validation

- `poetry run python manage.py test` — 1,462 tests passed
- `make lint` — isort and Black checks passed
- browser-verified warning tab behavior, singular/plural copy, required-field validation, and warning removal after saving complete metadata
- confirmed saved values render in the HTML metadata used for PDF generation

Closes #726
