### PR TITLE
Allow editors to add or remove subsection headings

### DIFF
--- a/nofos/bloom_nofos/static/js/nofos/subsection_edit.js
+++ b/nofos/bloom_nofos/static/js/nofos/subsection_edit.js
@@ -1,4 +1,21 @@
 document.addEventListener("DOMContentLoaded", () => {
+  const headingToggle = document.getElementById("has_heading");
+  const headingFields = document.getElementById("subsection-heading-fields");
+
+  if (headingToggle && headingFields) {
+    const headingInputs = headingFields.querySelectorAll("input, select");
+    const syncHeadingFields = () => {
+      const hasHeading = headingToggle.checked;
+      headingFields.hidden = !hasHeading;
+      headingInputs.forEach((input) => {
+        input.disabled = !hasHeading;
+      });
+    };
+
+    headingToggle.addEventListener("change", syncHeadingFields);
+    syncHeadingFields();
+  }
+
   const textEl = document.getElementById("subsection-html_id");
   const button = document.getElementById("subsection-html_id--button");
   if (!textEl || !button) return; // nothing to do

--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -275,7 +275,18 @@ class NofoMetadataForm(forms.ModelForm):
 
 # body needs a custom field and a custom widget so don't use the factory function
 class SubsectionEditForm(forms.ModelForm):
+    has_heading = forms.BooleanField(required=False)
+    heading_control_present = forms.BooleanField(
+        required=False,
+        initial=True,
+        widget=forms.HiddenInput,
+    )
     body = MartorFormField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.is_bound:
+            self.fields["has_heading"].initial = bool(self.instance.tag)
 
     class Meta:
         model = Subsection
@@ -286,11 +297,26 @@ class SubsectionEditForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
+        has_heading = cleaned_data.get("has_heading")
         name = cleaned_data.get("name")
         tag = cleaned_data.get("tag")
 
-        if tag and not name:
+        if not cleaned_data.get("heading_control_present"):
+            has_heading = bool(self.instance.tag)
+            cleaned_data["has_heading"] = has_heading
+            if has_heading:
+                if "name" not in self.data:
+                    name = cleaned_data["name"] = self.instance.name
+                if "tag" not in self.data:
+                    tag = cleaned_data["tag"] = self.instance.tag
+
+        if not has_heading:
+            cleaned_data["name"] = ""
+            cleaned_data["tag"] = ""
+        elif not name:
             self.add_error("name", "Subsection name can’t be empty.")
+        elif not tag:
+            self.add_error("tag", "Select a heading level.")
 
         return cleaned_data
 

--- a/nofos/nofos/nofo_compare.py
+++ b/nofos/nofos/nofo_compare.py
@@ -78,11 +78,13 @@ def result_match(original_subsection):
 
 
 def result_update(original_subsection, new_subsection):
+    old_name = get_subsection_name_or_order(original_subsection)
+    new_name = get_subsection_name_or_order(new_subsection)
     result = SubsectionDiff(
-        name=get_subsection_name_or_order(original_subsection),
+        name=html_diff(old_name, new_name) or new_name,
         section=original_subsection.section,
-        old_name=get_subsection_name_or_order(original_subsection),
-        new_name=get_subsection_name_or_order(new_subsection),
+        old_name=old_name,
+        new_name=new_name,
         status="UPDATE",
         old_value=original_subsection.body,
         new_value=new_subsection.body,
@@ -199,7 +201,7 @@ def compare_sections(old_section, new_section):
 
             # Now handle the matched pair
             matched_subsections.update([new_sub.id, matched_old.id])
-            if has_diff(
+            if matched_old.name != new_sub.name or has_diff(
                 html_diff(
                     markdownify(matched_old.body.strip()),
                     markdownify(new_sub.body.strip()),

--- a/nofos/nofos/templates/nofos/nofo_export.html
+++ b/nofos/nofos/templates/nofos/nofo_export.html
@@ -91,7 +91,7 @@
                                 {% with tag=subsection.tag content=subsection.name id=subsection.html_id|truncate_heading_ids_for_docx %}
                                   {% include "includes/heading.html" with tag=tag content=content id=id only %}
                                 {% endwith %}
-                                <div class="{% if not subsection.name and not subsection.callout_box %}margin-top-2 {% endif %}styled-subsection-body">
+                                <div {% if not subsection.name and subsection.html_id %}id="{{ subsection.html_id|truncate_heading_ids_for_docx }}"{% endif %} class="{% if not subsection.name and not subsection.callout_box %}margin-top-2 {% endif %}styled-subsection-body">
                                   {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|truncate_anchor_links_for_docx }}
                                 </div>
                             </td>
@@ -102,9 +102,11 @@
                           {% include "includes/heading.html" with tag=tag content=content id=id only %}
                         {% endwith %}
                         {% if subsection.body %}
-                          <div class="{% if not subsection.name %}margin-top-2 {% endif %}styled-subsection-body">
+                          <div {% if not subsection.name and subsection.html_id %}id="{{ subsection.html_id|truncate_heading_ids_for_docx }}"{% endif %} class="{% if not subsection.name %}margin-top-2 {% endif %}styled-subsection-body">
                             {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|truncate_anchor_links_for_docx }}
                           </div>
+                        {% elif not subsection.name and subsection.html_id %}
+                          <div id="{{ subsection.html_id|truncate_heading_ids_for_docx }}" class="margin-top-2 styled-subsection-body"></div>
                         {% endif %}
                       {% endif %}
                       {% if subsection.body %}

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -303,16 +303,18 @@
 
       <!-- SECTION CONTENT -->
       <div class="section--content">
+        {% with first_subsection=nofo.get_first_subsection %}
         {% if not section.has_section_page %}
           {% include "includes/heading.html" with tag="h2" content=section.name id=section.html_id only %}
         {% endif %}
         <!-- for the very first subsection, add the nofo agency, subagency, and tagline -->
         {% if section.order == 1 %}
           <div class="section--content--basic-information">
-            {% with first_subsection=nofo.get_first_subsection %}
+            {% if not first_subsection.callout_box %}
               {% with tag=first_subsection.tag content=first_subsection.name id=first_subsection.html_id %}
                 {% include "includes/heading.html" with tag=tag content=content id=id only %}
               {% endwith %}
+            {% endif %}
                 <div class="section--content--intro">
                   <p><strong>{{ nofo.opdiv }}</strong></p>
                   <p>{{ nofo.agency }}</p>
@@ -320,7 +322,6 @@
                   {% if nofo.subagency2 %}<p>{{ nofo.subagency2 }}</p>{% endif %}
                   {% if nofo.tagline %}<div class="nofo--tagline">{{ nofo.tagline|safe_markdown }}</div>{% endif %}
                 </div>
-            {% endwith %}
           </div>
         {% endif %}
 
@@ -352,7 +353,17 @@
               {% include "includes/callout_box.html" with subsection=subsection nofo=nofo only %}
             {% endif %}
           {% else %}
-            {% if subsection.name|lower != 'basic information' %}
+            {% if section.order == 1 and subsection.id == first_subsection.id %}
+              {% if subsection.name|lower != 'basic information' %}
+                {% spaceless %}
+                {% if 'page-break-before' in subsection.html_class %}
+                  {{ '<p>page-break-before</p>'|convert_paragraphs_to_hrs }}
+                {% endif %}
+                {% endspaceless %}
+                {% if not subsection.name and subsection.html_id %}<span id="{{ subsection.html_id }}" aria-hidden="true"></span>{% endif %}
+                {{ subsection.body|safe_markdown|add_classes_to_tables|replace_unicode_with_icon|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs }}
+              {% endif %}
+            {% elif subsection.name|lower != 'basic information' %}
               {% spaceless %}
               {% if 'page-break-before' in subsection.html_class %}
                 {{ '<p>page-break-before</p>'|convert_paragraphs_to_hrs }}
@@ -361,10 +372,12 @@
               {% with tag=subsection.tag content=subsection.name id=subsection.html_id class=subsection.html_class %}
                 {% include "includes/heading.html" with tag=tag content=content id=id class=class only %}
               {% endwith %}
-                {{ subsection.body|safe_markdown|add_classes_to_tables|replace_unicode_with_icon|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs }}
-              {% endif %}
+              {% if not subsection.name and subsection.html_id %}<span id="{{ subsection.html_id }}" aria-hidden="true"></span>{% endif %}
+              {{ subsection.body|safe_markdown|add_classes_to_tables|replace_unicode_with_icon|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs }}
+            {% endif %}
           {% endif %}
         {% endfor %}
+        {% endwith %}
       </div>
     </section>
   {% endfor %}

--- a/nofos/nofos/templates/nofos/nofo_view.html
+++ b/nofos/nofos/templates/nofos/nofo_view.html
@@ -307,6 +307,13 @@
         {% if not section.has_section_page %}
           {% include "includes/heading.html" with tag="h2" content=section.name id=section.html_id only %}
         {% endif %}
+        {% if section.order == 1 and not first_subsection.callout_box %}
+          {% spaceless %}
+          {% if 'page-break-before' in first_subsection.html_class %}
+            {{ '<p>page-break-before</p>'|convert_paragraphs_to_hrs }}
+          {% endif %}
+          {% endspaceless %}
+        {% endif %}
         <!-- for the very first subsection, add the nofo agency, subagency, and tagline -->
         {% if section.order == 1 %}
           <div class="section--content--basic-information">
@@ -355,11 +362,6 @@
           {% else %}
             {% if section.order == 1 and subsection.id == first_subsection.id %}
               {% if subsection.name|lower != 'basic information' %}
-                {% spaceless %}
-                {% if 'page-break-before' in subsection.html_class %}
-                  {{ '<p>page-break-before</p>'|convert_paragraphs_to_hrs }}
-                {% endif %}
-                {% endspaceless %}
                 {% if not subsection.name and subsection.html_id %}<span id="{{ subsection.html_id }}" aria-hidden="true"></span>{% endif %}
                 {{ subsection.body|safe_markdown|add_classes_to_tables|replace_unicode_with_icon|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs }}
               {% endif %}

--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -65,10 +65,32 @@
         </legend>
       {% endif %}
 
-      <!-- name -->
-      <div class="form-group">
-        {% with id="name" label=form.name.label value=form.name.value hint=form.name.help_text error=form.name.errors.0 input_type=form.name|input_type %}
-          {% if subsection.tag %}
+      {{ form.heading_control_present }}
+
+      <!-- heading -->
+      <div class="form-group margin-top-4 width-mobile">
+        <div class="usa-checkbox">
+          <input
+            class="usa-checkbox__input usa-checkbox__input--tile"
+            id="has_heading"
+            type="checkbox"
+            name="has_heading"
+            aria-controls="subsection-heading-fields"
+            {% if form.has_heading.value %}checked{% endif %}
+          >
+          <label class="usa-checkbox__label" for="has_heading">
+            Include a subsection heading
+            <span class="usa-checkbox__label-description">
+              Display a heading above this subsection’s content.
+            </span>
+          </label>
+        </div>
+      </div>
+
+      <div id="subsection-heading-fields">
+        <!-- name -->
+        <div class="form-group">
+          {% with id="name" label=form.name.label value=form.name.value hint=form.name.help_text error=form.name.errors.0 input_type=form.name|input_type %}
             {% include "includes/_text_input.html" with id=id label=label value=value error=error input_type=input_type safe_hint=True only %}
             {% if subsection.html_id %}
               <div class="usa-hint margin-top-05 hint--subsection-id" id="{{ id }}--hint-2">
@@ -78,20 +100,10 @@
                 </button>
               </div>
             {% endif %}
-          {% else %}
-            {% include "includes/_text_input.html" with id=id label=label value=value error=error input_type=input_type disabled="disabled" only %}
-          {% endif %}
-        {% endwith %}
-      </div>
+          {% endwith %}
+        </div>
 
-      <!-- tag -->
-      {% if not form.tag.value %}
-
-        {# if there is no tag, make this a hidden field #}
-        <input type="hidden" name="{{ form.tag.name }}" id="{{ form.tag.id_for_label }}" value="{{ subsection.tag }}">
-
-      {% else %}
-
+        <!-- tag -->
         <div class="form-group width-mobile">
           <label
             {% whitespaceless %}
@@ -123,7 +135,7 @@
             <option value="h7" {% if form.tag.value == 'h7' %}selected{% endif %}>Heading 7</option>
           </select>
         </div>
-      {% endif %}
+      </div>
 
       <!-- callout_box -->
       <div class="form-group margin-top-4 width-mobile">

--- a/nofos/nofos/tests_nofos/test_compare.py
+++ b/nofos/nofos/tests_nofos/test_compare.py
@@ -1092,3 +1092,71 @@ class TestCompareNofosMetadata(TestCase):
         self.assertEqual(application_deadline_add.old_value, "")
         self.assertEqual(application_deadline_add.new_value, "February 2, 2026")
         self.assertIn("<ins>February 2, 2026</ins>", application_deadline_add.diff)
+
+
+class HeadingPresenceComparisonTests(TestCase):
+    def setUp(self):
+        self.old_nofo = Nofo.objects.create(title="Old NOFO", opdiv="Test OpDiv")
+        self.new_nofo = Nofo.objects.create(title="New NOFO", opdiv="Test OpDiv")
+        self.old_section = Section.objects.create(
+            name="Step 1",
+            nofo=self.old_nofo,
+            order=1,
+            html_id="step-1",
+        )
+        self.new_section = Section.objects.create(
+            name="Step 1",
+            nofo=self.new_nofo,
+            order=1,
+            html_id="step-1",
+        )
+
+    def test_removed_heading_is_reported_as_update(self):
+        Subsection.objects.create(
+            section=self.old_section,
+            name="Application process",
+            tag="h3",
+            order=1,
+            body="Same body",
+        )
+        Subsection.objects.create(
+            section=self.new_section,
+            name="",
+            tag="",
+            order=1,
+            body="Same body",
+        )
+
+        result = compare_nofos(self.old_nofo, self.new_nofo)
+        subsection = result[0]["subsections"][0]
+
+        self.assertEqual(subsection.status, "UPDATE")
+        self.assertEqual(subsection.old_name, "Application process")
+        self.assertEqual(subsection.new_name, "(#1)")
+        self.assertIn("<del>Application process</del>", subsection.name)
+        self.assertIn("<ins>(#1)</ins>", subsection.name)
+
+    def test_added_heading_is_reported_as_update(self):
+        Subsection.objects.create(
+            section=self.old_section,
+            name="",
+            tag="",
+            order=1,
+            body="Same body",
+        )
+        Subsection.objects.create(
+            section=self.new_section,
+            name="Application process",
+            tag="h3",
+            order=1,
+            body="Same body",
+        )
+
+        result = compare_nofos(self.old_nofo, self.new_nofo)
+        subsection = result[0]["subsections"][0]
+
+        self.assertEqual(subsection.status, "UPDATE")
+        self.assertEqual(subsection.old_name, "(#1)")
+        self.assertEqual(subsection.new_name, "Application process")
+        self.assertIn("<del>(#1)</del>", subsection.name)
+        self.assertIn("<ins>Application process</ins>", subsection.name)

--- a/nofos/nofos/tests_nofos/test_reimport.py
+++ b/nofos/nofos/tests_nofos/test_reimport.py
@@ -295,6 +295,40 @@ class NofoReimportTests(TransactionTestCase):
         ).subsections.get(name="Eligibility Information")
         self.assertTrue(archived_subsection.callout_box)
 
+    def test_reimport_uses_source_heading_and_archives_manual_heading_state(self):
+        """Reimport remains source-authoritative for subsection headings."""
+        original_html_id = self.subsections[0].html_id
+        self.subsections[0].name = ""
+        self.subsections[0].tag = ""
+        self.subsections[0].save()
+
+        response = self.client.post(
+            reverse("nofos:nofo_import_overwrite", kwargs={"pk": self.nofo.id}),
+            {
+                "nofo-import": create_test_html_file(),
+                "preserve_page_breaks": "on",
+                "csrfmiddlewaretoken": "dummy",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        reimported_subsection = (
+            Nofo.objects.get(id=self.nofo.id)
+            .sections.get(name="Test Section 1")
+            .subsections.get(name="Eligibility Information")
+        )
+        self.assertEqual(reimported_subsection.tag, "h3")
+
+        archived_nofo = Nofo.objects.filter(successor_id=self.nofo.id).get()
+        archived_subsection = archived_nofo.sections.get(
+            name="Test Section 1"
+        ).subsections.get(order=10)
+        self.assertEqual(archived_subsection.name, "")
+        self.assertEqual(archived_subsection.tag, "")
+        self.assertEqual(archived_subsection.html_id, original_html_id)
+
     def test_reimport_success_behavior(self):
         """Test success message and redirect behavior for reimport."""
         test_file = create_test_html_file()

--- a/nofos/nofos/tests_nofos/test_subsection_edit.py
+++ b/nofos/nofos/tests_nofos/test_subsection_edit.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
@@ -380,3 +381,411 @@ class SubsectionCalloutRenderingTests(TestCase):
         self.assertEqual(regular_response.status_code, 200)
         self.assertNotContains(regular_response, '<table class="callout-box">')
         self.assertEqual(regular_response.content.decode().count(self.marker), 1)
+
+
+class SubsectionHeadingEditingTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="headings@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(email="headings@example.com", password="testpass123")
+
+        self.nofo = Nofo.objects.create(
+            title="Heading editing NOFO",
+            short_name="heading-editing",
+            number="TEST-HEADING-001",
+            group="bloom",
+            opdiv="HRSA",
+            agency="Test agency",
+            theme="portrait-hrsa-white",
+        )
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Step 2: Review",
+            html_id="step-2-review",
+            order=2,
+        )
+
+    def edit_url(self, subsection):
+        return reverse(
+            "nofos:subsection_edit",
+            args=[self.nofo.id, self.section.id, subsection.id],
+        )
+
+    def post_subsection(self, subsection, *, has_heading, **overrides):
+        data = {
+            "body": subsection.body,
+            "html_class": subsection.html_class,
+            "callout_box": str(subsection.callout_box),
+            "heading_control_present": "True",
+        }
+        if has_heading:
+            data.update(
+                {
+                    "has_heading": "on",
+                    "name": subsection.name,
+                    "tag": subsection.tag or "h3",
+                }
+            )
+        data.update(overrides)
+        return self.client.post(self.edit_url(subsection), data)
+
+    def test_edit_page_uses_existing_control_patterns_for_heading_state(self):
+        headed = Subsection.objects.create(
+            section=self.section,
+            name="Program details",
+            tag="h3",
+            order=1,
+            body="Program content",
+        )
+        headingless = Subsection.objects.create(
+            section=self.section,
+            name="",
+            tag="",
+            order=2,
+            body="Headingless content",
+        )
+
+        headed_response = self.client.get(self.edit_url(headed))
+        self.assertContains(headed_response, "Include a subsection heading")
+        self.assertContains(
+            headed_response,
+            "Display a heading above this subsection’s content.",
+        )
+        self.assertTrue(headed_response.context["form"]["has_heading"].value())
+        content = headed_response.content.decode()
+        self.assertLess(
+            content.index("Include a subsection heading"),
+            content.index("Subsection name"),
+        )
+        self.assertLess(
+            content.index("Heading level"), content.index("Is callout box?")
+        )
+        self.assertLess(
+            content.index("Is callout box?"), content.index("Add a page break")
+        )
+
+        headingless_response = self.client.get(self.edit_url(headingless))
+        self.assertFalse(headingless_response.context["form"]["has_heading"].value())
+
+    def test_headingless_subsection_can_gain_heading(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="",
+            tag="",
+            order=1,
+            body="Keep this body",
+            html_class="page-break-before",
+            callout_box=True,
+        )
+
+        response = self.post_subsection(
+            subsection,
+            has_heading=True,
+            name="Application process",
+            tag="h3",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.name, "Application process")
+        self.assertEqual(subsection.tag, "h3")
+        self.assertTrue(subsection.html_id)
+        self.assertEqual(subsection.body, "Keep this body")
+        self.assertEqual(subsection.html_class, "page-break-before")
+        self.assertTrue(subsection.callout_box)
+
+    def test_headed_subsection_can_remove_heading_and_keep_anchor(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="Application process",
+            tag="h3",
+            order=1,
+            body="Keep this body",
+            html_class="page-break-before",
+            callout_box=True,
+        )
+        original_html_id = subsection.html_id
+
+        response = self.post_subsection(subsection, has_heading=False)
+
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.name, "")
+        self.assertEqual(subsection.tag, "")
+        self.assertEqual(subsection.html_id, original_html_id)
+        self.assertEqual(subsection.body, "Keep this body")
+        self.assertEqual(subsection.html_class, "page-break-before")
+        self.assertTrue(subsection.callout_box)
+
+    def test_adding_heading_requires_name(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="",
+            tag="",
+            order=1,
+            body="Keep this body",
+        )
+
+        response = self.post_subsection(
+            subsection,
+            has_heading=True,
+            name="",
+            tag="h3",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Subsection name can’t be empty.")
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.name, "")
+        self.assertEqual(subsection.tag, "")
+
+    def test_existing_heading_can_still_be_renamed_and_releveled(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="Application process",
+            tag="h3",
+            order=1,
+            body="Keep this body",
+        )
+        original_html_id = subsection.html_id
+
+        response = self.post_subsection(
+            subsection,
+            has_heading=True,
+            name="Submission process",
+            tag="h4",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.name, "Submission process")
+        self.assertEqual(subsection.tag, "h4")
+        self.assertEqual(subsection.html_id, original_html_id)
+
+    def test_legacy_submission_without_heading_control_preserves_heading(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="Application process",
+            tag="h3",
+            order=1,
+            body="Original body",
+        )
+
+        response = self.client.post(
+            self.edit_url(subsection),
+            {
+                "body": "Updated body",
+                "html_class": "",
+                "callout_box": "False",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.name, "Application process")
+        self.assertEqual(subsection.tag, "h3")
+        self.assertEqual(subsection.body, "Updated body")
+
+    def test_legacy_submission_keeps_existing_heading_validation(self):
+        subsection = Subsection.objects.create(
+            section=self.section,
+            name="Application process",
+            tag="h3",
+            order=1,
+            body="Original body",
+        )
+
+        response = self.client.post(
+            self.edit_url(subsection),
+            {
+                "name": "",
+                "tag": "h3",
+                "body": "Updated body",
+                "html_class": "",
+                "callout_box": "False",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Subsection name can’t be empty.")
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.name, "Application process")
+        self.assertEqual(subsection.tag, "h3")
+        self.assertEqual(subsection.body, "Original body")
+
+
+class SubsectionHeadingRenderingTests(TestCase):
+    marker = "UNIQUE-HEADING-TRANSITION-MARKER"
+
+    def setUp(self):
+        User.objects.create_user(
+            email="heading-rendering@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(
+            email="heading-rendering@example.com",
+            password="testpass123",
+        )
+        self.nofo = Nofo.objects.create(
+            title="Heading rendering NOFO",
+            short_name="heading-rendering",
+            number="TEST-HEADING-002",
+            group="bloom",
+            opdiv="HRSA",
+            agency="Test agency",
+            theme="portrait-hrsa-white",
+        )
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Step 2: Review",
+            html_id="step-2-review",
+            order=2,
+        )
+        self.subsection = Subsection.objects.create(
+            section=self.section,
+            name="Application process",
+            tag="h3",
+            order=1,
+            body=self.marker,
+        )
+
+    def test_removing_heading_removes_toc_entry_but_keeps_html_anchor(self):
+        html_id = self.subsection.html_id
+        view_url = reverse("nofos:nofo_view", args=[self.nofo.id])
+
+        headed_response = self.client.get(view_url)
+        self.assertContains(headed_response, f'href="#{html_id}"')
+        self.assertContains(headed_response, f'<h3 id="{html_id}"')
+
+        self.subsection.name = ""
+        self.subsection.tag = ""
+        self.subsection.save()
+
+        headingless_response = self.client.get(view_url)
+        self.assertNotContains(headingless_response, f'href="#{html_id}"')
+        self.assertContains(
+            headingless_response,
+            f'<span id="{html_id}" aria-hidden="true"></span>',
+        )
+        self.assertEqual(
+            headingless_response.content.decode().count(f'id="{html_id}"'),
+            1,
+        )
+        self.assertEqual(
+            headingless_response.content.decode().count(self.marker),
+            1,
+        )
+
+    def test_first_subsection_heading_and_anchor_render_once(self):
+        first_section = Section.objects.create(
+            nofo=self.nofo,
+            name="Step 1: Prepare",
+            html_id="step-1-prepare",
+            order=1,
+        )
+        first_subsection = Subsection.objects.create(
+            section=first_section,
+            name="Records retention",
+            tag="h3",
+            order=1,
+            body="FIRST-SUBSECTION-BODY",
+            html_class="page-break-before",
+        )
+
+        response = self.client.get(reverse("nofos:nofo_view", args=[self.nofo.id]))
+        content = response.content.decode()
+
+        self.assertEqual(content.count(f'id="{first_subsection.html_id}"'), 1)
+        self.assertEqual(content.count(">Records retention</h3>"), 1)
+        self.assertEqual(content.count("FIRST-SUBSECTION-BODY"), 1)
+        self.assertEqual(content.count("page-break--hr--container"), 1)
+
+    def test_headingless_appendix_table_remains_direct_content_child(self):
+        first_section = Section.objects.create(
+            nofo=self.nofo,
+            name="Step 1: Prepare",
+            html_id="step-1-prepare",
+            order=1,
+        )
+        Subsection.objects.create(
+            section=first_section,
+            name="Basic information",
+            tag="h3",
+            order=1,
+        )
+        for order in range(3, 8):
+            Section.objects.create(
+                nofo=self.nofo,
+                name=f"Section {order}",
+                html_id=f"section-{order}",
+                order=order,
+            )
+        appendix = Section.objects.create(
+            nofo=self.nofo,
+            name="Appendix",
+            html_id="appendix",
+            order=8,
+        )
+        Subsection.objects.create(
+            section=appendix,
+            name="",
+            tag="",
+            order=1,
+            body="| Column |\n| --- |\n| Value |",
+        )
+
+        response = self.client.get(reverse("nofos:nofo_view", args=[self.nofo.id]))
+        soup = BeautifulSoup(response.content, "html.parser")
+        appendix_element = soup.find("section", id="section--appendix")
+        content_element = appendix_element.find(
+            "div",
+            class_="section--content",
+            recursive=False,
+        )
+
+        self.assertIn("section--appendix", appendix_element.get("class", []))
+        self.assertIsNotNone(content_element.find("table", recursive=False))
+
+    def test_word_export_keeps_anchor_when_heading_is_removed(self):
+        html_id = self.subsection.html_id
+        self.subsection.name = ""
+        self.subsection.tag = ""
+        self.subsection.save()
+
+        response = self.client.get(reverse("nofos:nofo_export", args=[self.nofo.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'<div id="{html_id}"')
+        self.assertEqual(response.content.decode().count(self.marker), 1)
+
+    def test_word_export_keeps_anchor_for_headingless_callout(self):
+        html_id = self.subsection.html_id
+        self.subsection.name = ""
+        self.subsection.tag = ""
+        self.subsection.callout_box = True
+        self.subsection.save()
+
+        response = self.client.get(reverse("nofos:nofo_export", args=[self.nofo.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<table class="callout-box">')
+        self.assertContains(response, f'<div id="{html_id}"')
+        self.assertEqual(response.content.decode().count(self.marker), 1)
+
+    def test_word_export_keeps_anchor_for_empty_headingless_subsection(self):
+        html_id = self.subsection.html_id
+        self.subsection.name = ""
+        self.subsection.tag = ""
+        self.subsection.body = ""
+        self.subsection.save()
+
+        response = self.client.get(reverse("nofos:nofo_export", args=[self.nofo.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'<div id="{html_id}"')

--- a/nofos/nofos/tests_nofos/test_subsection_edit.py
+++ b/nofos/nofos/tests_nofos/test_subsection_edit.py
@@ -705,6 +705,10 @@ class SubsectionHeadingRenderingTests(TestCase):
         self.assertEqual(content.count(">Records retention</h3>"), 1)
         self.assertEqual(content.count("FIRST-SUBSECTION-BODY"), 1)
         self.assertEqual(content.count("page-break--hr--container"), 1)
+        self.assertLess(
+            content.index("page-break--hr--container"),
+            content.index(">Records retention</h3>"),
+        )
 
     def test_headingless_appendix_table_remains_direct_content_child(self):
         first_section = Section.objects.create(


### PR DESCRIPTION
Closes #773.

## What changed

- Allows editors to add a heading to a headingless subsection.
- Allows editors to remove a heading while preserving the subsection content and existing anchor.
- Keeps subsection name and heading level together behind one heading-presence control.
- Makes added and removed headings visible in Compare.
- Preserves valid navigation targets in HTML and Word exports.
- Confirms that re-import remains source-authoritative for heading structure.

## Design alignment

- Reuses the existing tiled checkbox pattern already used for callout and page-break controls.
- Reuses the existing subsection-name input and heading-level select.
- Keeps the merged callout component from #775 unchanged.
- Adds no new CSS or standalone UI component.
- Uses only a small interaction in the existing subsection edit script to show or hide the existing heading fields.

The control order is:

1. Include a subsection heading
2. Subsection name and heading level, when applicable
3. Is callout box?
4. Add a page break

## Why

Builder already allows editors to rename headings and change their levels, but the edit page prevented the existing form and data model from representing headed-to-headingless and headingless-to-headed transitions. Editors could not directly correct missing or unnecessary subsection headings without changing the source document and re-importing.

## Validation

- Verified add-heading and remove-heading interactions in the rendered Builder UI.
- Verified existing callout and page-break controls remain unchanged.
- Covered heading state, validation, anchors, table-of-contents membership, first-subsection rendering, appendix tables, Compare, Word export, and re-import.
- 83 focused tests passed.
- Full test suite: 1,600 tests passed.

**Heading Removed Selection**
<img width="1280" height="1328" alt="image" src="https://github.com/user-attachments/assets/8f4268e7-81ba-47e1-9553-65ec0c790831" />

**Heading Added Selection**
<img width="1280" height="1565" alt="image" src="https://github.com/user-attachments/assets/c167b8fb-d986-4088-9060-fe71573f1f2e" />
