### PR TITLE
Add an 8 pt fallback for unusually dense callouts

### DIFF
--- a/nofos/bloom_nofos/static/theme-orientation-portrait.css
+++ b/nofos/bloom_nofos/static/theme-orientation-portrait.css
@@ -335,6 +335,15 @@ section.before-you-begin--era {
   font-size: 8.5pt;
 }
 
+.section--content--right-col.section--content--right-col--dense
+  .callout-box--questions
+  .callout-box--contents
+  p,
+.section--content--right-col.section--content--right-col--dense
+  .callout-box--contents {
+  font-size: 8pt;
+}
+
 .section--content--right-col .callout-box--contents p {
   padding-right: 5px;
 }

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -330,7 +330,7 @@
             {% if nofo_theme_orientation == 'portrait' %}
               {% with callouts=section|get_floating_callout_boxes_from_section %}
                 {% if callouts %}
-                  <div class="section--content--right-col{% if callouts|get_combined_wordcount_for_subsections > 99 %} section--content--right-col--tiny{% elif callouts|get_combined_wordcount_for_subsections > 79 %} section--content--right-col--smaller{% endif %}">
+                  <div class="section--content--right-col {{ callouts|get_floating_callout_size_classes }}">
                     {% for subsection in callouts %}
                       {% include "includes/callout_box.html" with subsection=subsection nofo=nofo break_colons=True only %}
                     {% endfor %}

--- a/nofos/nofos/templatetags/get_floating_callout_boxes_from_section.py
+++ b/nofos/nofos/templatetags/get_floating_callout_boxes_from_section.py
@@ -21,3 +21,17 @@ def get_combined_wordcount_for_subsections(subsections):
         word_count += len(subsection.body.split())
 
     return word_count
+
+
+@register.filter()
+def get_floating_callout_size_classes(subsections):
+    word_count = get_combined_wordcount_for_subsections(subsections)
+
+    if word_count > 149:
+        return "section--content--right-col--tiny section--content--right-col--dense"
+    if word_count > 99:
+        return "section--content--right-col--tiny"
+    if word_count > 79:
+        return "section--content--right-col--smaller"
+
+    return ""

--- a/nofos/nofos/tests_nofos/test_templatetags.py
+++ b/nofos/nofos/tests_nofos/test_templatetags.py
@@ -6,6 +6,9 @@ from django.utils.safestring import SafeString
 
 from nofos.models import Nofo, Section, Subsection
 from nofos.templatetags.add_classes_to_links import add_classes_to_broken_links
+from nofos.templatetags.get_floating_callout_boxes_from_section import (
+    get_floating_callout_size_classes,
+)
 from nofos.templatetags.replace_unicode_with_icon import replace_unicode_with_icon
 from nofos.templatetags.safe_br import safe_br
 from nofos.templatetags.utils import (
@@ -35,6 +38,56 @@ from nofos.templatetags.utils import (
 class MockSection:
     def __init__(self, name):
         self.name = name
+
+
+class GetFloatingCalloutSizeClassesTests(TestCase):
+    @staticmethod
+    def callouts_with_word_count(word_count):
+        return [Subsection(body="word " * word_count)]
+
+    @staticmethod
+    def callouts_with_word_counts(*word_counts):
+        return [Subsection(body="word " * count) for count in word_counts]
+
+    def test_default_size_through_79_words(self):
+        self.assertEqual(
+            get_floating_callout_size_classes(self.callouts_with_word_count(79)),
+            "",
+        )
+
+    def test_smaller_size_from_80_through_99_words(self):
+        self.assertEqual(
+            get_floating_callout_size_classes(self.callouts_with_word_count(80)),
+            "section--content--right-col--smaller",
+        )
+        self.assertEqual(
+            get_floating_callout_size_classes(self.callouts_with_word_count(99)),
+            "section--content--right-col--smaller",
+        )
+
+    def test_tiny_size_from_100_through_149_words(self):
+        self.assertEqual(
+            get_floating_callout_size_classes(self.callouts_with_word_count(100)),
+            "section--content--right-col--tiny",
+        )
+        self.assertEqual(
+            get_floating_callout_size_classes(self.callouts_with_word_count(149)),
+            "section--content--right-col--tiny",
+        )
+
+    def test_dense_size_at_150_words(self):
+        self.assertEqual(
+            get_floating_callout_size_classes(self.callouts_with_word_count(150)),
+            "section--content--right-col--tiny section--content--right-col--dense",
+        )
+
+    def test_dense_size_combines_all_floating_callouts(self):
+        self.assertEqual(
+            get_floating_callout_size_classes(
+                self.callouts_with_word_counts(6, 23, 124)
+            ),
+            "section--content--right-col--tiny section--content--right-col--dense",
+        )
 
 
 class ReplaceUnicodeWithIconTests(TestCase):


### PR DESCRIPTION
## What changed

- Added an 8 pt font tier for first-section floating callouts with 150 or more combined words.
- Preserved the existing 10 pt, 9.25 pt, and 8.5 pt tiers below that threshold.
- Kept **Have questions?** in the combined count with **Key facts** and **Key dates**.
- Moved the class selection into one template filter so the threshold boundaries can be tested directly.

## Why

The CDC K01 fixture investigated in #757 contains 153 combined callout words. Builder already applies its smallest current tier, 8.5 pt, but the production preview can still move the callouts to the next page.

This adds a narrowly targeted fallback without shrinking every callout currently above 99 words or requiring per-NOFO CSS.

Closes #759.

## Validation

- All 1,486 tests pass.
- Focused tests cover 79/80, 99/100, and 149/150 word boundaries.
- A fixture-shaped test confirms that 6 + 23 + 124 words across three callouts activates the dense tier.
- Black and isort checks pass.
- The imported CDC fixture reports 153 combined words and receives both the existing `tiny` class and the new `dense` class.
- Local CDC Default and ACF Light comparisons show the expected vertical reduction at 8 pt.

## Dev verification needed before merge

Local browser PDF output is not authoritative because production uses DocRaptor and Prince. Please:

1. Deploy this branch to dev.
2. Import the CDC K01 fixture used in #757.
3. Generate a watermarked **Preview PDF** in CDC Default.
4. Confirm **Key facts** and **Key dates** remain on the **Basic information** page and are readable at 100 percent.
5. Repeat with ACF Light.

If the callouts still move to the next page, leave the PR open so the threshold or layout treatment can be adjusted before merge.
