### PR TITLE
Allow editors to add or remove subsection callout styling

### DIFF
--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -65,19 +65,6 @@
         </legend>
       {% endif %}
 
-      <!-- callout_box -->
-      <div class="form-group margin-top-4 width-mobile">
-        <div class="usa-checkbox">
-          <input class="usa-checkbox__input usa-checkbox__input--tile" id="callout_box" type="checkbox" name="callout_box" {% if form.callout_box.value %}checked{% endif %}>
-          <label class="usa-checkbox__label" for="callout_box">Use callout box styling
-            <span class="usa-checkbox__label-description">
-              Callout boxes use an accent color to call attention to important content. In Step 1 of portrait documents, recognized Key facts, Key dates, and question callouts appear in the right margin.
-            </span>
-          </label>
-        </div>
-        <p class="usa-hint margin-top-1">Re-importing this NOFO replaces this setting with the styling from the source document.</p>
-      </div>
-
       <!-- name -->
       <div class="form-group">
         {% with id="name" label=form.name.label value=form.name.value hint=form.name.help_text error=form.name.errors.0 input_type=form.name|input_type %}
@@ -137,6 +124,20 @@
           </select>
         </div>
       {% endif %}
+
+      <!-- callout_box -->
+      <div class="form-group margin-top-4 width-mobile">
+        <div class="usa-checkbox">
+          <input class="usa-checkbox__input usa-checkbox__input--tile" id="callout_box" type="checkbox" name="callout_box" {% if form.callout_box.value %}checked{% endif %}>
+          <label class="usa-checkbox__label" for="callout_box">Use callout box styling
+            <span class="usa-checkbox__label-description">
+              Best for short, high-priority content that applicants need to notice quickly. Avoid using callout boxes for long narrative content or detailed policy explanations.
+            </span>
+          </label>
+        </div>
+        <p class="usa-hint margin-top-1">In Step 1 of portrait documents, recognized Key facts, Key dates, and question callouts appear in the right margin.</p>
+        <p class="usa-hint margin-top-1">Re-importing this NOFO replaces this setting with the styling from the source document.</p>
+      </div>
 
       <!-- html_class -->
       <div class="form-group margin-top-4">

--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -129,14 +129,10 @@
       <div class="form-group margin-top-4 width-mobile">
         <div class="usa-checkbox">
           <input class="usa-checkbox__input usa-checkbox__input--tile" id="callout_box" type="checkbox" name="callout_box" {% if form.callout_box.value %}checked{% endif %}>
-          <label class="usa-checkbox__label" for="callout_box">Use callout box styling
-            <span class="usa-checkbox__label-description">
-              Best for short, high-priority content that applicants need to notice quickly. Avoid using callout boxes for long narrative content or detailed policy explanations.
-            </span>
+          <label class="usa-checkbox__label" for="callout_box">Is callout box?
+            <span class="usa-checkbox__label-description">Callout boxes <span aria-hidden="true">(📦)</span> use an accent color to call attention to important content.</span>
           </label>
         </div>
-        <p class="usa-hint margin-top-1">In Step 1 of portrait documents, recognized Key facts, Key dates, and question callouts appear in the right margin.</p>
-        <p class="usa-hint margin-top-1">Re-importing this NOFO replaces this setting with the styling from the source document.</p>
       </div>
 
       <!-- html_class -->

--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -65,7 +65,18 @@
         </legend>
       {% endif %}
 
-      <input type="hidden" name="{{ form.callout_box.name }}" id="{{ form.callout_box.id_for_label }}" value="{{ subsection.callout_box }}">
+      <!-- callout_box -->
+      <div class="form-group margin-top-4 width-mobile">
+        <div class="usa-checkbox">
+          <input class="usa-checkbox__input usa-checkbox__input--tile" id="callout_box" type="checkbox" name="callout_box" {% if form.callout_box.value %}checked{% endif %}>
+          <label class="usa-checkbox__label" for="callout_box">Use callout box styling
+            <span class="usa-checkbox__label-description">
+              Callout boxes use an accent color to call attention to important content. In Step 1 of portrait documents, recognized Key facts, Key dates, and question callouts appear in the right margin.
+            </span>
+          </label>
+        </div>
+        <p class="usa-hint margin-top-1">Re-importing this NOFO replaces this setting with the styling from the source document.</p>
+      </div>
 
       <!-- name -->
       <div class="form-group">

--- a/nofos/nofos/tests_nofos/test_reimport.py
+++ b/nofos/nofos/tests_nofos/test_reimport.py
@@ -265,6 +265,36 @@ class NofoReimportTests(TransactionTestCase):
         self.assertFalse("page-break-before" in updated_subsections[0].html_class)
         self.assertFalse("page-break-before" in updated_subsections[1].html_class)
 
+    def test_reimport_uses_callout_state_from_source_and_archives_manual_state(self):
+        """Reimport remains source-authoritative for callout styling."""
+        self.subsections[0].callout_box = True
+        self.subsections[0].save()
+
+        response = self.client.post(
+            reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
+            {
+                "nofo-import": create_test_html_file(),
+                "preserve_page_breaks": "on",
+                "csrfmiddlewaretoken": "dummy",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        reimported_subsection = (
+            Nofo.objects.get(id=self.nofo.id)
+            .sections.get(name="Test Section 1")
+            .subsections.get(name="Eligibility Information")
+        )
+        self.assertFalse(reimported_subsection.callout_box)
+
+        archived_nofo = Nofo.objects.filter(successor_id=self.nofo.id).get()
+        archived_subsection = archived_nofo.sections.get(
+            name="Test Section 1"
+        ).subsections.get(name="Eligibility Information")
+        self.assertTrue(archived_subsection.callout_box)
+
     def test_reimport_success_behavior(self):
         """Test success message and redirect behavior for reimport."""
         test_file = create_test_html_file()

--- a/nofos/nofos/tests_nofos/test_subsection_edit.py
+++ b/nofos/nofos/tests_nofos/test_subsection_edit.py
@@ -156,21 +156,29 @@ class SubsectionCalloutEditingTests(TestCase):
         )
 
         regular_response = self.client.get(self.edit_url(regular))
-        self.assertContains(regular_response, "Use callout box styling")
+        self.assertContains(regular_response, "Is callout box?")
         self.assertContains(
             regular_response,
-            "Re-importing this NOFO replaces this setting",
+            "Callout boxes",
         )
         self.assertContains(
+            regular_response,
+            "use an accent color to call attention to important content.",
+        )
+        self.assertNotContains(
             regular_response,
             "Best for short, high-priority content",
         )
+        self.assertNotContains(
+            regular_response,
+            "Re-importing this NOFO replaces this setting",
+        )
         content = regular_response.content.decode()
         self.assertLess(
-            content.index("Heading level"), content.index("Use callout box styling")
+            content.index("Heading level"), content.index("Is callout box?")
         )
         self.assertLess(
-            content.index("Use callout box styling"), content.index("Add a page break")
+            content.index("Is callout box?"), content.index("Add a page break")
         )
         self.assertNotContains(
             regular_response,

--- a/nofos/nofos/tests_nofos/test_subsection_edit.py
+++ b/nofos/nofos/tests_nofos/test_subsection_edit.py
@@ -93,3 +93,271 @@ class SubsectionEditTemplateTest(TestCase):
         )
 
         self.assertNotContains(response, "Modifications date")
+
+
+class SubsectionCalloutEditingTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="callouts@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(email="callouts@example.com", password="testpass123")
+
+        self.nofo = Nofo.objects.create(
+            title="Callout editing NOFO",
+            short_name="callout-editing",
+            number="TEST-CALLOUT-001",
+            group="bloom",
+            opdiv="HRSA",
+            theme="portrait-hrsa-white",
+        )
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Step 2: Review",
+            html_id="step-2-review",
+            order=2,
+        )
+
+    def edit_url(self, subsection):
+        return reverse(
+            "nofos:subsection_edit",
+            args=[self.nofo.id, self.section.id, subsection.id],
+        )
+
+    def post_subsection(self, subsection, *, callout_box, **overrides):
+        data = {
+            "name": subsection.name,
+            "tag": subsection.tag,
+            "body": subsection.body,
+            "html_class": subsection.html_class,
+        }
+        data.update(overrides)
+        if callout_box:
+            data["callout_box"] = "on"
+        return self.client.post(self.edit_url(subsection), data)
+
+    def test_edit_page_exposes_current_callout_state(self):
+        regular = Subsection.objects.create(
+            section=self.section,
+            name="Regular subsection",
+            tag="h3",
+            order=1,
+            body="Regular content",
+        )
+        callout = Subsection.objects.create(
+            section=self.section,
+            name="Existing callout",
+            tag="h3",
+            order=2,
+            body="Callout content",
+            callout_box=True,
+        )
+
+        regular_response = self.client.get(self.edit_url(regular))
+        self.assertContains(regular_response, "Use callout box styling")
+        self.assertContains(
+            regular_response,
+            "Re-importing this NOFO replaces this setting",
+        )
+        self.assertNotContains(
+            regular_response,
+            'name="callout_box" checked',
+        )
+
+        callout_response = self.client.get(self.edit_url(callout))
+        self.assertContains(
+            callout_response,
+            'name="callout_box" checked',
+        )
+
+    def test_regular_subsection_can_be_changed_to_callout_without_other_changes(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="Program details",
+            tag="h3",
+            order=3,
+            body="Program details body",
+            html_class="page-break-before",
+        )
+        original_html_id = subsection.html_id
+
+        response = self.post_subsection(subsection, callout_box=True)
+
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertTrue(subsection.callout_box)
+        self.assertEqual(subsection.name, "Program details")
+        self.assertEqual(subsection.tag, "h3")
+        self.assertEqual(subsection.body, "Program details body")
+        self.assertEqual(subsection.order, 3)
+        self.assertEqual(subsection.html_id, original_html_id)
+        self.assertEqual(subsection.html_class, "page-break-before")
+
+    def test_callout_can_be_changed_to_regular_subsection(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="Program details",
+            tag="h3",
+            order=1,
+            body="Program details body",
+            callout_box=True,
+        )
+
+        response = self.post_subsection(subsection, callout_box=False)
+
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertFalse(subsection.callout_box)
+
+    def test_unnamed_subsection_supports_both_callout_transitions(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="",
+            tag="",
+            order=1,
+            body="Unnamed subsection body",
+        )
+
+        response = self.post_subsection(subsection, callout_box=True)
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertTrue(subsection.callout_box)
+
+        response = self.post_subsection(subsection, callout_box=False)
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertFalse(subsection.callout_box)
+
+    def test_editing_other_fields_preserves_checked_callout_state(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="Existing callout",
+            tag="h3",
+            order=1,
+            body="Original body",
+            callout_box=True,
+        )
+
+        response = self.post_subsection(
+            subsection,
+            callout_box=True,
+            body="Updated body",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertTrue(subsection.callout_box)
+        self.assertEqual(subsection.body, "Updated body")
+
+
+class SubsectionCalloutRenderingTests(TestCase):
+    marker = "UNIQUE-CALLOUT-RENDER-MARKER"
+
+    def setUp(self):
+        User.objects.create_user(
+            email="callout-rendering@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(
+            email="callout-rendering@example.com",
+            password="testpass123",
+        )
+        self.nofo = Nofo.objects.create(
+            title="Callout rendering NOFO",
+            short_name="callout-rendering",
+            number="TEST-CALLOUT-002",
+            group="bloom",
+            opdiv="HRSA",
+            agency="Test agency",
+            theme="portrait-hrsa-white",
+        )
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Step 1: Review the Opportunity",
+            html_id="step-1-review-the-opportunity",
+            order=1,
+        )
+        Subsection.objects.create(
+            section=self.section,
+            name="Basic information",
+            tag="h2",
+            order=1,
+            body="Basic information body",
+        )
+        self.subsection = Subsection.objects.create(
+            section=self.section,
+            name="Key facts",
+            tag="h3",
+            order=2,
+            body=self.marker,
+            html_class="page-break-before",
+            callout_box=True,
+        )
+
+    def rendered_nofo(self):
+        return self.client.get(reverse("nofos:nofo_view", args=[self.nofo.id]))
+
+    def test_recognized_step_one_callout_renders_once_in_portrait_right_column(self):
+        response = self.rendered_nofo()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode().count(self.marker), 1)
+        self.assertContains(response, "section--content--right-col")
+        self.assertContains(
+            response,
+            f'href="#{self.subsection.html_id}"',
+        )
+        self.assertContains(
+            response,
+            f'id="{self.subsection.html_id}"',
+        )
+        self.assertContains(response, "callout-box page-break-before")
+
+    def test_recognized_step_one_callout_renders_once_inline_in_landscape(self):
+        self.nofo.theme = "landscape-cdc-blue"
+        self.nofo.save()
+
+        response = self.rendered_nofo()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode().count(self.marker), 1)
+        self.assertNotContains(response, "section--content--right-col")
+        self.assertContains(response, "callout-box page-break-before")
+
+    def test_regular_subsection_renders_once_inline_with_same_toc_anchor(self):
+        self.subsection.callout_box = False
+        self.subsection.save()
+
+        response = self.rendered_nofo()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode().count(self.marker), 1)
+        self.assertNotContains(response, "section--content--right-col")
+        self.assertContains(
+            response,
+            f'href="#{self.subsection.html_id}"',
+        )
+        self.assertContains(
+            response,
+            f'id="{self.subsection.html_id}"',
+        )
+
+    def test_word_export_reflects_selected_callout_state(self):
+        export_url = reverse("nofos:nofo_export", args=[self.nofo.id])
+
+        callout_response = self.client.get(export_url)
+        self.assertEqual(callout_response.status_code, 200)
+        self.assertContains(callout_response, '<table class="callout-box">')
+        self.assertEqual(callout_response.content.decode().count(self.marker), 1)
+
+        self.subsection.callout_box = False
+        self.subsection.save()
+
+        regular_response = self.client.get(export_url)
+        self.assertEqual(regular_response.status_code, 200)
+        self.assertNotContains(regular_response, '<table class="callout-box">')
+        self.assertEqual(regular_response.content.decode().count(self.marker), 1)

--- a/nofos/nofos/tests_nofos/test_subsection_edit.py
+++ b/nofos/nofos/tests_nofos/test_subsection_edit.py
@@ -161,6 +161,17 @@ class SubsectionCalloutEditingTests(TestCase):
             regular_response,
             "Re-importing this NOFO replaces this setting",
         )
+        self.assertContains(
+            regular_response,
+            "Best for short, high-priority content",
+        )
+        content = regular_response.content.decode()
+        self.assertLess(
+            content.index("Heading level"), content.index("Use callout box styling")
+        )
+        self.assertLess(
+            content.index("Use callout box styling"), content.index("Add a page break")
+        )
         self.assertNotContains(
             regular_response,
             'name="callout_box" checked',


### PR DESCRIPTION
## Summary

- allow editors to add or remove callout-box styling from a subsection
- explain the existing Step 1 portrait placement behavior for recognized callouts
- clarify that reimport uses styling from the source document
- add regression coverage for editing, rendering, navigation, Word export, and reimport

## Why

Subsections already stored callout state and Builder already rendered both callout and regular subsections, but the edit screen submitted the existing value through a hidden field. Editors therefore could not correct callout styling without changing and reimporting the source document or requesting engineering support.

This exposes the existing state as an intentional editing choice without redesigning callout recognition or rendering.

Closes #772.

## User impact

Editors can now apply or remove callout styling while preserving the subsection's name, heading level, content, order, anchor, page-break setting, and table-of-contents behavior.

Recognized Step 1 callouts retain their existing portrait right-margin placement. Reimport remains source-authoritative, and the previous manual state remains available in the archived revision.

## Validation

- 1,577 tests passed before final rebase
- 27 focused subsection-edit and reimport tests passed after rebasing onto the latest `main`
- Django system checks passed
- Black and isort checks passed
- `git diff --check` passed
- independent code review found no actionable issues

## Visual evidence

**Before**, the subsection edit screen did not expose the stored callout state. 

<img width="1280" height="1325" alt="subsection-edit-before" src="https://github.com/user-attachments/assets/63d42a6c-b465-4556-948b-5bf16e32260c" />

**After** this change, it presents a USWDS tile checkbox with placement and reimport guidance.

<img width="1280" height="1454" alt="image" src="https://github.com/user-attachments/assets/e982f33a-70c8-4b55-b8af-a0cb65e6c529" />



