### PR TITLE
Treat imported metadata placeholders as missing

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -32,6 +32,7 @@ from .import_transforms import (
 )
 from .models import Nofo, Section, Subsection
 from .nofo_markdown import PRESERVE_BOOKMARK_TARGET_ATTR, md
+from .pdf_metadata import normalize_pdf_metadata_value
 from .utils import (
     add_html_id_to_subsection,
     clean_string,
@@ -1779,17 +1780,17 @@ def suggest_nofo_tagline(soup):
 
 def suggest_nofo_author(soup):
     suggestion = _suggest_by_startswith_string(soup, "Metadata Author:")
-    return suggestion or ""
+    return normalize_pdf_metadata_value(suggestion)
 
 
 def suggest_nofo_subject(soup):
     suggestion = _suggest_by_startswith_string(soup, "Metadata Subject:")
-    return suggestion or ""
+    return normalize_pdf_metadata_value(suggestion)
 
 
 def suggest_nofo_keywords(soup):
     suggestion = _suggest_by_startswith_string(soup, "Metadata Keywords:")
-    return suggestion or ""
+    return normalize_pdf_metadata_value(suggestion)
 
 
 def suggest_nofo_cover_image(nofo):

--- a/nofos/nofos/pdf_metadata.py
+++ b/nofos/nofos/pdf_metadata.py
@@ -1,0 +1,26 @@
+import re
+
+PDF_METADATA_FIELDS = (
+    ("author", "Author"),
+    ("subject", "Subject"),
+    ("keywords", "Keywords"),
+)
+
+_WHOLE_FIELD_PLACEHOLDER = re.compile(r"^\{[^{}]+\}$")
+
+
+def normalize_pdf_metadata_value(value):
+    """Convert a whole-field curly-brace placeholder to an empty value."""
+    if not value:
+        return ""
+
+    stripped_value = value.strip()
+    if not stripped_value or _WHOLE_FIELD_PLACEHOLDER.fullmatch(stripped_value):
+        return ""
+
+    return value
+
+
+def is_missing_pdf_metadata_value(value):
+    """Return whether a metadata value is empty or only a placeholder."""
+    return not normalize_pdf_metadata_value(value).strip()

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -4415,6 +4415,11 @@ class SuggestNofoAuthorTests(TestCase):
         soup = BeautifulSoup(html, "html.parser")
         self.assertEqual(suggest_nofo_author(soup), "Paul Craig")
 
+    def test_author_placeholder_is_treated_as_empty(self):
+        html = "<div><p>Metadata Author: {Leave blank. Coach will insert.}</p></div>"
+        soup = BeautifulSoup(html, "html.parser")
+        self.assertEqual(suggest_nofo_author(soup), "")
+
 
 class SuggestNofoSubjectTests(TestCase):
     def test_subject_present_in_paragraph(self):
@@ -4435,6 +4440,11 @@ class SuggestNofoSubjectTests(TestCase):
         self.assertEqual(
             suggest_nofo_subject(soup), "This NOFO is about helping people"
         )
+
+    def test_subject_placeholder_is_treated_as_empty(self):
+        html = "<div><p>Metadata Subject: {Leave blank. Coach will insert.}</p></div>"
+        soup = BeautifulSoup(html, "html.parser")
+        self.assertEqual(suggest_nofo_subject(soup), "")
 
 
 class SuggestNofoKeywordsTests(TestCase):
@@ -4463,6 +4473,11 @@ class SuggestNofoKeywordsTests(TestCase):
         self.assertEqual(
             suggest_nofo_keywords(soup), "Medicine, CDC, Awesome, Notice, Opportunity"
         )
+
+    def test_keywords_placeholder_is_treated_as_empty(self):
+        html = "<div><p>Metadata Keywords: {Leave blank. Coach will insert.}</p></div>"
+        soup = BeautifulSoup(html, "html.parser")
+        self.assertEqual(suggest_nofo_keywords(soup), "")
 
 
 class SuggestNofoFieldsTests(TestCase):

--- a/nofos/nofos/tests_nofos/test_metadata_warning.py
+++ b/nofos/nofos/tests_nofos/test_metadata_warning.py
@@ -95,6 +95,20 @@ class NofoMetadataWarningTests(TestCase):
             ["Author", "Keywords"],
         )
 
+    def test_placeholder_metadata_is_treated_as_missing(self):
+        self.nofo.author = "{Leave blank. Coach will insert.}"
+        self.nofo.subject = "Accessible funding opportunity"
+        self.nofo.keywords = " {Add search terms here} "
+        self.nofo.save()
+
+        response = self.client.get(self.edit_url)
+
+        panel = self._get_metadata_panel(response)
+        self.assertEqual(
+            [item.get_text(strip=True) for item in panel.select("li")],
+            ["Author", "Keywords"],
+        )
+
     def test_warning_is_hidden_when_all_metadata_is_present(self):
         self.nofo.author = "HHS"
         self.nofo.subject = "Accessible funding opportunity"

--- a/nofos/nofos/tests_nofos/test_pdf_metadata.py
+++ b/nofos/nofos/tests_nofos/test_pdf_metadata.py
@@ -1,0 +1,33 @@
+from django.test import SimpleTestCase
+
+from nofos.pdf_metadata import (
+    is_missing_pdf_metadata_value,
+    normalize_pdf_metadata_value,
+)
+
+
+class PdfMetadataPolicyTests(SimpleTestCase):
+    def test_empty_values_are_normalized_to_empty(self):
+        for value in (None, "", "  \n\t"):
+            with self.subTest(value=value):
+                self.assertEqual(normalize_pdf_metadata_value(value), "")
+                self.assertTrue(is_missing_pdf_metadata_value(value))
+
+    def test_whole_field_curly_brace_placeholder_is_normalized_to_empty(self):
+        for value in (
+            "{Leave blank. Coach will insert.}",
+            "  {Leave blank. Coach will insert.}  ",
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(normalize_pdf_metadata_value(value), "")
+                self.assertTrue(is_missing_pdf_metadata_value(value))
+
+    def test_real_metadata_is_preserved(self):
+        for value in (
+            "Administration for Children and Families",
+            "Research {Phase 2}",
+            "{HHS} grant opportunities",
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(normalize_pdf_metadata_value(value), value)
+                self.assertFalse(is_missing_pdf_metadata_value(value))

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -122,6 +122,7 @@ from .nofo import (
     suggest_nofo_title,
     upload_cover_image_to_s3,
 )
+from .pdf_metadata import PDF_METADATA_FIELDS, is_missing_pdf_metadata_value
 from .utils import create_nofo_audit_event, create_subsection_html_id, user_is_nih_group
 
 GroupAccessObjectMixin = GroupAccessObjectMixinFactory(Nofo)
@@ -362,15 +363,10 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
         # latest audit event (to show latest editor/user)
         context["updated_by"] = self.object.updated_by
 
-        metadata_fields = (
-            ("author", "Author"),
-            ("subject", "Subject"),
-            ("keywords", "Keywords"),
-        )
         context["missing_metadata_fields"] = [
             label
-            for field_name, label in metadata_fields
-            if not (getattr(self.object, field_name, "") or "").strip()
+            for field_name, label in PDF_METADATA_FIELDS
+            if is_missing_pdf_metadata_value(getattr(self.object, field_name, ""))
         ]
 
         # booleans to show/hide our various warning messages


### PR DESCRIPTION
## Summary

- normalize whole-field curly-brace placeholders in PDF Author, Subject, and Keywords to empty values during import
- use the same metadata policy when determining whether existing records need the incomplete-metadata warning
- preserve real metadata values, including values that contain embedded braces

## Why

Source Word documents can contain instructions such as
`{Leave blank. Coach will insert.}` in PDF metadata fields. Because these
strings were non-empty, NOFO Builder treated the fields as complete and could
carry the instructions into generated PDF metadata.

The investigation found that metadata extraction and completeness checking
used separate notions of “missing.” This change introduces one small shared
policy and applies it at both boundaries, without broadening the refactor of
`nofo.py`.

## User impact

New imports and reimports leave placeholder-only metadata empty, allowing the
existing warning to prompt users for real values. Existing NOFOs that already
contain placeholders now receive the same warning.

## Validation

- 26 focused metadata policy, import extraction, and warning tests
- full `nofos` Django test suite
- formatting and repository pre-commit checks
- independent subagent review found no actionable issues

## Screenshots

**Before**
<img width="1280" height="1855" alt="before-main-6927a6fd" src="https://github.com/user-attachments/assets/16393a36-3660-426a-9e06-43f5bc217e34" />

**After**
<img width="1280" height="2063" alt="after-d6e54280" src="https://github.com/user-attachments/assets/539bc05d-585a-4daf-9271-22c6bc756b32" />





Closes #756
