### PR TITLE
Stack multi-block checkbox table content

### DIFF
--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -337,6 +337,19 @@ body.cms-white table td img.usa-icon--check_box_outline_blank {
   display: flex;
 }
 
+.section--content table tr td.usa-icon__td--multi-block > div {
+  display: block;
+}
+
+.section--content
+  table
+  tr
+  td.usa-icon__td--multi-block
+  > div
+  > .usa-icon__line {
+  display: flex;
+}
+
 .section--content table tr td.usa-icon__td {
   vertical-align: top;
 }

--- a/nofos/nofos/templatetags/replace_unicode_with_icon.py
+++ b/nofos/nofos/templatetags/replace_unicode_with_icon.py
@@ -22,6 +22,17 @@ ICONS = [
     ("◻", uswds_check_box_outline_blank_icon),  # (◻) U+25FB WHITE MEDIUM SQUARE
 ]
 
+BLOCK_LEVEL_TAG_NAMES = {
+    "blockquote",
+    "div",
+    "dl",
+    "ol",
+    "p",
+    "pre",
+    "table",
+    "ul",
+}
+
 
 def has_link_in_above_rows(td):
     # Find the parent row of the cell
@@ -166,6 +177,44 @@ def wrap_td_contents_in_div(td):
     td.append(new_div)
 
 
+def add_multi_block_checkbox_classes(td):
+    """Keep the checkbox line separate from later block content in a table cell."""
+    direct_tag_children = [child for child in td.children if isinstance(child, Tag)]
+    content_container = (
+        direct_tag_children[0]
+        if len(direct_tag_children) == 1 and direct_tag_children[0].name == "div"
+        else td
+    )
+    block_children = [
+        child
+        for child in content_container.children
+        if isinstance(child, Tag) and child.name in BLOCK_LEVEL_TAG_NAMES
+    ]
+
+    if len(block_children) <= 1:
+        return
+
+    checkbox_lines = [
+        child
+        for child in block_children
+        if child.find("img", alt="Checkbox") is not None
+    ]
+    if not checkbox_lines:
+        return
+
+    _add_class_if_not_exists_to_tag(
+        element=td,
+        classname="usa-icon__td--multi-block",
+        tag_name="td",
+    )
+    for checkbox_line in checkbox_lines:
+        _add_class_if_not_exists_to_tag(
+            element=checkbox_line,
+            classname="usa-icon__line",
+            tag_name=checkbox_line.name,
+        )
+
+
 @register.filter()
 def replace_unicode_with_icon(html_string):
     """
@@ -250,6 +299,7 @@ def replace_unicode_with_icon(html_string):
                             tag_name="td",
                         )
 
+                    add_multi_block_checkbox_classes(parent_td)
                     wrap_text_in_span(parent_td)
                     wrap_td_contents_in_div(parent_td)
 

--- a/nofos/nofos/tests_nofos/test_templatetags.py
+++ b/nofos/nofos/tests_nofos/test_templatetags.py
@@ -1,11 +1,12 @@
 import re
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from django.test import TestCase
 from django.utils.safestring import SafeString
 
 from nofos.models import Nofo, Section, Subsection
 from nofos.templatetags.add_classes_to_links import add_classes_to_broken_links
+from nofos.templatetags.replace_unicode_with_icon import replace_unicode_with_icon
 from nofos.templatetags.safe_br import safe_br
 from nofos.templatetags.utils import (
     _add_class_if_not_exists_to_tag,
@@ -34,6 +35,103 @@ from nofos.templatetags.utils import (
 class MockSection:
     def __init__(self, name):
         self.name = name
+
+
+class ReplaceUnicodeWithIconTests(TestCase):
+    def render_cell(self, cell_html):
+        result = replace_unicode_with_icon(
+            f"<table><tbody><tr><td>{cell_html}</td></tr></tbody></table>"
+        )
+        return BeautifulSoup(result, "html.parser").find("td")
+
+    def direct_tag_names(self, element):
+        return [child.name for child in element.children if isinstance(child, Tag)]
+
+    def test_simple_checkbox_cell_keeps_existing_flex_structure(self):
+        td = self.render_cell("◻ Plain text")
+
+        self.assertIn("usa-icon__td", td.get("class", []))
+        self.assertNotIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertIsNotNone(td.find("img", alt="Checkbox"))
+        self.assertEqual(self.direct_tag_names(td.div), ["img", "span"])
+        self.assertIsNone(td.find(class_="usa-icon__line"))
+
+    def test_linked_checkbox_cell_keeps_existing_flex_structure(self):
+        td = self.render_cell('◻ <a href="https://example.com">Linked label</a>')
+
+        self.assertIn("usa-icon__td--link", td.get("class", []))
+        self.assertNotIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertEqual(self.direct_tag_names(td.div), ["img", "a"])
+        self.assertIsNone(td.find(class_="usa-icon__line"))
+
+    def test_two_paragraph_checkbox_cell_marks_first_paragraph_as_icon_line(self):
+        td = self.render_cell("<p>◻ Checkbox label</p><p>More detail</p>")
+
+        self.assertIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertEqual(self.direct_tag_names(td.div), ["p", "p"])
+        self.assertIn("usa-icon__line", td.div.find_all(recursive=False)[0]["class"])
+        self.assertIsNotNone(td.div.find_all(recursive=False)[0].find("img"))
+
+    def test_checkbox_paragraph_and_list_are_separate_blocks(self):
+        td = self.render_cell(
+            "<p>◻ Training plan</p><ul><li>Include milestones</li></ul>"
+        )
+
+        self.assertIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertEqual(self.direct_tag_names(td.div), ["p", "ul"])
+        self.assertIn("usa-icon__line", td.div.p.get("class", []))
+        self.assertNotIn("usa-icon__line", td.div.ul.get("class", []))
+
+    def test_non_checkbox_multi_block_cell_is_unchanged(self):
+        td = self.render_cell(
+            "<p>Plain label</p><p>More detail</p><ul><li>Item</li></ul>"
+        )
+
+        self.assertEqual(td.get("class", []), [])
+        self.assertIsNone(td.find("div", recursive=False))
+        self.assertEqual(
+            self.direct_tag_names(td),
+            ["p", "p", "ul"],
+        )
+
+    def test_nested_inline_checkbox_marks_direct_paragraph_as_icon_line(self):
+        td = self.render_cell(
+            "<p><strong><span>◻</span> Nested label</strong></p><p>More detail</p>"
+        )
+
+        self.assertIn("usa-icon__td--multi-block", td.get("class", []))
+        checkbox_line = td.div.find_all(recursive=False)[0]
+        self.assertEqual(checkbox_line.name, "p")
+        self.assertIn("usa-icon__line", checkbox_line.get("class", []))
+        self.assertIsNotNone(checkbox_line.find("strong").find("img", alt="Checkbox"))
+
+    def test_arrow_wrapped_cell_still_marks_checkbox_line(self):
+        td = self.render_cell("<p>↑ Trend</p><p>◻ Confirm result</p><p>More detail</p>")
+
+        self.assertIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertEqual(self.direct_tag_names(td.div), ["p", "p", "p"])
+        checkbox_line = td.find("img", alt="Checkbox").find_parent("p")
+        self.assertIn("usa-icon__line", checkbox_line.get("class", []))
+        self.assertIsNotNone(td.find("img", alt="Report upward trend"))
+
+    def test_each_checkbox_paragraph_is_marked_as_an_icon_line(self):
+        td = self.render_cell("<p>◻ First choice</p><p>◻ Second choice</p>")
+
+        self.assertIn("usa-icon__td--multi-block", td.get("class", []))
+        checkbox_lines = td.find_all("p", class_="usa-icon__line")
+        self.assertEqual(len(checkbox_lines), 2)
+        self.assertTrue(
+            all(line.find("img", alt="Checkbox") for line in checkbox_lines)
+        )
+
+    def test_existing_div_with_sibling_block_is_not_treated_as_generated_wrapper(self):
+        td = self.render_cell("<div><p>◻ Checkbox label</p></div><p>More detail</p>")
+
+        self.assertIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertEqual(self.direct_tag_names(td), ["div", "p"])
+        blocks = td.find_all(recursive=False)
+        self.assertIn("usa-icon__line", blocks[0].get("class", []))
+        self.assertNotIn("usa-icon__line", blocks[1].get("class", []))
 
 
 class TestAddClassIfNotExists(TestCase):


### PR DESCRIPTION
## Summary

Fixes #742.

NOFO Builder previously applied a flex layout to every top-level block inside checkbox table cells. That worked for a checkbox with a short label, but cells containing later paragraphs or lists could render those blocks side by side.

This change keeps the checkbox and its label aligned while allowing later content to flow vertically.

## What changed

- Detect checkbox cells containing multiple content blocks.
- Apply the existing flex alignment only to each checkbox line.
- Preserve current behavior for simple and linked checkbox cells.
- Handle mixed icon cells and repeated checkbox lines.
- Add focused regression coverage for simple, linked, nested, multi-paragraph, list, mixed-icon, repeated-checkbox, and non-checkbox cases.

## User impact

Authors can use valid multi-paragraph or list content in Word table cells containing checkboxes without having to rewrite the table as HTML or flatten the content into one paragraph.

## Validation

- 163 template-tag tests pass.
- Pre-commit formatting and repository checks pass.
- The DOCX table fixture passed through the real import and render filters.
- A computed browser layout check confirmed simple rows remain aligned and later blocks stack vertically.
- An independent skeptical review identified a mixed-icon edge case, which is covered by the final implementation and tests.