### PR TITLE
Remove CDC Landscape themes from theme selection dropdown (#479)

### DIFF
--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -154,6 +154,8 @@ NIH_ALLOWED_CHOICES = {
 # Keep legacy theme values valid on stored NOFOs, but do not offer them for new selection.
 RETIRED_THEME_CHOICES = {
     "portrait-hrsa-blue": "HRSA (Default, legacy)",
+    "landscape-cdc-blue": "CDC Landscape (Default, legacy)",
+    "landscape-cdc-white": "CDC Landscape (Light, legacy)",
 }
 
 

--- a/nofos/nofos/tests_nofos/test_theme_options.py
+++ b/nofos/nofos/tests_nofos/test_theme_options.py
@@ -323,3 +323,84 @@ class NonNIHUserThemeOptionsTests(TestCase):
         form = NofoThemeOptionsForm(data, instance=self.nofo, user=self.user)
         self.assertFalse(form.is_valid())
         self.assertIn("theme", form.errors)
+
+
+class RetiredCdcLandscapeThemeTests(TestCase):
+    """
+    The "CDC Landscape (Default)" and "CDC Landscape (Light)" themes
+    (landscape-cdc-blue / landscape-cdc-white) were removed from the
+    Builder's theme selection dropdown (issue #479) because they were
+    unused. They must not be offered as a choice on any NOFO, but a NOFO
+    that already has one of these themes assigned must still show/preserve
+    that value instead of silently switching to something else.
+    """
+
+    def setUp(self):
+        self.user = _make_user("cdc")
+
+    def test_retired_themes_excluded_for_nofo_with_current_theme(self):
+        nofo = _make_nofo("cdc", theme="portrait-cdc-blue")
+        form = NofoThemeOptionsForm(instance=nofo, user=self.user)
+        theme_values = _theme_choice_values(form)
+        self.assertNotIn("landscape-cdc-blue", theme_values)
+        self.assertNotIn("landscape-cdc-white", theme_values)
+
+    def test_retired_theme_preserved_when_already_assigned(self):
+        nofo = _make_nofo("cdc", theme="landscape-cdc-blue")
+        form = NofoThemeOptionsForm(instance=nofo, user=self.user)
+        theme_values = _theme_choice_values(form)
+        # The NOFO's own (retired) theme is preserved as a choice...
+        self.assertIn("landscape-cdc-blue", theme_values)
+        # ...but the *other* retired theme is still not offered.
+        self.assertNotIn("landscape-cdc-white", theme_values)
+
+    def test_retired_theme_not_reintroduced_for_other_nofos(self):
+        # Assigning the retired theme to one NOFO must not leak it back
+        # into the choices offered for a different NOFO.
+        _make_nofo("cdc", theme="landscape-cdc-blue")
+        other_nofo = _make_nofo("cdc", theme="portrait-cdc-white")
+        form = NofoThemeOptionsForm(instance=other_nofo, user=self.user)
+        self.assertNotIn("landscape-cdc-blue", _theme_choice_values(form))
+
+    def test_get_edit_view_preserves_retired_theme(self):
+        nofo = _make_nofo(
+            "cdc",
+            theme="landscape-cdc-white",
+            cover="nofo--cover-page--hero",
+            icon_style="nofo--icons--border",
+        )
+        client = Client()
+        client.login(email="cdc@example.com", password="testpass123")
+        url = reverse("nofos:nofo_edit_theme_options", kwargs={"pk": nofo.id})
+
+        response = client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        nofo.refresh_from_db()
+        self.assertEqual(nofo.theme, "landscape-cdc-white")
+        self.assertContains(response, "CDC Landscape (Light, legacy)")
+        self.assertContains(response, 'value="landscape-cdc-white" selected')
+
+    def test_valid_submission_can_keep_existing_retired_theme(self):
+        # A user shouldn't be forced off a retired theme just because
+        # it's no longer offered for *new* selections.
+        nofo = _make_nofo("cdc", theme="landscape-cdc-blue")
+        data = {
+            "theme": "landscape-cdc-blue",
+            "cover": "nofo--cover-page--text",
+            "icon_style": "nofo--icons--solid",
+        }
+        form = NofoThemeOptionsForm(data, instance=nofo, user=self.user)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_retired_theme_submission_is_rejected_for_other_nofo(self):
+        # Switching *into* a retired theme from a non-retired one must fail.
+        nofo = _make_nofo("cdc", theme="portrait-cdc-blue")
+        data = {
+            "theme": "landscape-cdc-blue",
+            "cover": "nofo--cover-page--text",
+            "icon_style": "nofo--icons--solid",
+        }
+        form = NofoThemeOptionsForm(data, instance=nofo, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("theme", form.errors)


### PR DESCRIPTION
## Summary

Closes #479. Removes "CDC Landscape (Default)" (`landscape-cdc-blue`) and "CDC Landscape (Light)" (`landscape-cdc-white`) from the Builder's theme selection dropdown — they were unused as selectable options.

- **`nofos/nofos/forms.py`** — `NofoThemeOptionsForm` now excludes these two values when building the theme dropdown's optgroups. `models.THEME_CHOICES` is intentionally left untouched: `Nofo.save()` calls `full_clean()` on every save (not just when the theme field changes), which validates `theme` against `THEME_CHOICES`. Removing the values there would break saving *any* existing NOFO currently assigned one of these themes (any edit — title, status, etc. — would raise a `ValidationError`), not just prevent selecting them. Keeping them in `THEME_CHOICES` but filtering them out of the form's choices removes them from selection while leaving any existing NOFO fully renderable and editable.
- This PR was rebased on top of `main`, which in the meantime added a `RETIRED_THEME_CHOICES` mechanism for the same purpose (retiring `portrait-hrsa-blue`). Rather than keep two parallel mechanisms, the two CDC Landscape themes were folded into that shared `RETIRED_THEME_CHOICES` dict alongside the HRSA entry. If a NOFO's current theme is one of the two retired CDC Landscape values, the form still includes it (relabeled with a "(legacy)" suffix, e.g. "CDC Landscape (Default, legacy)") so the edit page shows/preserves that value on load instead of silently defaulting to a different theme — it just isn't offered as something to switch *into* on any NOFO.
- **`nofos/nofos/tests_nofos/test_theme_options.py`** — added `RetiredCdcLandscapeThemeTests` (named to match the existing `RETIRED_THEME_CHOICES` convention) covering: the two themes are excluded from the dropdown for NOFOs not already using them, a NOFO's own retired theme is preserved as a choice while the *other* retired theme still isn't offered, the retired theme doesn't leak into other NOFOs' choices, the edit view's GET response renders the existing value as `selected` (with its legacy label) without changing the DB record, a form re-submission of the unchanged retired theme still validates, and a fresh attempt to switch a different NOFO *into* the retired theme is rejected.

## Existing NOFO usage

Confirmed — no live NOFOs currently use either theme, so this is safe to merge as-is.

## Test plan

- [x] `poetry run python manage.py test nofos.tests_nofos.test_theme_options` — 31 tests pass
- [x] `poetry run python manage.py test` — full suite (1597 tests) passes
- [x] `isort --check` / `black --check` clean on changed files
- [x] Confirmed via test that a NOFO with an existing retired theme still renders that value (with its legacy label) as `selected` on its edit page and is not force-reset to a different theme
