### PR TITLE
Block ambiguous mixed-heading imports

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -116,6 +116,51 @@ def parse_uploaded_file_as_html_string(uploaded_file):
         raise ValidationError("Please import a .docx or HTML file.")
 
 
+def resolve_section_heading_level(soup):
+    """Choose the section heading level without silently discarding earlier content."""
+    section_heading_candidates = [
+        heading
+        for heading in soup.find_all(["h1", "h2"])
+        if clean_string(heading.get_text(" ", strip=True))
+        and heading.find_parent("table") is None
+    ]
+
+    first_h1_index = next(
+        (
+            index
+            for index, heading in enumerate(section_heading_candidates)
+            if heading.name == "h1"
+        ),
+        None,
+    )
+    if first_h1_index is None:
+        return "h2"
+
+    h2_before_first_h1 = next(
+        (
+            heading
+            for heading in section_heading_candidates[:first_h1_index]
+            if heading.name == "h2"
+        ),
+        None,
+    )
+    if h2_before_first_h1 is None:
+        return "h1"
+
+    h2_text = clean_string(h2_before_first_h1.get_text(" ", strip=True))
+    h1_text = clean_string(
+        section_heading_candidates[first_h1_index].get_text(" ", strip=True)
+    )
+    raise ValidationError(
+        "The document uses Heading 2 before its first Heading 1. "
+        f'NOFO Builder would skip content beginning with Heading 2 "{h2_text}" '
+        f'and start at Heading 1 "{h1_text}". '
+        "In Word, apply the same heading level to all main sections, save the "
+        "document, and import it again.",
+        code="ambiguous_heading_hierarchy",
+    )
+
+
 def process_nofo_html(soup, top_heading_level):
     """
     Takes a soup object, cleans it up and mutates it, and returns a modified soup object.

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -64,6 +64,7 @@ from .nofo import (
     replace_chars,
     replace_src_for_inline_images,
     replace_value_in_subsections,
+    resolve_section_heading_level,
     sanitize_imported_text,
     suggest_all_nofo_fields,
     suggest_nofo_agency,
@@ -130,6 +131,59 @@ class ReplaceCharsTests(TestCase):
             "<tr><th scope='row'>Table row</th><td><p>◻ Work plan 1</p></td></tr>"
         )
         self.assertEqual(replace_chars(test_string), test_string)
+
+
+class ResolveSectionHeadingLevelTests(TestCase):
+    def test_h1_only_document_is_valid(self):
+        soup = BeautifulSoup("<h1>Step 1</h1><p>Body</p><h1>Step 2</h1>", "html.parser")
+
+        self.assertEqual(resolve_section_heading_level(soup), "h1")
+
+    def test_h2_only_document_is_valid(self):
+        soup = BeautifulSoup("<h2>Step 1</h2><p>Body</p><h2>Step 2</h2>", "html.parser")
+
+        self.assertEqual(resolve_section_heading_level(soup), "h2")
+
+    def test_h1_sections_with_h2_subsections_are_valid(self):
+        soup = BeautifulSoup(
+            "<h1>Step 1</h1><h2>Basic information</h2><p>Body</p>",
+            "html.parser",
+        )
+
+        self.assertEqual(resolve_section_heading_level(soup), "h1")
+
+    def test_blank_h2_before_first_h1_is_ignored(self):
+        soup = BeautifulSoup("<h2> </h2><h1>Step 1</h1>", "html.parser")
+
+        self.assertEqual(resolve_section_heading_level(soup), "h1")
+
+    def test_h1_inside_table_does_not_override_h2_section_level(self):
+        soup = BeautifulSoup(
+            "<h2>Step 1</h2>"
+            "<table><tr><td><h1>Table label</h1></td></tr></table>"
+            "<h2>Step 2</h2>",
+            "html.parser",
+        )
+
+        self.assertEqual(resolve_section_heading_level(soup), "h2")
+
+    def test_populated_h2_before_first_h1_is_blocked_with_examples(self):
+        soup = BeautifulSoup(
+            "<h2>Step 1: Review the Opportunity</h2><p>Body</p>"
+            "<h2>Step 2: Get Ready to Apply</h2>"
+            "<h1>Appendix A: Award data</h1>",
+            "html.parser",
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            resolve_section_heading_level(soup)
+
+        self.assertEqual(context.exception.code, "ambiguous_heading_hierarchy")
+        message = context.exception.messages[0]
+        self.assertIn("Heading 2 before its first Heading 1", message)
+        self.assertIn('Heading 2 "Step 1: Review the Opportunity"', message)
+        self.assertIn('Heading 1 "Appendix A: Award data"', message)
+        self.assertIn("apply the same heading level to all main sections", message)
 
 
 class TestsCleanTableCells(TestCase):

--- a/nofos/nofos/tests_nofos/test_import.py
+++ b/nofos/nofos/tests_nofos/test_import.py
@@ -404,7 +404,10 @@ class TestNofoImportMixedHeadingHierarchy(TestCase):
         self.client.login(email="heading-test@example.com", password="testpass123")
         self.import_url = reverse("nofos:nofo_import")
 
-    def test_import_blocks_h2_sections_before_late_h1_appendix_on_shared_page(self):
+    @patch("nofos.views.log_exception")
+    def test_import_blocks_h2_sections_before_late_h1_appendix_on_shared_page(
+        self, log_error
+    ):
         html_content = """
         <p>OpDiv: Centers for Medicare &amp; Medicaid Services (CMS)</p>
         <p>Opportunity name: Mixed heading fixture</p>
@@ -437,6 +440,13 @@ class TestNofoImportMixedHeadingHierarchy(TestCase):
         self.assertIn(f'href="{self.import_url}"', content)
         self.assertIn("simplerNOFOs@agile6.com", content)
         self.assertEqual(Nofo.objects.count(), 0)
+        log_error.assert_called_once()
+        self.assertEqual(log_error.call_args.kwargs["level"], "warning")
+        self.assertEqual(
+            log_error.call_args.kwargs["context"],
+            "BaseNofoImportView:ValidationError:IMPORT-AMBIGUOUS-HEADINGS",
+        )
+        self.assertEqual(log_error.call_args.kwargs["status"], 422)
 
     def test_table_h1_does_not_hide_h2_sections(self):
         html_content = """

--- a/nofos/nofos/tests_nofos/test_import.py
+++ b/nofos/nofos/tests_nofos/test_import.py
@@ -390,3 +390,84 @@ class TestBlockingImportErrorPages(TestCase):
             f'href="{reverse("nofos:nofo_edit", kwargs={"pk": nofo.id})}"',
             content,
         )
+
+
+class TestNofoImportMixedHeadingHierarchy(TestCase):
+    def setUp(self):
+        self.user = BloomUser.objects.create_user(
+            email="heading-test@example.com",
+            password="testpass123",
+            force_password_reset=False,
+            group="bloom",
+        )
+        self.client = Client()
+        self.client.login(email="heading-test@example.com", password="testpass123")
+        self.import_url = reverse("nofos:nofo_import")
+
+    def test_import_blocks_h2_sections_before_late_h1_appendix_on_shared_page(self):
+        html_content = """
+        <p>OpDiv: Centers for Medicare &amp; Medicaid Services (CMS)</p>
+        <p>Opportunity name: Mixed heading fixture</p>
+        <p>Opportunity number: CMS-TEST-745</p>
+        <h2>Step 1: Review the Opportunity</h2>
+        <p>Important content that must not be silently dropped.</p>
+        <h2>Step 2: Get Ready to Apply</h2>
+        <h1>Appendix A: Award data</h1>
+        <p>Appendix content.</p>
+        """
+        uploaded_file = SimpleUploadedFile(
+            "mixed-headings.html",
+            html_content.encode("utf-8"),
+            content_type="text/html",
+        )
+
+        response = self.client.post(
+            self.import_url,
+            {"nofo-import": uploaded_file},
+        )
+
+        content = response.content.decode("utf-8")
+        self.assertEqual(response.status_code, 422)
+        self.assertIn("We couldn’t safely determine the document structure", content)
+        self.assertIn("IMPORT-AMBIGUOUS-HEADINGS", content)
+        self.assertIn("Heading 2 before its first Heading 1", content)
+        self.assertIn("Step 1: Review the Opportunity", content)
+        self.assertIn("Appendix A: Award data", content)
+        self.assertIn("Apply one consistent heading level", content)
+        self.assertIn(f'href="{self.import_url}"', content)
+        self.assertIn("simplerNOFOs@agile6.com", content)
+        self.assertEqual(Nofo.objects.count(), 0)
+
+    def test_table_h1_does_not_hide_h2_sections(self):
+        html_content = """
+        <p>OpDiv: Centers for Medicare &amp; Medicaid Services (CMS)</p>
+        <p>Opportunity name: Table heading fixture</p>
+        <p>Opportunity number: CMS-TEST-TABLE-H1</p>
+        <h2>Step 1: Review the Opportunity</h2>
+        <p>First section content.</p>
+        <table>
+          <tr><td><h1>Table label</h1></td></tr>
+        </table>
+        <h2>Step 2: Get Ready to Apply</h2>
+        <p>Second section content.</p>
+        """
+        uploaded_file = SimpleUploadedFile(
+            "table-heading.html",
+            html_content.encode("utf-8"),
+            content_type="text/html",
+        )
+
+        response = self.client.post(
+            self.import_url,
+            {"nofo-import": uploaded_file},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        nofo = Nofo.objects.get()
+        self.assertEqual(
+            list(nofo.sections.values_list("name", flat=True)),
+            [
+                "Step 1: Review the Opportunity",
+                "Step 2: Get Ready to Apply",
+            ],
+        )

--- a/nofos/nofos/tests_nofos/test_reimport.py
+++ b/nofos/nofos/tests_nofos/test_reimport.py
@@ -469,3 +469,53 @@ class NofosImportOverwriteViewTests(TestCase):
             p_after_h1.text.strip(),
             "The document you uploaded has a different opportunity number than the current NOFO.",
         )
+
+    def test_confirm_reimport_ignores_h1_inside_table_when_h2_defines_sections(self):
+        html_content = """
+        <p>Opportunity name: Table heading fixture</p>
+        <p>Opdiv: ACF</p>
+        <p>Opportunity number: NOFO-ACF-002</p>
+        <h2>Step 1: Review the Opportunity</h2>
+        <p>First section content.</p>
+        <table>
+          <tr><td><h1>Table label</h1></td></tr>
+        </table>
+        <h2>Step 2: Get Ready to Apply</h2>
+        <p>Second section content.</p>
+        """
+        test_file = SimpleUploadedFile(
+            "table-heading.html",
+            html_content.encode("utf-8"),
+            content_type="text/html",
+        )
+
+        response = self.client.post(
+            self.import_url,
+            {
+                "nofo-import": test_file,
+                "csrfmiddlewaretoken": "dummy",
+            },
+        )
+        self.assertRedirects(
+            response,
+            reverse("nofos:nofo_import_confirm_overwrite", kwargs={"pk": self.nofo.pk}),
+            fetch_redirect_response=False,
+        )
+
+        response = self.client.post(
+            reverse("nofos:nofo_import_confirm_overwrite", kwargs={"pk": self.nofo.pk})
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("nofos:nofo_edit", kwargs={"pk": self.nofo.pk}),
+            fetch_redirect_response=False,
+        )
+        self.nofo.refresh_from_db()
+        self.assertEqual(
+            list(self.nofo.sections.values_list("name", flat=True)),
+            [
+                "Step 1: Review the Opportunity",
+                "Step 2: Get Ready to Apply",
+            ],
+        )

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -114,6 +114,7 @@ from .nofo import (
     replace_chars,
     replace_links,
     replace_value_in_subsections,
+    resolve_section_heading_level,
     restore_subsection_metadata,
     suggest_all_nofo_fields,
     suggest_nofo_opdiv,
@@ -486,7 +487,7 @@ class BaseNofoImportView(View):
             # 3. Clean/transform HTML
             cleaned_content = replace_links(replace_chars(file_content))
             soup = BeautifulSoup(cleaned_content, "html.parser")
-            top_heading_level = "h1" if soup.find("h1") else "h2"
+            top_heading_level = resolve_section_heading_level(soup)
             soup, instructions_tables = process_nofo_html(soup, top_heading_level)
 
             # 4. Build sections and subsections as python dicts
@@ -547,6 +548,21 @@ class BaseNofoImportView(View):
                     recovery_steps=[
                         "Open the document in Word.",
                         "Ask a NOFO designer or administrator to review its custom formatting and styles.",
+                        "Save the document, then select it again.",
+                    ],
+                    retry_url=self.get_retry_url(),
+                )
+
+            if "ambiguous_heading_hierarchy" in error_codes:
+                return render_blocking_import_error(
+                    request,
+                    title="We couldn’t safely determine the document structure",
+                    summary=error_message,
+                    error_code="IMPORT-AMBIGUOUS-HEADINGS",
+                    status=422,
+                    recovery_steps=[
+                        "Open the document in Word and review the Heading 1 and Heading 2 styles named above.",
+                        "Apply one consistent heading level to all main sections.",
                         "Save the document, then select it again.",
                     ],
                     retry_url=self.get_retry_url(),

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -554,6 +554,13 @@ class BaseNofoImportView(View):
                 )
 
             if "ambiguous_heading_hierarchy" in error_codes:
+                log_exception(
+                    request,
+                    e,
+                    level="warning",
+                    context="BaseNofoImportView:ValidationError:IMPORT-AMBIGUOUS-HEADINGS",
+                    status=422,
+                )
                 return render_blocking_import_error(
                     request,
                     title="We couldn’t safely determine the document structure",
@@ -861,7 +868,7 @@ class NofosConfirmReimportView(GroupAccessObjectMixin, View):
             return redirect("nofos:nofo_import_overwrite", pk=nofo.id)
 
         soup = BeautifulSoup(reimport_data["soup"], "html.parser")
-        top_heading_level = "h1" if soup.find("h1") else "h2"
+        top_heading_level = resolve_section_heading_level(soup)
 
         sections = BaseNofoImportView.get_sections_and_subsections_from_soup(
             soup, top_heading_level


### PR DESCRIPTION
## What changed

- Detects when a document starts its main sections with Heading 2, then introduces Heading 1 later
- Stops the import before NOFO Builder can silently omit the earlier Heading 2 content
- Shows the shared import error page with example conflicting headings and clear recovery steps
- Uses one heading resolver for both validation and section parsing
- Ignores headings used inside tables when choosing the document's main section level

## Previous behavior

NOFO Builder chose Heading 1 whenever any Heading 1 appeared in the document. If populated Heading 2 sections came first, Builder could start at the later Heading 1 and silently leave the earlier content out of the imported NOFO.

## Intended behavior

When the document structure is ambiguous, NOFO Builder now blocks the import and asks the user to apply one consistent heading level to the main sections in Word. Documents that use Heading 1 only, Heading 2 only, or Heading 1 with Heading 2 subsections continue to import normally. Headings used as table formatting do not change the main section level.

## Validation

- 1,513 automated tests pass
- 198 focused import, compare, and composer tests pass
- Added an end-to-end regression proving an H1 inside a table does not hide surrounding H2 sections
- Reproduced the original failure with the real CMS content guide fixture
- Completed a skeptical review and follow-up review with no remaining findings

Closes #745