### PR TITLE
Simplify blank-Opdiv error page: link "Import it again" to homepage

### DIFF
--- a/nofos/bloom_nofos/templates/400.html
+++ b/nofos/bloom_nofos/templates/400.html
@@ -15,14 +15,9 @@
 			<li>Open the Word document.</li>
 			<li>Add a value after ‘Opdiv:’ — this is the agency’s operating division (for example, ‘Administration for Children and Families’ or ‘CDC’).</li>
 			<li>Save the document.</li>
-			<li>Import it again.</li>
+			<li><a href="{% url 'index' %}">Import it again.</a></li>
 		</ol>
 		<p><strong>Still need help?</strong> Request assistance with your NOFO’s template from your agency’s grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl">NOFO Builder Feedback Form</a>.</p>
-		<p>What’s next: fix the file and try importing it again. Or, if you’d rather stop here:</p>
-		<ul class="usa-list">
-			<li><a href="{% url 'index' %}">homepage</a></li>
-			<li><a href="{% url 'nofos:nofo_index' %}">all nofos</a></li>
-		</ul>
 	{% else %}
 		<h1 class="font-heading-xl margin-y-0">{% if status %}{{ status }}{% else %}400{% endif %} Error</h1>
 		{% if error_message %}

--- a/nofos/nofos/tests_nofos/test_import.py
+++ b/nofos/nofos/tests_nofos/test_import.py
@@ -192,18 +192,16 @@ class TestNofoImportBlankOpdivError(TestCase):
         self.assertIn("Open the Word document.", content)
         self.assertIn("Add a value after ‘Opdiv:’", content)
         self.assertIn("Save the document.", content)
-        self.assertIn("Import it again.", content)
+        # Step 4 links "Import it again." back to the homepage
+        self.assertIn(f'<a href="{reverse("index")}">Import it again.</a>', content)
 
         # Escalation paragraph
         self.assertIn("Still need help?", content)
         self.assertIn("NOFO Builder Feedback Form", content)
         self.assertIn("https://forms.office.com/pages/responsepage.aspx", content)
 
-        # "What's next" replaces "Maybe go back to:"
-        self.assertIn("What’s next", content)
+        # No "Maybe go back to:" links/text (that's the generic 400 page's copy)
         self.assertNotIn("Maybe go back to:", content)
-        self.assertIn(f'href="{reverse("index")}"', content)
-        self.assertIn(f'href="{reverse("nofos:nofo_index")}"', content)
 
         # The raw validation error dict must not leak through
         self.assertNotIn("This field cannot be blank", content)


### PR DESCRIPTION
## Summary
Follow-up to #732.

The blank-Opdiv NOFO import error page (`400.html`, `opdiv_blank_error` branch) had a "Steps to fix" list ending in a plain-text "Import it again." step, immediately followed by a separate "What's next" paragraph and a homepage/all-NOFOs link list — effectively saying "try again" twice with two different UI treatments.

- Removed the "What's next" paragraph and its homepage/all-NOFOs `<ul>`.
- Turned step 4 of "Steps to fix" into a link back to the homepage (`<li><a href="{% url 'index' %}">Import it again.</a></li>`), reusing the same `{% url 'index' %}` tag already used elsewhere in this file.
- Scoped entirely to the `opdiv_blank_error` branch of `nofos/bloom_nofos/templates/400.html` — the generic 400 error path and other error pages (404/500) are untouched.
- Updated `TestNofoImportBlankOpdivError` in `nofos/nofos/tests_nofos/test_import.py` (covers both the HTML-missing-label and real-docx-blank-value cases) to match: dropped the "What's next" and all-NOFOs-link assertions, and added an assertion that `reverse("index")` now appears specifically as the href of the "Import it again." anchor.

### Before → After
- Before: "Steps to fix" ending in plain-text "Import it again." → separate "What's next: fix the file and try importing it again. Or, if you'd rather stop here:" paragraph → homepage / all NOFOs links.
- After: "Steps to fix" ending in a linked "Import it again." (→ homepage). No separate "What's next" section.

## Test plan
- [x] `poetry run python manage.py test nofos.tests_nofos.test_import` — all passing.
- [x] `poetry run python manage.py test nofos.tests_nofos.test_reimport nofos.tests_nofos.test_mammoth nofos.tests_nofos.test_metadata_warning` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)