### PR TITLE
Align wrapped checkbox links in HTML tables

### DIFF
--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -344,7 +344,7 @@ body.cms-white table td img.usa-icon--check_box_outline_blank {
 .section--content
   table
   tr
-  td.usa-icon__td--multi-block
+  td.usa-icon__td
   > div
   > .usa-icon__line {
   display: flex;

--- a/nofos/nofos/templatetags/replace_unicode_with_icon.py
+++ b/nofos/nofos/templatetags/replace_unicode_with_icon.py
@@ -177,8 +177,8 @@ def wrap_td_contents_in_div(td):
     td.append(new_div)
 
 
-def add_multi_block_checkbox_classes(td):
-    """Keep the checkbox line separate from later block content in a table cell."""
+def add_checkbox_layout_classes(td):
+    """Align checkbox lines while preserving later block content in a table cell."""
     direct_tag_children = [child for child in td.children if isinstance(child, Tag)]
     content_container = (
         direct_tag_children[0]
@@ -191,9 +191,6 @@ def add_multi_block_checkbox_classes(td):
         if isinstance(child, Tag) and child.name in BLOCK_LEVEL_TAG_NAMES
     ]
 
-    if len(block_children) <= 1:
-        return
-
     checkbox_lines = [
         child
         for child in block_children
@@ -202,12 +199,17 @@ def add_multi_block_checkbox_classes(td):
     if not checkbox_lines:
         return
 
-    _add_class_if_not_exists_to_tag(
-        element=td,
-        classname="usa-icon__td--multi-block",
-        tag_name="td",
-    )
+    is_multi_block = len(block_children) > 1
+    if is_multi_block:
+        _add_class_if_not_exists_to_tag(
+            element=td,
+            classname="usa-icon__td--multi-block",
+            tag_name="td",
+        )
+
     for checkbox_line in checkbox_lines:
+        if not is_multi_block and checkbox_line.name != "p":
+            continue
         _add_class_if_not_exists_to_tag(
             element=checkbox_line,
             classname="usa-icon__line",
@@ -299,7 +301,7 @@ def replace_unicode_with_icon(html_string):
                             tag_name="td",
                         )
 
-                    add_multi_block_checkbox_classes(parent_td)
+                    add_checkbox_layout_classes(parent_td)
                     wrap_text_in_span(parent_td)
                     wrap_td_contents_in_div(parent_td)
 

--- a/nofos/nofos/tests_nofos/test_templatetags.py
+++ b/nofos/nofos/tests_nofos/test_templatetags.py
@@ -64,6 +64,26 @@ class ReplaceUnicodeWithIconTests(TestCase):
         self.assertEqual(self.direct_tag_names(td.div), ["img", "a"])
         self.assertIsNone(td.find(class_="usa-icon__line"))
 
+    def test_linked_checkbox_paragraph_gets_hanging_alignment(self):
+        td = self.render_cell(
+            '<p>◻ <a href="https://example.com">Long linked label</a></p>'
+        )
+
+        self.assertIn("usa-icon__td", td.get("class", []))
+        self.assertIn("usa-icon__td--link", td.get("class", []))
+        self.assertNotIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertIn("usa-icon__line", td.div.p.get("class", []))
+        self.assertEqual(self.direct_tag_names(td.div.p), ["img", "a"])
+        self.assertEqual(td.div.p.a["href"], "https://example.com")
+
+    def test_single_checkbox_list_keeps_normal_list_layout(self):
+        td = self.render_cell("<ul><li>◻ Item one</li><li>Item two</li></ul>")
+
+        self.assertIn("usa-icon__td", td.get("class", []))
+        self.assertNotIn("usa-icon__td--multi-block", td.get("class", []))
+        self.assertNotIn("usa-icon__line", td.div.ul.get("class", []))
+        self.assertEqual(self.direct_tag_names(td.div.ul), ["li", "li"])
+
     def test_two_paragraph_checkbox_cell_marks_first_paragraph_as_icon_line(self):
         td = self.render_cell("<p>◻ Checkbox label</p><p>More detail</p>")
 


### PR DESCRIPTION
## Summary

Fixes #744.

NOFO Builder previously kept a checkbox and a long linked label inline inside one paragraph when a complex Word table was preserved as HTML. The first line began beside the checkbox, but later lines wrapped underneath it.

This change treats a checkbox-containing paragraph as one flex line, so every wrapped line aligns under the label.

## What changed

- Mark single checkbox paragraphs with the existing checkbox-line class.
- Reuse the layout pattern introduced by #743 without treating the whole cell as multi-block.
- Keep broader #743 behavior for cells containing multiple blocks.
- Preserve direct checkbox text/link cells and normal list layout.
- Add regression coverage for linked paragraphs and checkbox lists.

## User impact

Long linked labels in HTML-preserved tables now use a hanging alignment. Users do not need to rewrite the table as Markdown or remove the hyperlink.

## Validation

- 11 focused checkbox-layout tests pass.
- 165 template-tag tests pass.
- Pre-commit and diff checks pass.
- A skeptical review found a single-list regression in the first implementation; the corrected version was re-reviewed with no remaining findings.
- The real Builder browser preview showed a three-line linked label with all lines starting at the same horizontal position.
- The hyperlink target remained unchanged.
- The multi-block row from #743 remained vertically stacked.

The local PDF request reached DocRaptor, but DocRaptor could not retrieve the document from a localhost URL. Preview and PDF share the same rendered template and stylesheet; the final PDF should be checked in an environment DocRaptor can access.
