### PR TITLE
Default HRSA NOFOs to Light theme

### DIFF
--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -151,6 +151,11 @@ NIH_ALLOWED_CHOICES = {
     "icon_style": frozenset(["nofo--icons--solid"]),
 }
 
+# Keep legacy theme values valid on stored NOFOs, but do not offer them for new selection.
+RETIRED_THEME_CHOICES = {
+    "portrait-hrsa-blue": "HRSA (Default, legacy)",
+}
+
 
 class NofoThemeOptionsForm(forms.ModelForm):
     class Meta:
@@ -161,6 +166,23 @@ class NofoThemeOptionsForm(forms.ModelForm):
         super(NofoThemeOptionsForm, self).__init__(*args, **kwargs)
 
         self.user = user
+        existing_legacy_theme = None
+        if self.instance and not self.instance._state.adding:
+            if self.instance.theme in RETIRED_THEME_CHOICES:
+                existing_legacy_theme = self.instance.theme
+
+        selectable_theme_choices = [
+            (
+                value,
+                (
+                    RETIRED_THEME_CHOICES[value]
+                    if value == existing_legacy_theme
+                    else label
+                ),
+            )
+            for value, label in THEME_CHOICES
+            if value not in RETIRED_THEME_CHOICES or value == existing_legacy_theme
+        ]
 
         if user_is_nih_group(user):
             # NIH users see a restricted set of choices for all three fields.
@@ -169,7 +191,7 @@ class NofoThemeOptionsForm(forms.ModelForm):
                     "NIH",
                     [
                         (v, l)
-                        for v, l in THEME_CHOICES
+                        for v, l in selectable_theme_choices
                         if v in NIH_ALLOWED_CHOICES["theme"]
                     ],
                 )
@@ -187,7 +209,7 @@ class NofoThemeOptionsForm(forms.ModelForm):
         else:
             # -------- Filter theme choices into optgroups by OpDiv
             theme_categories_dict = {}
-            for value, label in THEME_CHOICES:
+            for value, label in selectable_theme_choices:
                 opdiv = label.split(" ")[0]
                 theme_categories_dict.setdefault(opdiv, []).append((value, label))
 

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1556,6 +1556,11 @@ def suggest_nofo_theme(nofo_number, opdiv=""):
     ):
         return "portrait-nih-white"
 
+    if "health resources and services administration" in opdiv_lower or re.search(
+        r"\bhrsa\b", opdiv_lower
+    ):
+        return "portrait-hrsa-white"
+
     if "cdc-" in nofo_number.lower():
         return "portrait-cdc-blue"
 
@@ -1571,12 +1576,12 @@ def suggest_nofo_theme(nofo_number, opdiv=""):
     if "ihs-" in nofo_number.lower():
         return "portrait-ihs-white"
 
+    if re.search(r"(?:^|-)hrsa-", nofo_number.lower()):
+        return "portrait-hrsa-white"
+
     # NOFO numbers with "RFA" are also CDC, but do this check last
     if "rfa-" in nofo_number.lower():
         return "portrait-cdc-blue"
-
-    if "hrsa-" in nofo_number.lower():
-        return "portrait-hrsa-blue"
 
     return "portrait-nih-white"
 

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3679,8 +3679,26 @@ class HTMLSuggestDeadlineTests(TestCase):
 class HTMLSuggestThemeTests(TestCase):
     def test_suggest_nofo_number_hrsa_returns_hrsa_theme(self):
         nofo_number = "HRSA-24-019"
-        nofo_theme = "portrait-hrsa-blue"
+        nofo_theme = "portrait-hrsa-white"
         self.assertEqual(suggest_nofo_theme(nofo_number), nofo_theme)
+
+    def test_suggest_nofo_number_embedded_hrsa_returns_hrsa_theme(self):
+        self.assertEqual(
+            suggest_nofo_theme("HHS-2027-HRSA-ABC-001"),
+            "portrait-hrsa-white",
+        )
+
+    def test_suggest_nofo_number_hrsa_takes_precedence_over_rfa(self):
+        self.assertEqual(
+            suggest_nofo_theme("HRSA-RFA-24-019"),
+            "portrait-hrsa-white",
+        )
+
+    def test_suggest_nofo_number_hrsa_substring_does_not_match(self):
+        self.assertEqual(
+            suggest_nofo_theme("NOTHRSA-24-019"),
+            "portrait-nih-white",
+        )
 
     def test_suggest_nofo_number_nih_returns_nih_theme(self):
         nofo_number = "NIH-25-001"
@@ -3758,6 +3776,36 @@ class HTMLSuggestThemeTests(TestCase):
                 "CDC-RFA-DP-25-001", opdiv="National Institutes of Health (NIH)"
             ),
             "portrait-nih-white",
+        )
+
+    def test_suggest_opdiv_hrsa_full_name_returns_hrsa_light_theme(self):
+        self.assertEqual(
+            suggest_nofo_theme(
+                "UNKNOWN-001",
+                opdiv="Health Resources and Services Administration",
+            ),
+            "portrait-hrsa-white",
+        )
+
+    def test_suggest_opdiv_hrsa_abbreviation_returns_hrsa_light_theme(self):
+        self.assertEqual(
+            suggest_nofo_theme("UNKNOWN-001", opdiv="HRSA"),
+            "portrait-hrsa-white",
+        )
+
+    def test_suggest_opdiv_nih_takes_precedence_over_hrsa(self):
+        self.assertEqual(
+            suggest_nofo_theme(
+                "HRSA-24-019",
+                opdiv="National Institutes of Health (NIH), not HRSA",
+            ),
+            "portrait-nih-white",
+        )
+
+    def test_suggest_opdiv_containing_hrsa_substring_does_not_match(self):
+        self.assertEqual(
+            suggest_nofo_theme("CDC-RFA-DP-25-001", opdiv="CHRSAlliance"),
+            "portrait-cdc-blue",
         )
 
     def test_suggest_no_opdiv_par_number_falls_to_nih_theme(self):
@@ -4088,7 +4136,7 @@ class SuggestNofoFieldsTests(TestCase):
             self.nofo.keywords,
             "cowpolk, wild west, economic development, training, cattle ranching",
         )
-        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
+        self.assertEqual(self.nofo.theme, "portrait-hrsa-white")
         self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
 
     def test_suggest_all_nofo_fields_with_missing_data(self):
@@ -4118,7 +4166,7 @@ class SuggestNofoFieldsTests(TestCase):
         self.assertEqual(self.nofo.keywords, "")
 
         # still get set
-        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
+        self.assertEqual(self.nofo.theme, "portrait-hrsa-white")
         self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
 
     def test_suggest_all_nofo_fields_overwrite_empty_fields(self):

--- a/nofos/nofos/tests_nofos/test_theme_options.py
+++ b/nofos/nofos/tests_nofos/test_theme_options.py
@@ -6,6 +6,12 @@ from nofos.forms import NIH_ALLOWED_CHOICES, NIH_THEME_DEFAULTS, NofoThemeOption
 from nofos.models import Nofo
 
 
+def _theme_choice_values(form):
+    return [
+        value for _, options in form.fields["theme"].choices for value, _ in options
+    ]
+
+
 def _make_nofo(group, **overrides):
     defaults = dict(
         title="Test NOFO",
@@ -35,8 +41,7 @@ class NIHUserThemeOptionsFormTests(TestCase):
 
     def test_theme_choices_restricted_to_nih_only(self):
         form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
-        all_values = [v for _, opts in form.fields["theme"].choices for v, _ in opts]
-        self.assertEqual(all_values, ["portrait-nih-white"])
+        self.assertEqual(_theme_choice_values(form), ["portrait-nih-white"])
 
     def test_cover_choices_exclude_hero(self):
         form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
@@ -213,7 +218,7 @@ class NonNIHUserThemeOptionsTests(TestCase):
         self.user = _make_user("hrsa")
         self.nofo = _make_nofo(
             "hrsa",
-            theme="portrait-hrsa-blue",
+            theme="portrait-hrsa-white",
             cover="nofo--cover-page--hero",
             icon_style="nofo--icons--border",
         )
@@ -228,6 +233,22 @@ class NonNIHUserThemeOptionsTests(TestCase):
         self.assertIn("nofo--cover-page--medium", cover_values)
         self.assertIn("nofo--cover-page--text", cover_values)
 
+    def test_hrsa_user_only_sees_hrsa_light_theme(self):
+        form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
+        self.assertEqual(_theme_choice_values(form), ["portrait-hrsa-white"])
+
+    def test_bloom_user_does_not_see_retired_hrsa_theme(self):
+        bloom_user = _make_user("bloom")
+        form = NofoThemeOptionsForm(instance=self.nofo, user=bloom_user)
+        theme_values = _theme_choice_values(form)
+        self.assertIn("portrait-hrsa-white", theme_values)
+        self.assertNotIn("portrait-hrsa-blue", theme_values)
+
+    def test_new_nofo_cannot_select_retired_hrsa_theme(self):
+        unsaved_nofo = Nofo(group="hrsa", theme="portrait-hrsa-blue")
+        form = NofoThemeOptionsForm(instance=unsaved_nofo, user=self.user)
+        self.assertNotIn("portrait-hrsa-blue", _theme_choice_values(form))
+
     def test_non_nih_user_sees_multiple_icon_style_choices(self):
         form = NofoThemeOptionsForm(instance=self.nofo, user=self.user)
         icon_values = [v for v, _ in form.fields["icon_style"].choices]
@@ -235,6 +256,9 @@ class NonNIHUserThemeOptionsTests(TestCase):
         self.assertGreater(len(icon_values), 1)
 
     def test_non_nih_user_get_does_not_change_nofo_fields(self):
+        self.nofo.theme = "portrait-hrsa-blue"
+        self.nofo.save()
+
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.nofo.refresh_from_db()
@@ -242,11 +266,60 @@ class NonNIHUserThemeOptionsTests(TestCase):
         self.assertEqual(self.nofo.cover, "nofo--cover-page--hero")
         self.assertEqual(self.nofo.icon_style, "nofo--icons--border")
 
+    def test_legacy_hrsa_theme_can_be_preserved_when_saving_other_options(self):
+        self.nofo.theme = "portrait-hrsa-blue"
+        self.nofo.save()
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "HRSA (Default, legacy)")
+        self.assertContains(
+            response,
+            '<option value="portrait-hrsa-blue" selected>',
+        )
+
+        response = self.client.post(
+            self.url,
+            {
+                "theme": "portrait-hrsa-blue",
+                "cover": "nofo--cover-page--medium",
+                "icon_style": "nofo--icons--solid",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
+        self.assertEqual(self.nofo.cover, "nofo--cover-page--medium")
+        self.assertEqual(self.nofo.icon_style, "nofo--icons--solid")
+
+    def test_legacy_hrsa_theme_remains_model_valid_and_renderable(self):
+        self.nofo.theme = "portrait-hrsa-blue"
+        self.nofo.full_clean()
+        self.nofo.save()
+        self.nofo.refresh_from_db()
+        self.assertEqual(self.nofo.theme, "portrait-hrsa-blue")
+
+        response = self.client.get(
+            reverse("nofos:nofo_view", kwargs={"pk": self.nofo.id})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "portrait-hrsa-blue")
+
     def test_non_nih_user_can_submit_any_valid_cover(self):
+        data = {
+            "theme": "portrait-hrsa-white",
+            "cover": "nofo--cover-page--hero",
+            "icon_style": "nofo--icons--border",
+        }
+        form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_retired_hrsa_theme_submission_is_rejected(self):
         data = {
             "theme": "portrait-hrsa-blue",
             "cover": "nofo--cover-page--hero",
             "icon_style": "nofo--icons--border",
         }
         form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
-        self.assertTrue(form.is_valid(), form.errors)
+        self.assertFalse(form.is_valid())
+        self.assertIn("theme", form.errors)


### PR DESCRIPTION
## What changed

- New HRSA imports now default to **HRSA (Light)** when the opportunity number or OpDiv identifies HRSA.
- **HRSA (Default)** is no longer available for new selection in Theme Options.
- Existing NOFOs already using HRSA (Default) keep a clearly labeled legacy option, so they can still load, save, and render without changing themes unexpectedly.
- Added coverage for HRSA matching, false positives, precedence, dropdown choices, crafted submissions, and legacy compatibility.

## Why

HRSA asked for Light to become the standard theme and for the previous Default option to be retired from new use. The underlying legacy theme remains supported so existing NOFOs are not changed or broken.

Closes #749.

## Validation

- 57 focused tests pass
- Black and isort checks pass
- `makemigrations --check --dry-run` reports no changes
- Browser verification confirms the new Light-only selection, Light rendering, and legacy Default preservation

## Screenshots

### New HRSA records only offer Light

<img width="1280" height="720" alt="HRSA Light-only theme dropdown" src="https://github.com/user-attachments/assets/efd81864-00f8-494b-8b41-bf4542cd7d3e" />

### HRSA Light rendering

<img width="1280" height="720" alt="HRSA Light theme rendering" src="https://github.com/user-attachments/assets/391f0f53-3eae-4e1a-9bb6-5e24b1e3ea8f" />

### Existing HRSA Default records preserve their legacy theme after save

<img width="1280" height="720" alt="Legacy HRSA Default theme preserved after save" src="https://github.com/user-attachments/assets/8fcfbf99-8100-4d0c-9a76-7b50bd655334" />
