### PR TITLE
Preserve internal bookmark targets during import

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -27,7 +27,7 @@ from django.utils.html import escape
 from slugify import slugify
 
 from .models import Nofo, Section, Subsection
-from .nofo_markdown import md
+from .nofo_markdown import PRESERVE_BOOKMARK_TARGET_ATTR, md
 from .utils import (
     add_html_id_to_subsection,
     clean_string,
@@ -1843,10 +1843,22 @@ def combine_consecutive_links(soup):
             if next_sibling.next_sibling and next_sibling.next_sibling.name == "a":
                 next_sibling = next_sibling.next_sibling
 
+        link_href = link.get("href")
+        next_sibling_is_link = next_sibling and next_sibling.name == "a"
+        next_link_href = next_sibling.get("href") if next_sibling_is_link else None
+        same_nonempty_href = link_href and link_href == next_link_href
+        same_id_only_target = (
+            not link_href
+            and not next_link_href
+            and link.get("id")
+            and next_sibling_is_link
+            and link.get("id") == next_sibling.get("id")
+        )
+
         if (
             next_sibling
             and next_sibling.name == "a"
-            and link.get("href") == next_sibling.get("href")
+            and (same_nonempty_href or same_id_only_target)
         ):
             # If there's whitespace, add a space before merging texts
             separator = " " if whitespace_between else ""
@@ -2284,24 +2296,36 @@ def preserve_bookmark_targets(soup):
     """
     This function mutates the soup!
 
-    Adjusts empty bookmark links in an HTML document to preserve their target IDs while cleaning up the document structure.
+    Preserves referenced empty bookmark targets at their exact source locations and normalizes
+    unreferenced non-Word bookmark targets onto their parent elements.
 
-    This function processes all empty <a> tags in the provided BeautifulSoup object that meet the following criteria:
-    - Have an 'id' attribute (which does not start with an underscore)
-    - Do not contain an 'href' or any text content
+    Referenced empty anchors are marked so the Markdown converter retains them as minimal raw HTML
+    anchors. Unreferenced anchors without an underscore prefix continue through the existing
+    ``nb_bookmark_`` parent-transfer behavior. Unreferenced Word bookmarks whose IDs begin with an
+    underscore are left alone and may be discarded by Markdown conversion.
 
-    For each matching <a> tag:
-    1. The function prepends "nb_bookmark_" to the <a> tag's 'id'.
-    2. It searches for any other <a> tags in the document with an 'href' attribute pointing to the original 'id' and updates their 'href' to the new prefixed 'id'.
-    3. If the parent of the empty <a> tag does not have an 'id', the new prefixed 'id' is copied to the parent element.
-    4. The original empty <a> tag is then removed from the document.
+    Only anchors with an ``id``, no ``href``, and no text are considered.
     """
+    referenced_ids = {
+        link["href"][1:]
+        for link in soup.find_all("a", href=True)
+        if link["href"].startswith("#")
+    }
+
     empty_links = [
         a for a in soup.find_all("a", id=True, href=False) if not a.text.strip()
     ]
     for link in empty_links:
+        original_id = link.get("id", "")
+
+        if original_id in referenced_ids:
+            # Mark only targets that are actually referenced. The Markdown
+            # converter retains these empty anchors as raw HTML and removes
+            # this implementation-only attribute.
+            link[PRESERVE_BOOKMARK_TARGET_ATTR] = ""
+            continue
+
         if not link.get("id", "").startswith("_"):
-            original_id = link.get("id", "")
             new_id = "nb_bookmark_{}".format(original_id)
 
             link["id"] = new_id  # Update the id of the empty <a> tag

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -2309,7 +2309,7 @@ def preserve_bookmark_targets(soup):
     referenced_ids = {
         link["href"][1:]
         for link in soup.find_all("a", href=True)
-        if link["href"].startswith("#")
+        if link["href"].startswith("#") and link["href"][1:]
     }
 
     empty_links = [
@@ -2317,6 +2317,9 @@ def preserve_bookmark_targets(soup):
     ]
     for link in empty_links:
         original_id = link.get("id", "")
+
+        if not original_id:
+            continue
 
         if original_id in referenced_ids:
             # Mark only targets that are actually referenced. The Markdown

--- a/nofos/nofos/nofo_markdown.py
+++ b/nofos/nofos/nofo_markdown.py
@@ -7,6 +7,8 @@ from markdownify import MarkdownConverter
 # https://github.com/matthewwithanm/python-markdownify/blob/2d654a6b7e822e1547199da855c9d304d162cb27/markdownify/__init__.py#L9
 re_line_with_content = re.compile(r"^(.*)", flags=re.MULTILINE)
 
+PRESERVE_BOOKMARK_TARGET_ATTR = "data-nofo-preserve-bookmark-target"
+
 
 def get_width_class(th):
     def _get_num_columns_th(th):
@@ -62,6 +64,14 @@ class NofoMarkdownConverter(MarkdownConverter):
                 del el["class"]
 
     def convert_a(self, el, text, parent_tags):
+        # Referenced, empty bookmark targets need to remain raw HTML so their
+        # IDs survive the HTML -> Markdown -> HTML round trip at the exact
+        # location where they appeared in the source document.
+        if el.has_attr(PRESERVE_BOOKMARK_TARGET_ATTR):
+            bookmark_target = BeautifulSoup("", "html.parser").new_tag("a")
+            bookmark_target["id"] = el.get("id", "")
+            return str(bookmark_target)
+
         # keep the in-text footnote links as HTML so that the ids aren't lost
         if el and el.attrs.get("id", "").startswith(("footnote", "endnote")):
             self._remove_classes_recursive(el)

--- a/nofos/nofos/nofo_markdown.py
+++ b/nofos/nofos/nofo_markdown.py
@@ -67,9 +67,14 @@ class NofoMarkdownConverter(MarkdownConverter):
         # Referenced, empty bookmark targets need to remain raw HTML so their
         # IDs survive the HTML -> Markdown -> HTML round trip at the exact
         # location where they appeared in the source document.
-        if el.has_attr(PRESERVE_BOOKMARK_TARGET_ATTR):
+        if (
+            el.has_attr(PRESERVE_BOOKMARK_TARGET_ATTR)
+            and el.get("id")
+            and not el.get("href")
+            and not text.strip()
+        ):
             bookmark_target = BeautifulSoup("", "html.parser").new_tag("a")
-            bookmark_target["id"] = el.get("id", "")
+            bookmark_target["id"] = el["id"]
             return str(bookmark_target)
 
         # keep the in-text footnote links as HTML so that the ids aren't lost

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -5315,6 +5315,12 @@ class PreserveBookmarkTargetsTest(TestCase):
         preserve_bookmark_targets(soup)
         self.assertEqual(str(soup), html)
 
+    def test_blank_fragment_does_not_preserve_blank_id(self):
+        html = '<p><a href="#">Empty fragment</a><a id=""></a></p>'
+        soup = BeautifulSoup(html, "html.parser")
+        preserve_bookmark_targets(soup)
+        self.assertEqual(str(soup), html)
+
     def test_parent_already_has_id(self):
         html = '<p id="existing-id">Paragraph with <a id="bookmark2"></a> an empty link.</p>'
         soup = BeautifulSoup(html, "html.parser")

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -58,6 +58,7 @@ from .nofo import (
     preserve_bookmark_targets,
     preserve_heading_links,
     preserve_table_heading_links,
+    process_nofo_html,
     remove_cover_image_from_s3,
     remove_google_tracking_info_from_links,
     replace_chars,
@@ -983,6 +984,38 @@ class CreateNOFOTests(TestCase):
         self.assertEqual(len(nofo.sections.all()), 1)
         self.assertEqual(nofo.sections.first().html_class, "")
         self.assertEqual(len(nofo.sections.first().subsections.all()), 2)
+
+    def test_import_preserves_referenced_bookmark_targets(self):
+        html = """
+            <h2>Step 1: Review the Opportunity</h2>
+            <h3>Program description</h3>
+            <p>
+              Adjacent targets:
+              <a id="_unreferenced_adjacent"></a><a id="_referenced_adjacent"></a>
+            </p>
+            <p>
+              Standalone target: <a id="_referenced_standalone"></a> remains here.
+            </p>
+            <p>
+              See <a href="#_referenced_adjacent">adjacent</a> and
+              <a href="#_referenced_standalone">standalone</a>.
+            </p>
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        soup, _ = process_nofo_html(soup, top_heading_level="h2")
+        sections = get_subsections_from_sections(
+            get_sections_from_soup(soup, top_heading_level="h2"),
+            top_heading_level="h2",
+        )
+
+        nofo = create_nofo("Bookmark targets", sections, opdiv="Test OpDiv")
+        add_headings_to_document(nofo)
+
+        self.assertEqual(find_broken_links(nofo), [])
+        body = nofo.sections.first().subsections.first().body
+        self.assertIn('<a id="_referenced_adjacent"></a>', body)
+        self.assertIn('<a id="_referenced_standalone"></a>', body)
+        self.assertNotIn("data-nofo-preserve-bookmark-target", body)
 
     def test_create_nofo_success_duplicate_nofos(self):
         """
@@ -4379,11 +4412,11 @@ class CombineLinksTestCase(TestCase):
         combine_consecutive_links(soup)
         self.assertEqual(str(soup), '<p>See <a id="t.123">First link</a></p>')
 
-    def test_second_unmatched_link_is_dropped(self):
+    def test_distinct_id_only_links_are_not_merged(self):
         html = '<p>See <a id="t.111"></a><a id="t.999"></a></p>'
         soup = BeautifulSoup(html, "html.parser")
         combine_consecutive_links(soup)
-        self.assertEqual(str(soup), '<p>See <a id="t.111"></a></p>')
+        self.assertEqual(str(soup), html)
 
     def test_consecutive_links_wrapped_in_spans_merged(self):
         html = '<p>See <span><a href="#h.ggohvukufhrn">30% cost-sharing</a></span><a href="#h.ggohvukufhrn"> </a><span><a class="c6" href="#h.ggohvukufhrn">requirement</a></span></p>'
@@ -5251,7 +5284,7 @@ class PreserveBookmarkTargetsTest(TestCase):
         html = '<p>Some text and a <a id="bookmark1"></a> link.</p><a href="#bookmark1">Reference link</a>'
         soup = BeautifulSoup(html, "html.parser")
         preserve_bookmark_targets(soup)
-        expected = '<p id="nb_bookmark_bookmark1">Some text and a  link.</p><a href="#nb_bookmark_bookmark1">Reference link</a>'
+        expected = '<p>Some text and a <a data-nofo-preserve-bookmark-target="" id="bookmark1"></a> link.</p><a href="#bookmark1">Reference link</a>'
         self.assertEqual(str(soup), expected)
 
     def test_ignore_anchor_with_underscore_prefix(self):
@@ -5261,6 +5294,26 @@ class PreserveBookmarkTargetsTest(TestCase):
         # No changes expected since the id starts with an underscore
         expected = '<p>Paragraph with <a id="_internal"></a> internal bookmark.</p>'
         self.assertEqual(str(soup), expected)
+
+    def test_referenced_underscore_anchor_is_marked_for_markdown_preservation(self):
+        html = (
+            '<p>Target <a id="_internal"></a> here.</p>'
+            '<p>See <a href="#_internal">the target</a>.</p>'
+        )
+        soup = BeautifulSoup(html, "html.parser")
+        preserve_bookmark_targets(soup)
+        expected = (
+            '<p>Target <a data-nofo-preserve-bookmark-target="" '
+            'id="_internal"></a> here.</p>'
+            '<p>See <a href="#_internal">the target</a>.</p>'
+        )
+        self.assertEqual(str(soup), expected)
+
+    def test_unreferenced_underscore_anchor_is_not_marked(self):
+        html = '<p>Target <a id="_internal"></a> here.</p>'
+        soup = BeautifulSoup(html, "html.parser")
+        preserve_bookmark_targets(soup)
+        self.assertEqual(str(soup), html)
 
     def test_parent_already_has_id(self):
         html = '<p id="existing-id">Paragraph with <a id="bookmark2"></a> an empty link.</p>'
@@ -5274,8 +5327,8 @@ class PreserveBookmarkTargetsTest(TestCase):
         html = '<p>Text with a <a href="#bookmark2">reference link</a>.</p><p id="existing-id">Paragraph with <a id="bookmark2"></a> an empty link.</p>'
         soup = BeautifulSoup(html, "html.parser")
         preserve_bookmark_targets(soup)
-        # Expect that the href changes as does the original id, but the id of the parent p element does not change
-        expected = '<p>Text with a <a href="#nb_bookmark_bookmark2">reference link</a>.</p><p id="existing-id">Paragraph with <a id="nb_bookmark_bookmark2"></a> an empty link.</p>'
+        # Referenced targets remain at their exact source location.
+        expected = '<p>Text with a <a href="#bookmark2">reference link</a>.</p><p id="existing-id">Paragraph with <a data-nofo-preserve-bookmark-target="" id="bookmark2"></a> an empty link.</p>'
         self.assertEqual(str(soup), expected)
 
     def test_multiple_empty_anchors(self):

--- a/nofos/nofos/tests_nofos/test_nofo_markdown.py
+++ b/nofos/nofos/tests_nofos/test_nofo_markdown.py
@@ -596,6 +596,15 @@ class NofoMarkdownConverterATest(TestCase):
         md_body = md(html)
         self.assertEqual(md_body.strip(), expected_html)
 
+    def test_referenced_bookmark_target_remains_raw_html(self):
+        html = (
+            '<p>Before<a class="source-class" '
+            'data-nofo-preserve-bookmark-target="" id="_internal" '
+            'onclick="alert(1)"></a>after</p>'
+        )
+        expected = 'Before<a id="_internal"></a>after'
+        self.assertEqual(md(html).strip(), expected)
+
 
 class NofoMarkdownConverterPTest(TestCase):
     maxDiff = None

--- a/nofos/nofos/tests_nofos/test_nofo_markdown.py
+++ b/nofos/nofos/tests_nofos/test_nofo_markdown.py
@@ -605,6 +605,14 @@ class NofoMarkdownConverterATest(TestCase):
         expected = 'Before<a id="_internal"></a>after'
         self.assertEqual(md(html).strip(), expected)
 
+    def test_preservation_marker_does_not_replace_nonempty_link(self):
+        html = (
+            '<p>Before <a data-nofo-preserve-bookmark-target="" '
+            'href="https://example.com">important text</a> after.</p>'
+        )
+        expected = "Before [important text](https://example.com) after."
+        self.assertEqual(md(html).strip(), expected)
+
 
 class NofoMarkdownConverterPTest(TestCase):
     maxDiff = None


### PR DESCRIPTION
## What changed

NOFO Builder now keeps internal bookmark targets that are referenced by links in an imported Word document.

It preserves each target at the location specified by the source document. It does not guess that the bookmark belongs to a nearby heading or change where the link should go.

## Previous behavior

Builder could remove a valid bookmark target while importing a Word document but keep the link that pointed to it.

This happened in two ways:

- Builder treated different adjacent bookmark targets as duplicates because neither had a web address.
- Empty bookmark targets could disappear when Builder converted HTML into Markdown.

The source document could therefore contain a working internal link, but Builder would import it as broken and then report the link as an error.

## Intended behavior

When a source document contains both an internal link and its bookmark target, Builder should preserve both.

Builder now:

- keeps different bookmark targets separate
- preserves referenced empty targets through Markdown conversion
- keeps targets at their exact source positions
- leaves unrelated, unreferenced Word bookmarks alone
- does not infer or remap destinations based on nearby headings

## Validation

The CDC test document begins with four broken-link instances already present in the source. Before this fix, Builder introduced two more. After this fix, the final Builder document contains only the original four.

Both Builder-created failures are resolved:

- `_Responsiveness_criteria` is preserved
- `_Indirect_cost_agreement` is preserved

The available OCS test documents continue to import with zero broken links.

Tests and checks:

- 1,467 tests passed
- Black passed
- isort passed
- `git diff --check` passed
- model-level regression coverage was added for adjacent and standalone bookmark targets

Closes #737