### PR TITLE
Standardize blocking import errors

### DIFF
--- a/nofos/bloom_nofos/error_helpers.py
+++ b/nofos/bloom_nofos/error_helpers.py
@@ -1,0 +1,46 @@
+from django.shortcuts import render
+
+
+def render_blocking_import_error(
+    request,
+    *,
+    title,
+    summary,
+    error_code,
+    status=400,
+    recovery_steps=None,
+    retry_url=None,
+    retry_label="Try the import again",
+):
+    """Render a safe, actionable error page for a blocked document import."""
+    return render(
+        request,
+        "import_error.html",
+        status=status,
+        context={
+            "error_title": title,
+            "error_summary": summary,
+            "error_code": error_code,
+            "recovery_steps": recovery_steps or [],
+            "retry_url": retry_url,
+            "retry_label": retry_label,
+        },
+    )
+
+
+def render_import_server_error(request, *, retry_url=None):
+    """Return a sanitized 500 response for an unexpected import failure."""
+    return render_blocking_import_error(
+        request,
+        title="We couldn’t finish importing this document",
+        summary=(
+            "Something went wrong in NOFO Builder. The document was not imported."
+        ),
+        error_code="IMPORT-UNEXPECTED",
+        status=500,
+        recovery_steps=[
+            "Try the import again.",
+            "If the problem continues, use the help options below and include the error code.",
+        ],
+        retry_url=retry_url,
+    )

--- a/nofos/bloom_nofos/error_helpers.py
+++ b/nofos/bloom_nofos/error_helpers.py
@@ -1,5 +1,10 @@
 from django.shortcuts import render
 
+DOCUMENT_STRUCTURE_RECOVERY_STEPS = (
+    "Review the document’s required metadata and heading structure.",
+    "Save the document, then select it again.",
+)
+
 
 def render_blocking_import_error(
     request,

--- a/nofos/bloom_nofos/templates/400.html
+++ b/nofos/bloom_nofos/templates/400.html
@@ -7,35 +7,22 @@
 
 
 {% block content %}
-	{% if opdiv_blank_error %}
-		<h1 class="font-heading-xl margin-y-0">We couldn’t import this NOFO</h1>
-		<p>The <strong>‘Opdiv:’</strong> field on page 1 of the Word document is blank. NOFO Builder needs this field filled in before it can import the document.</p>
-		<p>Steps to fix:</p>
-		<ol class="usa-list">
-			<li>Open the Word document.</li>
-			<li>Add a value after ‘Opdiv:’ — this is the agency’s operating division (for example, ‘Administration for Children and Families’ or ‘CDC’).</li>
-			<li>Save the document.</li>
-			<li><a href="{% url 'index' %}">Import it again.</a></li>
-		</ol>
-		<p><strong>Still need help?</strong> Request assistance with your NOFO’s template from your agency’s grants policy office or submit a request using the <a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&route=shorturl" target="_blank" rel="noopener noreferrer">NOFO Builder Feedback Form</a>.</p>
-	{% else %}
-		<h1 class="font-heading-xl margin-y-0">{% if status %}{{ status }}{% else %}400{% endif %} Error</h1>
-		{% if error_message %}
-			{% if '<p>' in error_message %}
-				{{ error_message | safe_markdown }}
-			{% else %}
-				<p><strong>{{ error_message }}</strong></p>
-			{% endif %}
-		{% elif error_message_html %}
-			{{ error_message_html | safe_markdown }}
+	<h1 class="font-heading-xl margin-y-0">{% if status %}{{ status }}{% else %}400{% endif %} Error</h1>
+	{% if error_message %}
+		{% if '<p>' in error_message %}
+			{{ error_message | safe_markdown }}
 		{% else %}
-			<p><strong>{% if status %}{{ status }}{% else %}400{% endif %} error.</strong></p>
+			<p><strong>{{ error_message }}</strong></p>
 		{% endif %}
-	  <p>If you don’t know what this means, let Paul (<a href="mailto:p.craig@bloomworks.digital">p.craig@bloomworks.digital</a>) know what happened and he will get to the bottom of it.</p>
-		<p>Maybe go back to:</p>
-		<ul class="usa-list">
-			<li><a href="{% url 'index' %}">homepage</a></li>
-			<li><a href="{% url 'nofos:nofo_index' %}">all nofos</a></li>
-		</ul>
+	{% elif error_message_html %}
+		{{ error_message_html | safe_markdown }}
+	{% else %}
+		<p><strong>{% if status %}{{ status }}{% else %}400{% endif %} error.</strong></p>
 	{% endif %}
+	{% include 'includes/error_support.html' %}
+	<p>Maybe go back to:</p>
+	<ul class="usa-list">
+		<li><a href="{% url 'index' %}">homepage</a></li>
+		<li><a href="{% url 'nofos:nofo_index' %}">all nofos</a></li>
+	</ul>
 {% endblock %}

--- a/nofos/bloom_nofos/templates/500.html
+++ b/nofos/bloom_nofos/templates/500.html
@@ -8,7 +8,7 @@
 {% block content %}
 	<h1 class="font-heading-xl margin-y-0">500 Error - Server Error</h1>
 	<p>Sorry, something went wrong on our end. Our team has been notified of this issue.</p>
-	<p>If you'd like to report this error, please <a href="https://airtable.com/appdaa5AqUwI8jdOo/pagpyAKIEOyLofFCw/form" target="_blank">submit a support ticket</a> and we'll investigate the issue.</p>
+	{% include 'includes/error_support.html' %}
 	<p>You may want to visit:</p>
 	<ul class="usa-list">
 		<li><a href="{% url 'index' %}">homepage</a></li>

--- a/nofos/bloom_nofos/templates/import_error.html
+++ b/nofos/bloom_nofos/templates/import_error.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block title %}
+	{{ error_title }}
+{% endblock %}
+
+{% block content %}
+	<h1 class="font-heading-xl margin-y-0">{{ error_title }}</h1>
+	<p>{{ error_summary }}</p>
+
+	{% if recovery_steps %}
+		<p>What to do next:</p>
+		<ol class="usa-list">
+			{% for step in recovery_steps %}
+				<li>{{ step }}</li>
+			{% endfor %}
+		</ol>
+	{% endif %}
+
+	{% if retry_url %}
+		<p><a class="usa-button" href="{{ retry_url }}">{{ retry_label }}</a></p>
+	{% endif %}
+
+	<p><strong>Error code:</strong> <code>{{ error_code }}</code></p>
+	{% include 'includes/error_support.html' %}
+{% endblock %}

--- a/nofos/bloom_nofos/templates/includes/error_support.html
+++ b/nofos/bloom_nofos/templates/includes/error_support.html
@@ -1,0 +1,7 @@
+<p>
+	<strong>Need help resolving this error?</strong>
+	Submit a request using the
+	<a href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&amp;route=shorturl" target="_blank" rel="noopener noreferrer">NOFO Builder Feedback Form</a>,
+	or email <a href="mailto:simplerNOFOs@agile6.com">simplerNOFOs@agile6.com</a>.
+	Include what you were trying to do{% if error_code %} and the error code shown above{% endif %}.
+</p>

--- a/nofos/bloom_nofos/templates/includes/feedback_link.html
+++ b/nofos/bloom_nofos/templates/includes/feedback_link.html
@@ -3,6 +3,6 @@
     class="usa-link usa-link--external{% if html_class %} {{ html_class }}{% endif %}"
     rel="noreferrer"
     target="_blank"
-    href="https://forms.office.com/r/KH4icQuZ0S"
+    href="https://forms.office.com/pages/responsepage.aspx?id=MQ4fl9YAQk644EezQrxEVYC_OcE8wOtCti0qyoocsCpUOVFCQkpaR043SVo4TkpGOFNEVkNOR0o1SyQlQCN0PWcu&amp;route=shorturl"
 >{% if link_text %}{{ link_text }}{% else %}Give us feedback{% endif %}</a>
 {% endspaceless %}

--- a/nofos/compare/test_views.py
+++ b/nofos/compare/test_views.py
@@ -353,6 +353,52 @@ class CompareImportViewTests(TestCase):
         self.assertEqual(follow_response.status_code, 200)
         self.assertContains(follow_response, "Error: Oops! No fos uploaded.")
 
+    @patch("nofos.views.parse_uploaded_file_as_html_string")
+    @patch("compare.views.create_compare_document")
+    def test_unexpected_creation_error_uses_safe_500_page(
+        self, create_document, parse_file
+    ):
+        parse_file.return_value = (
+            "<p>Opdiv: CDC</p><h1>Section</h1><h2>Subsection</h2><p>Body</p>"
+        )
+        create_document.side_effect = RuntimeError("private comparison detail")
+        uploaded_file = SimpleUploadedFile(
+            "comparison.html", b"placeholder", content_type="text/html"
+        )
+
+        response = self.client.post(self.url, {"nofo-import": uploaded_file})
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("IMPORT-UNEXPECTED", content)
+        self.assertIn(f'href="{self.url}"', content)
+        self.assertNotIn("private comparison detail", content)
+
+    @patch("nofos.views.parse_uploaded_file_as_html_string")
+    @patch("compare.views.create_nofo")
+    def test_import_to_existing_document_uses_safe_500_page(
+        self, create_document, parse_file
+    ):
+        parse_file.return_value = (
+            "<p>Opdiv: CDC</p><h1>Section</h1><h2>Subsection</h2><p>Body</p>"
+        )
+        create_document.side_effect = RuntimeError("private compare-to-doc detail")
+        document = CompareDocument.objects.create(
+            title="Existing comparison", opdiv="CDC", group="bloom"
+        )
+        url = reverse("compare:compare_import_to_doc", kwargs={"pk": document.pk})
+        uploaded_file = SimpleUploadedFile(
+            "comparison.html", b"placeholder", content_type="text/html"
+        )
+
+        response = self.client.post(url, {"nofo-import": uploaded_file})
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("IMPORT-UNEXPECTED", content)
+        self.assertIn(f'href="{url}"', content)
+        self.assertNotIn("private compare-to-doc detail", content)
+
 
 # Edit the title right after importing
 class CompareImportTitleViewTests(TestCase):

--- a/nofos/compare/views.py
+++ b/nofos/compare/views.py
@@ -3,6 +3,7 @@ import json
 import uuid
 
 from bloom_nofos.error_helpers import (
+    DOCUMENT_STRUCTURE_RECOVERY_STEPS,
     render_blocking_import_error,
     render_import_server_error,
 )
@@ -189,10 +190,7 @@ class CompareImportView(LoginRequiredMixin, BaseNofoImportView):
                     "NOFO Builder could not create a valid comparison document from the uploaded document."
                 ),
                 error_code="COMPARE-IMPORT-INVALID",
-                recovery_steps=[
-                    "Review the document’s required metadata and heading structure.",
-                    "Save the document, then select it again.",
-                ],
+                recovery_steps=DOCUMENT_STRUCTURE_RECOVERY_STEPS,
                 retry_url=reverse("compare:compare_import"),
             )
         except Exception as e:
@@ -491,10 +489,7 @@ class CompareImportToDocView(
                     "NOFO Builder could not create a valid comparison from the uploaded document."
                 ),
                 error_code="COMPARE-TO-DOC-INVALID",
-                recovery_steps=[
-                    "Review the document’s required metadata and heading structure.",
-                    "Save the document, then select it again.",
-                ],
+                recovery_steps=DOCUMENT_STRUCTURE_RECOVERY_STEPS,
                 retry_url=self.get_retry_url(),
             )
         except Exception as e:

--- a/nofos/compare/views.py
+++ b/nofos/compare/views.py
@@ -2,6 +2,10 @@ import csv
 import json
 import uuid
 
+from bloom_nofos.error_helpers import (
+    render_blocking_import_error,
+    render_import_server_error,
+)
 from bloom_nofos.logs import log_exception
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -10,7 +14,7 @@ from django.db import transaction
 from django.forms.models import model_to_dict
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.views.generic import DetailView, ListView, UpdateView, View
 
@@ -175,20 +179,32 @@ class CompareImportView(LoginRequiredMixin, BaseNofoImportView):
             log_exception(
                 request,
                 e,
-                context="CompareImportView:ValidationError",
+                context="CompareImportView:ValidationError:COMPARE-IMPORT-INVALID",
                 status=400,
             )
-            return HttpResponseBadRequest(
-                f"<p><strong>Error creating Document:</strong></p> {e.message}"
+            return render_blocking_import_error(
+                request,
+                title="We couldn’t import this comparison document",
+                summary=(
+                    "NOFO Builder could not create a valid comparison document from the uploaded document."
+                ),
+                error_code="COMPARE-IMPORT-INVALID",
+                recovery_steps=[
+                    "Review the document’s required metadata and heading structure.",
+                    "Save the document, then select it again.",
+                ],
+                retry_url=reverse("compare:compare_import"),
             )
         except Exception as e:
             log_exception(
                 request,
                 e,
-                context="CompareImportView:Exception",
+                context="CompareImportView:Exception:IMPORT-UNEXPECTED",
                 status=500,
             )
-            return HttpResponseBadRequest(f"Error creating Document: {str(e)}")
+            return render_import_server_error(
+                request, retry_url=reverse("compare:compare_import")
+            )
 
 
 class CompareImportTitleView(GroupAccessObjectMixin, UpdateView):
@@ -461,8 +477,34 @@ class CompareImportToDocView(
                 new_nofo_id=new_nofo.pk,
             )
 
+        except ValidationError as e:
+            log_exception(
+                request,
+                e,
+                context="CompareImportToDocView:ValidationError:COMPARE-TO-DOC-INVALID",
+                status=400,
+            )
+            return render_blocking_import_error(
+                request,
+                title="We couldn’t compare this document",
+                summary=(
+                    "NOFO Builder could not create a valid comparison from the uploaded document."
+                ),
+                error_code="COMPARE-TO-DOC-INVALID",
+                recovery_steps=[
+                    "Review the document’s required metadata and heading structure.",
+                    "Save the document, then select it again.",
+                ],
+                retry_url=self.get_retry_url(),
+            )
         except Exception as e:
-            return HttpResponseBadRequest(f"Error comparing document: {str(e)}")
+            log_exception(
+                request,
+                e,
+                context="CompareImportToDocView:Exception:IMPORT-UNEXPECTED",
+                status=500,
+            )
+            return render_import_server_error(request, retry_url=self.get_retry_url())
 
 
 class CompareDocumentView(GroupAccessObjectMixin, LoginRequiredMixin, View):

--- a/nofos/composer/tests/test_views.py
+++ b/nofos/composer/tests/test_views.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import patch
 
 from composer.models import (
     ContentGuide,
@@ -9,6 +10,7 @@ from composer.models import (
 from composer.views import ComposerSectionView
 from django.contrib.auth import get_user_model
 from django.contrib.messages import get_messages
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
@@ -161,6 +163,29 @@ class ComposerImportViewTests(TestCase):
         follow_response = self.client.get(response["Location"])
         self.assertEqual(follow_response.status_code, 200)
         self.assertContains(follow_response, "Error: Oops! No fos uploaded.")
+
+    @patch("nofos.views.parse_uploaded_file_as_html_string")
+    @patch("composer.views.create_content_guide_document")
+    def test_creation_validation_error_uses_safe_blocking_page(
+        self, create_document, parse_file
+    ):
+        parse_file.return_value = (
+            "<p>Opdiv: CDC</p><h1>Section</h1><h2>Subsection</h2><p>Body</p>"
+        )
+        create_document.side_effect = ValidationError(
+            {"internal_field": ["private validation detail"]}
+        )
+        uploaded_file = SimpleUploadedFile(
+            "guide.html", b"placeholder", content_type="text/html"
+        )
+
+        response = self.client.post(self.url, {"nofo-import": uploaded_file})
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("COMPOSER-IMPORT-INVALID", content)
+        self.assertIn(f'href="{self.url}"', content)
+        self.assertNotIn("private validation detail", content)
 
 
 class ComposerImportTitleViewTests(TestCase):

--- a/nofos/composer/views.py
+++ b/nofos/composer/views.py
@@ -1,6 +1,10 @@
 import json
 from typing import Dict
 
+from bloom_nofos.error_helpers import (
+    render_blocking_import_error,
+    render_import_server_error,
+)
 from bloom_nofos.html_diff import has_diff, html_diff
 from bloom_nofos.logs import log_exception
 from bloom_nofos.utils import generate_docx_download_response
@@ -468,20 +472,32 @@ class ComposerImportView(ComposerAdminRequiredMixin, BaseNofoImportView):
             log_exception(
                 request,
                 e,
-                context="ComposerImportView:ValidationError",
+                context="ComposerImportView:ValidationError:COMPOSER-IMPORT-INVALID",
                 status=400,
             )
-            return HttpResponseBadRequest(
-                f"<p><strong>Error creating Content Guide:</strong></p> {e.message}"
+            return render_blocking_import_error(
+                request,
+                title="We couldn’t import this content guide",
+                summary=(
+                    "NOFO Builder could not create a valid content guide from the uploaded document."
+                ),
+                error_code="COMPOSER-IMPORT-INVALID",
+                recovery_steps=[
+                    "Review the document’s required metadata and heading structure.",
+                    "Save the document, then select it again.",
+                ],
+                retry_url=reverse("composer:composer_import"),
             )
         except Exception as e:
             log_exception(
                 request,
                 e,
-                context="ComposerImportView:Exception",
+                context="ComposerImportView:Exception:IMPORT-UNEXPECTED",
                 status=500,
             )
-            return HttpResponseBadRequest(f"Error creating Content Guide: {str(e)}")
+            return render_import_server_error(
+                request, retry_url=reverse("composer:composer_import")
+            )
 
 
 class ComposerImportTitleView(

--- a/nofos/composer/views.py
+++ b/nofos/composer/views.py
@@ -2,6 +2,7 @@ import json
 from typing import Dict
 
 from bloom_nofos.error_helpers import (
+    DOCUMENT_STRUCTURE_RECOVERY_STEPS,
     render_blocking_import_error,
     render_import_server_error,
 )
@@ -482,10 +483,7 @@ class ComposerImportView(ComposerAdminRequiredMixin, BaseNofoImportView):
                     "NOFO Builder could not create a valid content guide from the uploaded document."
                 ),
                 error_code="COMPOSER-IMPORT-INVALID",
-                recovery_steps=[
-                    "Review the document’s required metadata and heading structure.",
-                    "Save the document, then select it again.",
-                ],
+                recovery_steps=DOCUMENT_STRUCTURE_RECOVERY_STEPS,
                 retry_url=reverse("composer:composer_import"),
             )
         except Exception as e:

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -87,7 +87,10 @@ def parse_uploaded_file_as_html_string(uploaded_file):
                 uploaded_file, style_map=style_map_manager.get_style_map()
             )
         except Exception as e:
-            raise ValidationError(f"Error importing .docx file: {e}")
+            raise ValidationError(
+                "NOFO Builder could not read this Word document.",
+                code="docx_conversion",
+            ) from e
 
         # If strict mode, check for warnings
         if config.WORD_IMPORT_STRICT_MODE:
@@ -103,7 +106,8 @@ def parse_uploaded_file_as_html_string(uploaded_file):
             if warnings:
                 warnings_str = "<ul><li>{}</li></ul>".format("</li><li>".join(warnings))
                 raise ValidationError(
-                    f"<p>Mammoth warnings found. These styles are not recognized by our style map:</p>{warnings_str}"
+                    f"<p>Mammoth warnings found. These styles are not recognized by our style map:</p>{warnings_str}",
+                    code="strict_formatting",
                 )
 
         return doc_to_html_result.value

--- a/nofos/nofos/tests_nofos/test_import.py
+++ b/nofos/nofos/tests_nofos/test_import.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 from constance.test import override_config
 from django.conf import settings
@@ -8,6 +9,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from users.models import BloomUser
 
+from nofos.models import Nofo
 from nofos.nofo import parse_uploaded_file_as_html_string
 
 
@@ -124,6 +126,22 @@ class TestParseNofoFile(TestCase):
                 str(context.exception),
             )
 
+    @patch("nofos.nofo.mammoth.convert_to_html")
+    def test_docx_conversion_error_is_sanitized(self, convert_to_html):
+        convert_to_html.side_effect = RuntimeError("private converter detail")
+        docx_file = SimpleUploadedFile(
+            "broken.docx",
+            b"not important",
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            parse_uploaded_file_as_html_string(docx_file)
+
+        self.assertEqual(context.exception.error_list[0].code, "docx_conversion")
+        self.assertIn("could not read this Word document", str(context.exception))
+        self.assertNotIn("private converter detail", str(context.exception))
+
 
 class TestNofoImportBlankOpdivError(TestCase):
     """
@@ -190,17 +208,20 @@ class TestNofoImportBlankOpdivError(TestCase):
 
         # Steps to fix
         self.assertIn("Open the Word document.", content)
-        self.assertIn("Add a value after ‘Opdiv:’", content)
-        self.assertIn("Save the document.", content)
-        # Step 4 links "Import it again." back to the homepage
-        self.assertIn(f'<a href="{reverse("index")}">Import it again.</a>', content)
+        self.assertIn("Add the agency’s operating division after ‘Opdiv:’", content)
+        self.assertIn("Save the document, then select it again.", content)
+        # The retry action returns directly to the import form.
+        self.assertIn(f'href="{reverse("nofos:nofo_import")}"', content)
+        self.assertIn("Try the import again", content)
 
-        # Escalation paragraph — feedback form link opens in a new tab
-        self.assertIn("Still need help?", content)
+        # Escalation paragraph uses the shared support channels.
+        self.assertIn("Need help resolving this error?", content)
         self.assertIn("NOFO Builder Feedback Form", content)
         self.assertIn("https://forms.office.com/pages/responsepage.aspx", content)
+        self.assertIn("simplerNOFOs@agile6.com", content)
         self.assertIn('target="_blank"', content)
         self.assertIn('rel="noopener noreferrer"', content)
+        self.assertIn("IMPORT-OPDIV-BLANK", content)
 
         # No "Maybe go back to:" links/text (that's the generic 400 page's copy)
         self.assertNotIn("Maybe go back to:", content)
@@ -228,7 +249,7 @@ class TestNofoImportBlankOpdivError(TestCase):
         """
         Real .docx upload (via Mammoth conversion) where the "OpDiv:" label is
         present on the page but has no value after it — the real-world scenario
-        from the original bug report.
+        from the originally reported bug.
         """
         response = self.client.post(
             reverse("nofos:nofo_import"),
@@ -240,3 +261,132 @@ class TestNofoImportBlankOpdivError(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self._assert_actionable_opdiv_error_page(response.content.decode("utf-8"))
+
+
+class TestBlockingImportErrorPages(TestCase):
+    def setUp(self):
+        self.user = BloomUser.objects.create_user(
+            email="errors@example.com",
+            password="testpass123",
+            force_password_reset=False,
+            group="bloom",
+        )
+        self.client.login(email="errors@example.com", password="testpass123")
+        self.import_url = reverse("nofos:nofo_import")
+        self.docx_warning_fixture_path = os.path.join(
+            settings.BASE_DIR,
+            "nofos",
+            "fixtures",
+            "docx",
+            "lists--mammoth-warning.docx",
+        )
+
+    def test_strict_mode_warning_is_actionable_and_hides_converter_details(self):
+        with open(self.docx_warning_fixture_path, "rb") as f:
+            docx_file = SimpleUploadedFile(
+                "lists--mammoth-warning.docx",
+                f.read(),
+                content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+
+        with override_config(WORD_IMPORT_STRICT_MODE=True):
+            response = self.client.post(self.import_url, {"nofo-import": docx_file})
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 422)
+        self.assertIn("We couldn’t import this document", content)
+        self.assertIn("IMPORT-STRICT-FORMATTING", content)
+        self.assertIn(f'href="{self.import_url}"', content)
+        self.assertIn("simplerNOFOs@agile6.com", content)
+        self.assertNotIn("Mammoth", content)
+        self.assertNotIn("Style ID", content)
+        self.assertNotIn("Paulsundocumentedstyle", content)
+
+    @patch("nofos.views.log_exception")
+    @patch("nofos.nofo.mammoth.convert_to_html")
+    def test_docx_conversion_failure_uses_logged_safe_page(
+        self, convert_to_html, log_error
+    ):
+        convert_to_html.side_effect = RuntimeError("private converter detail")
+        docx_file = SimpleUploadedFile(
+            "broken.docx",
+            b"not important",
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+        response = self.client.post(self.import_url, {"nofo-import": docx_file})
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 422)
+        self.assertIn("IMPORT-DOCX-CONVERSION", content)
+        self.assertIn(f'href="{self.import_url}"', content)
+        self.assertNotIn("private converter detail", content)
+        log_error.assert_called_once()
+        self.assertEqual(
+            log_error.call_args.kwargs["context"],
+            "BaseNofoImportView:ValidationError:IMPORT-DOCX-CONVERSION",
+        )
+
+    @patch("nofos.views.log_exception")
+    def test_strict_formatting_code_is_logged(self, log_error):
+        with open(self.docx_warning_fixture_path, "rb") as f:
+            docx_file = SimpleUploadedFile(
+                "lists--mammoth-warning.docx",
+                f.read(),
+                content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+
+        with override_config(WORD_IMPORT_STRICT_MODE=True):
+            response = self.client.post(self.import_url, {"nofo-import": docx_file})
+
+        self.assertEqual(response.status_code, 422)
+        log_error.assert_called_once()
+        self.assertEqual(
+            log_error.call_args.kwargs["context"],
+            "BaseNofoImportView:ValidationError:IMPORT-STRICT-FORMATTING",
+        )
+
+    @patch("nofos.views.parse_uploaded_file_as_html_string")
+    def test_unexpected_import_error_returns_sanitized_500(self, parse_file):
+        parse_file.side_effect = RuntimeError("private implementation detail")
+        uploaded_file = SimpleUploadedFile(
+            "test.html", b"<h1>Test</h1>", content_type="text/html"
+        )
+
+        response = self.client.post(self.import_url, {"nofo-import": uploaded_file})
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("We couldn’t finish importing this document", content)
+        self.assertIn("IMPORT-UNEXPECTED", content)
+        self.assertIn(f'href="{self.import_url}"', content)
+        self.assertIn("simplerNOFOs@agile6.com", content)
+        self.assertNotIn("private implementation detail", content)
+
+    @patch("nofos.views.parse_uploaded_file_as_html_string")
+    def test_blocked_reimport_uses_shared_page_and_returns_to_nofo(self, parse_file):
+        parse_file.return_value = (
+            "<p>Opportunity number: TEST-001</p>"
+            "<h1>Section</h1><h2>Subsection</h2><p>Body</p>"
+        )
+        nofo = Nofo.objects.create(
+            title="Published NOFO",
+            number="TEST-001",
+            opdiv="CDC",
+            group="bloom",
+            status="published",
+        )
+        reimport_url = reverse("nofos:nofo_import_overwrite", kwargs={"pk": nofo.id})
+        uploaded_file = SimpleUploadedFile(
+            "test.html", b"placeholder", content_type="text/html"
+        )
+
+        response = self.client.post(reimport_url, {"nofo-import": uploaded_file})
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("REIMPORT-STATUS-BLOCKED", content)
+        self.assertIn(
+            f'href="{reverse("nofos:nofo_edit", kwargs={"pk": nofo.id})}"',
+            content,
+        )

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import docraptor
 from bloom_nofos.error_helpers import (
+    DOCUMENT_STRUCTURE_RECOVERY_STEPS,
     render_blocking_import_error,
     render_import_server_error,
 )
@@ -527,8 +528,7 @@ class BaseNofoImportView(View):
                     retry_url=self.get_retry_url(),
                 )
 
-            # Retain the message check for older callers that do not set a code.
-            if "strict_formatting" in error_codes or "Mammoth" in error_message:
+            if "strict_formatting" in error_codes:
                 log_exception(
                     request,
                     e,
@@ -671,10 +671,7 @@ class NofosImportNewView(BaseNofoImportView):
                     "NOFO Builder could not create a valid NOFO from the uploaded document."
                 ),
                 error_code="IMPORT-CREATE-INVALID",
-                recovery_steps=[
-                    "Review the document’s required metadata and heading structure.",
-                    "Save the document, then select it again.",
-                ],
+                recovery_steps=DOCUMENT_STRUCTURE_RECOVERY_STEPS,
                 retry_url=self.get_retry_url(),
             )
         except Exception as e:
@@ -797,10 +794,7 @@ class NofosImportOverwriteView(
                     "NOFO Builder could not replace this NOFO with the uploaded document."
                 ),
                 error_code="REIMPORT-DOCUMENT-INVALID",
-                recovery_steps=[
-                    "Review the document’s required metadata and heading structure.",
-                    "Save the document, then select it again.",
-                ],
+                recovery_steps=DOCUMENT_STRUCTURE_RECOVERY_STEPS,
                 retry_url=reverse(
                     "nofos:nofo_import_overwrite", kwargs={"pk": nofo.id}
                 ),

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -4,6 +4,10 @@ import uuid
 from datetime import datetime
 
 import docraptor
+from bloom_nofos.error_helpers import (
+    render_blocking_import_error,
+    render_import_server_error,
+)
 from bloom_nofos.html_diff import has_diff, html_diff
 from bloom_nofos.logs import log_exception
 from bloom_nofos.utils import cast_to_boolean, generate_docx_download_response
@@ -18,7 +22,7 @@ from django.db.models import Q
 from django.forms.models import model_to_dict
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.utils import dateformat, dateparse, timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -452,6 +456,11 @@ class BaseNofoImportView(View):
         """
         return {}
 
+    def get_retry_url(self):
+        return reverse(
+            self.get_redirect_url_name(), kwargs=self.get_redirect_url_kwargs()
+        )
+
     def get(self, request, *args, **kwargs):
         """
         Default get method: just render a template.
@@ -490,14 +499,57 @@ class BaseNofoImportView(View):
             )
 
         except ValidationError as e:
-            # Render a distinct error page for mammoth style map warnings
+            error_codes = {
+                error.code for error in getattr(e, "error_list", []) if error.code
+            }
             error_message = ",".join(e.messages)
-            if "Mammoth" in error_message:
-                return render(
+
+            if "docx_conversion" in error_codes:
+                log_exception(
                     request,
-                    "400.html",
+                    e,
+                    context="BaseNofoImportView:ValidationError:IMPORT-DOCX-CONVERSION",
                     status=422,
-                    context={"error_message_html": error_message, "status": 422},
+                )
+                return render_blocking_import_error(
+                    request,
+                    title="We couldn’t import this Word document",
+                    summary=(
+                        "NOFO Builder could not read the selected Word document. "
+                        "The document was not imported."
+                    ),
+                    error_code="IMPORT-DOCX-CONVERSION",
+                    status=422,
+                    recovery_steps=[
+                        "Open the document in Word and confirm that it opens normally.",
+                        "Save it as a new .docx file, then select the new file.",
+                    ],
+                    retry_url=self.get_retry_url(),
+                )
+
+            # Retain the message check for older callers that do not set a code.
+            if "strict_formatting" in error_codes or "Mammoth" in error_message:
+                log_exception(
+                    request,
+                    e,
+                    context="BaseNofoImportView:ValidationError:IMPORT-STRICT-FORMATTING",
+                    status=422,
+                )
+                return render_blocking_import_error(
+                    request,
+                    title="We couldn’t import this document",
+                    summary=(
+                        "The Word document contains formatting that NOFO Builder "
+                        "cannot safely process while strict import checks are enabled."
+                    ),
+                    error_code="IMPORT-STRICT-FORMATTING",
+                    status=422,
+                    recovery_steps=[
+                        "Open the document in Word.",
+                        "Ask a NOFO designer or administrator to review its custom formatting and styles.",
+                        "Save the document, then select it again.",
+                    ],
+                    retry_url=self.get_retry_url(),
                 )
 
             # These errors show up as inline validation errors
@@ -510,10 +562,10 @@ class BaseNofoImportView(View):
             log_exception(
                 request,
                 e,
-                context="BaseNofoImportView:Exception",
+                context="BaseNofoImportView:Exception:IMPORT-UNEXPECTED",
                 status=500,
             )
-            return HttpResponseBadRequest(f"500 error: {str(e)}")
+            return render_import_server_error(request, retry_url=self.get_retry_url())
 
         filename = uploaded_file.name.strip()
 
@@ -580,41 +632,59 @@ class NofosImportNewView(BaseNofoImportView):
             return redirect("nofos:nofo_import_title", pk=nofo.id)
 
         except ValidationError as e:
+            opdiv_errors = getattr(e, "error_dict", {}).get("opdiv", [])
+            is_blank_opdiv = any(error.code == "blank" for error in opdiv_errors)
             log_exception(
                 request,
                 e,
-                context="NofosImportNewView:ValidationError",
+                context=(
+                    "NofosImportNewView:ValidationError:IMPORT-OPDIV-BLANK"
+                    if is_blank_opdiv
+                    else "NofosImportNewView:ValidationError:IMPORT-CREATE-INVALID"
+                ),
                 status=400,
             )
 
             # Blank "Opdiv:" field gets a dedicated, actionable error page
-            opdiv_errors = getattr(e, "error_dict", {}).get("opdiv", [])
-            if any(error.code == "blank" for error in opdiv_errors):
-                return render(
+            if is_blank_opdiv:
+                return render_blocking_import_error(
                     request,
-                    "400.html",
+                    title="We couldn’t import this NOFO",
+                    summary=(
+                        "The ‘Opdiv:’ field on page 1 of the Word document is blank. "
+                        "NOFO Builder needs this field filled in before it can import the document."
+                    ),
+                    error_code="IMPORT-OPDIV-BLANK",
                     status=400,
-                    context={"opdiv_blank_error": True, "status": 400},
+                    recovery_steps=[
+                        "Open the Word document.",
+                        "Add the agency’s operating division after ‘Opdiv:’ (for example, ‘Administration for Children and Families’ or ‘CDC’).",
+                        "Save the document, then select it again.",
+                    ],
+                    retry_url=self.get_retry_url(),
                 )
 
-            message = (
-                e.message
-                if hasattr(e, "message")
-                else (
-                    str(e.message_dict) if hasattr(e, "message_dict") else e.messages[0]
-                )
-            )
-            return HttpResponseBadRequest(
-                f"<p><strong>Error creating NOFO:</strong></p> {message}"
+            return render_blocking_import_error(
+                request,
+                title="We couldn’t create this NOFO",
+                summary=(
+                    "NOFO Builder could not create a valid NOFO from the uploaded document."
+                ),
+                error_code="IMPORT-CREATE-INVALID",
+                recovery_steps=[
+                    "Review the document’s required metadata and heading structure.",
+                    "Save the document, then select it again.",
+                ],
+                retry_url=self.get_retry_url(),
             )
         except Exception as e:
             log_exception(
                 request,
                 e,
-                context="NofosImportNewView:Exception",
+                context="NofosImportNewView:Exception:IMPORT-UNEXPECTED",
                 status=500,
             )
-            return HttpResponseBadRequest(f"Error creating NOFO: {str(e)}")
+            return render_import_server_error(request, retry_url=self.get_retry_url())
 
 
 class NofosImportOverwriteView(
@@ -651,8 +721,15 @@ class NofosImportOverwriteView(
         """
         nofo = self.nofo
         if nofo.status in ["published", "review", "doge", "paused"]:
-            return HttpResponseBadRequest(
-                "{} NOFOs can’t be re-imported.".format(nofo.get_status_display())
+            return render_blocking_import_error(
+                request,
+                title="We couldn’t re-import this NOFO",
+                summary="{} NOFOs can’t be re-imported.".format(
+                    nofo.get_status_display()
+                ),
+                error_code="REIMPORT-STATUS-BLOCKED",
+                retry_url=reverse("nofos:nofo_edit", kwargs={"pk": nofo.id}),
+                retry_label="Return to the NOFO",
             )
 
         if_preserve_page_breaks = request.POST.get("preserve_page_breaks") == "on"
@@ -710,20 +787,37 @@ class NofosImportOverwriteView(
             log_exception(
                 request,
                 e,
-                context="NofosImportOverwriteView:ValidationError",
+                context="NofosImportOverwriteView:ValidationError:REIMPORT-DOCUMENT-INVALID",
                 status=400,
             )
-            return HttpResponseBadRequest(
-                f"<p><strong>Error re-importing NOFO:</strong></p> {e.message}"
+            return render_blocking_import_error(
+                request,
+                title="We couldn’t re-import this NOFO",
+                summary=(
+                    "NOFO Builder could not replace this NOFO with the uploaded document."
+                ),
+                error_code="REIMPORT-DOCUMENT-INVALID",
+                recovery_steps=[
+                    "Review the document’s required metadata and heading structure.",
+                    "Save the document, then select it again.",
+                ],
+                retry_url=reverse(
+                    "nofos:nofo_import_overwrite", kwargs={"pk": nofo.id}
+                ),
             )
         except Exception as e:
             log_exception(
                 request,
                 e,
-                context="NofosImportOverwriteView:Exception",
+                context="NofosImportOverwriteView:Exception:IMPORT-UNEXPECTED",
                 status=500,
             )
-            return HttpResponseBadRequest(f"Error re-importing NOFO: {str(e)}")
+            return render_import_server_error(
+                request,
+                retry_url=reverse(
+                    "nofos:nofo_import_overwrite", kwargs={"pk": nofo.id}
+                ),
+            )
 
 
 class NofosConfirmReimportView(GroupAccessObjectMixin, View):


### PR DESCRIPTION
## Summary

Standardize blocking import errors across NOFO import, re-import, Composer, and Compare.

Previously, these failures used several different full-page responses. Some exposed converter or validation details, some returned HTTP 400 for unexpected server failures, and recovery and support guidance varied by workflow.

Now, blocking import failures use one plain-language pattern with:

- context-specific explanations and recovery steps
- retry links that return to the originating workflow
- stable support codes that are also recorded in logs
- the NOFO Builder Feedback Form and simplerNOFOs@agile6.com
- sanitized HTTP 500 responses for unexpected failures
- sanitized HTTP 422 responses for Word conversion and strict-formatting failures

The existing inline form validation and pre-publishing checks are unchanged.

## Screenshots

### Recoverable import error

<img width="1280" height="720" alt="Recoverable blank OpDiv import error" src="https://github.com/user-attachments/assets/1c50d573-46d6-400a-8722-abb1a2429ecd" />

### Unexpected import error

<img width="1280" height="720" alt="Sanitized unexpected import error" src="https://github.com/user-attachments/assets/d054d5d8-b01a-4a4f-9bba-90f996a984b6" />

## Validation

- 25 focused import, Composer, and Compare tests passed
- full suite: 1,491 tests passed
- Black and isort checks passed
- skeptical subagent review completed with no remaining findings
- visually verified the recoverable and unexpected error pages locally

Closes #746