### PR TITLE
Update pyasn1 to 0.6.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1243,14 +1243,14 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Updated the resolved `pyasn1` dependency from 0.6.3 to 0.6.4. No other dependency changed.

## Why

The Anchore scan blocked the [NOFO production deployment](https://github.com/HHS/simpler-grants-gov/actions/runs/29941858461) because `pyasn1 0.6.3` is affected by two high-severity advisories:

- `GHSA-hm4w-wwcw-mr6r`
- `GHSA-8ppf-4f7h-5ppj`

Both are fixed in 0.6.4.

## Validation

- `poetry check --lock`
- Installed the updated lockfile and confirmed `pyasn1 0.6.4`
- `pip check`: no broken requirements
- Full Builder test suite: 1,482 tests passed
- Black and isort checks passed
- Pre-commit checks passed

CI's image vulnerability scan is the final confirmation that the deployment blocker is resolved.

Closes #753