### PR TITLE
Open NOFO Builder Feedback Form link in a new tab on blank-Opdiv error page

### DIFF
--- a/nofos/bloom_nofos/templates/400.html
+++ b/nofos/bloom_nofos/templates/400.html
@@ -17,7 +17,7 @@
 			<li>Save the document.</li>
 			<li><a href="{% url 'index' %}">Import it again.</a></li>
 		</ol>
-		<p><strong>Still need help?</strong> Request assistance with your NOFO’s template from your agency’s grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl">NOFO Builder Feedback Form</a>.</p>
+		<p><strong>Still need help?</strong> Request assistance with your NOFO’s template from your agency’s grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">NOFO Builder Feedback Form</a>.</p>
 	{% else %}
 		<h1 class="font-heading-xl margin-y-0">{% if status %}{{ status }}{% else %}400{% endif %} Error</h1>
 		{% if error_message %}

--- a/nofos/nofos/tests_nofos/test_import.py
+++ b/nofos/nofos/tests_nofos/test_import.py
@@ -195,10 +195,12 @@ class TestNofoImportBlankOpdivError(TestCase):
         # Step 4 links "Import it again." back to the homepage
         self.assertIn(f'<a href="{reverse("index")}">Import it again.</a>', content)
 
-        # Escalation paragraph
+        # Escalation paragraph — feedback form link opens in a new tab
         self.assertIn("Still need help?", content)
         self.assertIn("NOFO Builder Feedback Form", content)
         self.assertIn("https://forms.office.com/pages/responsepage.aspx", content)
+        self.assertIn('target="_blank"', content)
+        self.assertIn('rel="noopener noreferrer"', content)
 
         # No "Maybe go back to:" links/text (that's the generic 400 page's copy)
         self.assertNotIn("Maybe go back to:", content)


### PR DESCRIPTION
## Summary
Follow-up to the prior blank-Opdiv error page PRs (#732, #733).

The "Still need help?" escalation paragraph on the blank-Opdiv NOFO import error page (`400.html`, `opdiv_blank_error` branch) links to the NOFO Builder Feedback Form. It previously opened in the same tab, navigating the user away from the error page.

- Added `target="_blank" rel="noopener noreferrer"` to just that one link. No other links on this page (or elsewhere) were touched.
- **Convention check:** this exact URL and link text ("NOFO Builder Feedback Form") already appear in `nofos/users/templates/users/login.html:82`, using plain `target="_blank" rel="noopener noreferrer"` with no `usa-link--external` class and no visually-hidden "(opens in a new tab)" text. Followed that existing convention exactly for consistency, rather than introducing a new accessibility pattern for this one link.
- Updated the shared assertion helper in `TestNofoImportBlankOpdivError` (`nofos/nofos/tests_nofos/test_import.py`, covers both the HTML-missing-label and real-docx-blank-value tests) to assert `target="_blank"` and `rel="noopener noreferrer"` are present.

## Test plan
- [x] `poetry run python manage.py test nofos.tests_nofos.test_import` — all passing.
- [x] `poetry run python manage.py test nofos.tests_nofos.test_reimport nofos.tests_nofos.test_mammoth nofos.tests_nofos.test_metadata_warning users` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)