### PR TITLE
Add vulnerability scans to CI via new workflow

### DIFF
--- a/.dockleconfig
+++ b/.dockleconfig
@@ -1,0 +1,17 @@
+# This file is allows you to specify a list of files that is acceptable to Dockle
+# To allow multiple files, use a list of names, example below. Make sure to remove the leading #
+# DOCKLE_ACCEPT_FILES="file1,path/to/file2,file3/path,etc"
+# https://github.com/goodwithtech/dockle#accept-suspicious-environment-variables--files--file-extensions
+#
+# This file mirrors the .dockleconfig used by the deployment pipeline in
+# HHS/simpler-grants-gov so that the scan run on PRs here enforces the same rules.
+# Keep the two files in sync when adding or removing an entry.
+#
+# Note: that file is shared across every image built in the monorepo, so it is kept
+# here verbatim to make syncing mechanical. Only the "app/" entries can match this
+# image (they resolve to /app in the container, i.e. app/nofos/... is /app/nofos/...);
+# the "api/" and "analytics/" entries belong to other images and simply never match.
+#
+# The apiflask/settings file is a stub file that apiflask creates, and has no sensitive data in. We are ignoring it since it is unused
+# The settings.py files under the docx have been reviewed and do not hold sensitive info in them.
+DOCKLE_ACCEPT_FILES=api/.venv/lib/python3.14/site-packages/newrelic/api/settings.py,api/.venv/lib/python3.14/site-packages/apiflask/settings.py,api/.venv/lib/python3.14/site-packages/docx/oxml/settings.py,api/.venv/lib/python3.14/site-packages/docx/parts/settings.py,api/.venv/lib/python3.14/site-packages/docx/settings.py,analytics/.venv/lib/python3.14/site-packages/newrelic/api/settings.py,analytics/.venv/lib/python3.14/site-packages/jedi/settings.py,app/.venv/lib/python3.14/site-packages/isort/settings.py,app/nofos/bloom_nofos/settings.py,app/.venv/lib/python3.14/site-packages/easyaudit/settings.py,app/.venv/lib/python3.14/site-packages/constance/settings.py,app/.venv/lib/python3.14/site-packages/cssutils/settings.py,app/.venv/lib/python3.14/site-packages/martor/settings.py

--- a/.github/workflows/code_scans.yml
+++ b/.github/workflows/code_scans.yml
@@ -2,6 +2,10 @@
 # Security code scans that mirror the rules enforced by the deployment pipeline in
 # HHS/simpler-grants-gov (.github/workflows/vulnerability-scans-nofos.yml), so that
 # vulnerabilities are caught on the PR instead of at deploy time.
+#
+# Upstream builds and caches the image in a separate workflow (ci-nofos.yml) and the
+# scan jobs restore it. There is no equivalent build workflow here, so the build job
+# below fills that role and the three scan jobs restore its cached image.
 
 name: Code Scans
 
@@ -28,9 +32,115 @@ on:
         type: boolean
 
 jobs:
+  build:
+    name: Build Image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4.3.1
+
+      - name: Build Docker container PROD
+        run: make build IS_PROD_ARG=1
+
+      - name: Save prod container image to file
+        run: docker save nofos:latest > /tmp/docker-image.tar
+
+      - name: Cache Docker image PROD
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+  trivy-scan:
+    name: Trivy Scan
+    runs-on: ubuntu-22.04
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4.3.1
+
+      - name: Clear ignore files
+        if: inputs.bypass_ignore == true
+        run: |
+          rm .trivyignore
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached trivy vulnerability and Java DBs
+        id: trivy-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: trivy-cache-${{ steps.date.outputs.date }}
+
+      # Download and extract the vulnerability DB and Java DB
+      # This is based on the instructions here:
+      # https://github.com/aquasecurity/trivy-action/?tab=readme-ov-file#updating-caches-in-the-default-branch
+
+      - name: Setup oras
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        uses: oras-project/setup-oras@v1
+
+      - name: Download and extract the vulnerability DB
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.cache/trivy/db"
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C "$GITHUB_WORKSPACE/.cache/trivy/db"
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.cache/trivy/java-db"
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C "$GITHUB_WORKSPACE/.cache/trivy/java-db"
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: trivy-cache-${{ steps.date.outputs.date }}
+
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Load cached Docker image
+        run: docker load < /tmp/docker-image.tar
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: image
+          image-ref: nofos:latest
+          format: table
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: os
+          scanners: vuln,secret
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
+          # PyJWT has an example with a fake JWT that Trivy flags.
+          # see: https://github.com/aquasecurity/trivy/discussions/5772
+          TRIVY_SKIP_FILES: "/app/.venv/lib/python*/site-packages/PyJWT-*.dist-info/METADATA"
+
+      - name: Save output to workflow summary
+        if: always() # Runs even if there is a failure
+        run: |
+          echo "View results in GitHub Action logs" >> "$GITHUB_STEP_SUMMARY"
+
   anchore-scan:
     name: Anchore Scan
     runs-on: ubuntu-22.04
+    needs: build
 
     steps:
       - uses: actions/checkout@v4.3.1
@@ -43,13 +153,19 @@ jobs:
           rm .grype.yml
           mv new.grype.yml .grype.yml
 
-      - name: Build Docker container PROD
-        id: build
-        run: make build IS_PROD_ARG=1
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Load cached Docker image
+        id: load
+        run: docker load < /tmp/docker-image.tar
 
       - name: Run Anchore vulnerability scan (json)
         # Runs even if an earlier scan failed, but only if we have an image to scan
-        if: always() && steps.build.outcome == 'success'
+        if: always() && steps.load.outcome == 'success'
         uses: anchore/scan-action@v6
         id: anchore-scan-json
         with:
@@ -59,7 +175,7 @@ jobs:
           severity-cutoff: medium
 
       - name: Run Anchore vulnerability scan (table)
-        if: always() && steps.build.outcome == 'success'
+        if: always() && steps.load.outcome == 'success'
         uses: anchore/scan-action@v6
         with:
           image: nofos:latest
@@ -71,3 +187,48 @@ jobs:
         if: always() && steps.anchore-scan-json.outputs.json != ''
         run: |
           jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-json.outputs.json }}
+
+  dockle-scan:
+    name: Dockle Scan
+    runs-on: ubuntu-22.04
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4.3.1
+
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Load cached Docker image
+        run: docker load < /tmp/docker-image.tar
+
+      # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
+      # variable, this will save the variable in this file to env for Dockle
+      - name: Set any acceptable Dockle files
+        run: |
+          if grep -q "^DOCKLE_ACCEPT_FILES=.*" .dockleconfig; then
+            grep -s '^DOCKLE_ACCEPT_FILES=' .dockleconfig >> "$GITHUB_ENV"
+          fi
+
+      - name: Create temporary .dockleignore
+        run: echo "DKL-DI-0006" > .dockleignore
+
+      - name: Run Dockle container linter
+        uses: erzz/dockle-action@v1.4.1
+        with:
+          image: nofos:latest
+          exit-code: "1"
+          failure-threshold: WARN
+          accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}
+
+      - name: Save output to workflow summary
+        if: failure() # Only runs if there is a failure
+        run: |
+          {
+            echo '```json'
+            cat dockle-report.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/code_scans.yml
+++ b/.github/workflows/code_scans.yml
@@ -1,0 +1,73 @@
+# code_scans.yml
+# Security code scans that mirror the rules enforced by the deployment pipeline in
+# HHS/simpler-grants-gov (.github/workflows/vulnerability-scans-nofos.yml), so that
+# vulnerabilities are caught on the PR instead of at deploy time.
+
+name: Code Scans
+
+on:
+  workflow_call: # Called by the orchestrator workflow (main.yml)
+    inputs:
+      branch:
+        description: "Branch to run code scans on"
+        required: false
+        default: "main"
+        type: "string"
+      bypass_ignore:
+        description: "controls if we want to not honor the scan ignore files during this run"
+        required: false
+        default: false
+        type: boolean
+
+  workflow_dispatch:
+    inputs:
+      bypass_ignore:
+        description: "controls if we want to not honor the scan ignore files during this run"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  anchore-scan:
+    name: Anchore Scan
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4.3.1
+
+      - name: Clear ignore files
+        # Drop the per-CVE safelist entries but keep the fix-state rules
+        if: inputs.bypass_ignore == true
+        run: |
+          grep -v "\- vulnerability:" .grype.yml > new.grype.yml
+          rm .grype.yml
+          mv new.grype.yml .grype.yml
+
+      - name: Build Docker container PROD
+        id: build
+        run: make build IS_PROD_ARG=1
+
+      - name: Run Anchore vulnerability scan (json)
+        # Runs even if an earlier scan failed, but only if we have an image to scan
+        if: always() && steps.build.outcome == 'success'
+        uses: anchore/scan-action@v6
+        id: anchore-scan-json
+        with:
+          image: nofos:latest
+          output-format: json
+          fail-build: true
+          severity-cutoff: medium
+
+      - name: Run Anchore vulnerability scan (table)
+        if: always() && steps.build.outcome == 'success'
+        uses: anchore/scan-action@v6
+        with:
+          image: nofos:latest
+          output-format: table
+          fail-build: true
+          severity-cutoff: medium
+
+      - name: Print output to workflow summary
+        if: always() && steps.anchore-scan-json.outputs.json != ''
+        run: |
+          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-json.outputs.json }}

--- a/.github/workflows/django_ci.yml
+++ b/.github/workflows/django_ci.yml
@@ -1,11 +1,9 @@
 name: Django CI
 
 on:
-  pull_request: # Run on every PR
-    branches:
-      - main
-      - "**"
-
+  # Triggered only by the orchestrator workflow (main.yml), which already runs on
+  # every PR and on push to main. A pull_request trigger here as well would run
+  # this workflow twice per PR.
   workflow_call: # Allow this workflow to be called by other workflows
     inputs:
       branch:
@@ -15,7 +13,8 @@ on:
         type: "string"
 
 jobs:
-  ci:
+  unit-tests:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,15 @@ on:
       - main
 
 jobs:
-  ci:
-    uses: ./.github/workflows/django_ci.yml # Call the CI workflow
+  run-tests:
+    name: Run Tests
+    uses: ./.github/workflows/django_ci.yml # Call the unit test workflow
     with:
       branch: ${{ github.ref_name }}
     secrets: inherit
 
   code-scans:
-    uses: ./.github/workflows/code_scans.yml # Call the code scans workflow (Anchore/grype scan)
+    name: Code Scans
+    uses: ./.github/workflows/code_scans.yml # Call the code scans workflow (Trivy/Anchore/Dockle)
     with:
       branch: ${{ github.ref_name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,3 +16,8 @@ jobs:
     with:
       branch: ${{ github.ref_name }}
     secrets: inherit
+
+  code-scans:
+    uses: ./.github/workflows/code_scans.yml # Call the code scans workflow (Anchore/grype scan)
+    with:
+      branch: ${{ github.ref_name }}

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,56 @@
+fail-on-severity: "medium"
+
+# List of vulnerabilities to ignore for the anchore scan
+# https://github.com/anchore/grype#specifying-matches-to-ignore
+#
+# This file mirrors the .grype.yml used by the deployment pipeline in
+# HHS/simpler-grants-gov so that the scan run on PRs here enforces the same rules.
+# Keep the two files in sync when adding or removing an entry.
+
+# Please add safelists in the following format to make it easier when checking
+# Package/module name: URL to vulnerability for checking updates
+#  Versions:     URL to the version history
+#  Dependencies: Name of any other packages or modules that are dependent on this version
+#                 Link to the dependencies for ease of checking for updates
+#  Issue:         Why there is a finding and why this is here or not been removed
+#  Last checked:  Date last checked in scans
+# - vulnerability: The-CVE-or-vuln-id # Remove comment at start of line
+
+ignore:
+  # These settings ignore any findings that fall into these categories
+  - fix-state: not-fixed
+  - fix-state: wont-fix
+  - fix-state: unknown
+
+  # Not fixed in GA Python yet
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 05/13/26
+  - vulnerability: CVE-2025-15366
+
+  # Not fixed in GA Python yet
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 05/13/2026
+  - vulnerability: CVE-2025-15367
+
+  # Fix only in pre-release Python 3.15 (3.15.0b3); no fix in any GA 3.14.x yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 07/01/2026
+  - vulnerability: CVE-2026-12003
+
+  # html.parser.HTMLParser
+  # Fix only in pre-release Python 3.15 (3.15.0b3); no fix in any GA 3.14.x yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 07/13/2026
+  - vulnerability: CVE-2026-15308
+
+  # Fix only in pre-release Python 3.15 (3.15.0b4); no fix in any GA 3.14.x yet.
+  # Last checked: 07/30/2026
+  - vulnerability: CVE-2026-11940
+
+  # Fix only in pre-release Python 3.15 (3.15.0b4); no fix in any GA 3.14.x yet.
+  # Last checked: 07/30/2026
+  - vulnerability: CVE-2026-11972
+
+  # Fix only in pre-release Python 3.15 (3.15.0b4); no fix in any GA 3.14.x yet.
+  # Last checked: 07/30/2026
+  - vulnerability: CVE-2026-0864

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,14 @@
+# List of vulnerabilities to ignore for the trivy scan
+#
+# This file mirrors the .trivyignore used by the deployment pipeline in
+# HHS/simpler-grants-gov so that the scan run on PRs here enforces the same rules.
+# Keep the two files in sync when adding or removing an entry.
+#
+# Please add safelists in the following format to make it easier when checking
+# Package/module name: URL to vulnerability for checking updates
+#  Versions:     URL to the version history
+#  Dependencies: Name of any other packages or modules that are dependent on this version
+#                 Link to the dependencies for ease of checking for updates
+#  Issue:         Why there is a finding and why this is here or not been removed
+#  Last checked:  Date last checked in scans
+#The-CVE-or-vuln-id # Remove comment at start of line


### PR DESCRIPTION
## What changed

Adds the three vulnerability scans from the deployment pipeline to CI, so image vulnerabilities are caught on the PR instead of at deploy time.

**`.github/workflows/code_scans.yml`** (new) — reusable workflow with four jobs:

| Job | What it does |
|---|---|
| `build` | Builds the prod image (`make build IS_PROD_ARG=1`), `docker save`s it, caches it |
| `trivy-scan` | `aquasecurity/trivy-action@master` — OS vulns + secrets, `exit-code: 1`, `ignore-unfixed: true` |
| `anchore-scan` | `anchore/scan-action@v6` — JSON + table, `severity-cutoff: medium`, `fail-build: true` |
| `dockle-scan` | `erzz/dockle-action@v1.4.1` — container lint, `failure-threshold: WARN` |

**`.github/workflows/main.yml`** — new `code-scans` job calling the above, running in parallel with the existing `ci` job on every PR and on push to `main`.

**`.github/workflows/django_ci.yml`** — removed its standalone `pull_request` trigger. It had one *and* was called by `main.yml`, so Django CI ran twice on every PR (visible as both `ci` and `ci / ci`). `main.yml` is now the sole entry point for both workflows.

**Job naming** — the old `ci / ci` check name said nothing about what ran. Jobs are now named for what they actually do ("unit tests" specifically, since integration tests aren't included):

| Old check name | New check name |
|---|---|
| `ci`, `ci / ci` (ran twice) | `Run Tests / Run Unit Tests` |
| `code-scans / Trivy Scan` etc. | `Code Scans / Trivy Scan` etc. |

**Three new config files** — the scans read these from the workspace, and none existed in this repo. Without them the scans would use defaults and fail on findings the deploy pipeline ignores.

- `.grype.yml` — `fail-on-severity: medium`, the three `fix-state` ignores (`not-fixed`, `wont-fix`, `unknown`), and the seven CVE safelist entries with their justification comments.
- `.trivyignore` — upstream's has no active entries (all comments); it's included because the `bypass_ignore` path does `rm .trivyignore`, which needs the file to exist.
- `.dockleconfig` — supplies `DOCKLE_ACCEPT_FILES`.

## Why

The deployment pipeline in HHS/simpler-grants-gov already gates on these scans via [`vulnerability-scans-nofos.yml`](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/vulnerability-scans-nofos.yml), but only at deploy time — after the code has merged here. This moves the same rules onto the PR.

All scan parameters, the Trivy DB-caching sequence, the `TRIVY_SKIP_FILES` PyJWT false-positive skip, the runtime `.dockleignore` carrying `DKL-DI-0006`, the `bypass_ignore` input, and the config file contents are taken from the reference workflow and its config files.

## Notes for reviewers

**The build is its own job.** Upstream builds and caches the image in a separate workflow (`ci-nofos.yml`) that the scan workflow restores from; there's no equivalent here. Rather than build the image three times — identical image, triple the runner minutes — the `build` job fills that role and the three scan jobs restore its cached image using the same cache key. Trade-off: the image tar is restored three times, so if cache transfer turns out slower than rebuilding, this is the knob to turn.

**`.dockleconfig` is kept verbatim, and most of it is inert here.** Upstream's copy is shared across every image in the monorepo, so only the `app/`-prefixed entries can ever match this image (`app/nofos/bloom_nofos/settings.py` → `/app/nofos/...` in the container). The `api/` and `analytics/` entries belong to other images and never match. I kept them so syncing with upstream stays mechanical instead of requiring judgment — happy to trim to just the six `app/` entries if you'd prefer.

**Three files now need to stay in sync with upstream** (`.grype.yml`, `.trivyignore`, `.dockleconfig`) when a CVE or accepted file is added or dropped. Each carries a comment saying so. Open to a better approach if one exists.

**One deviation from upstream's step conditions:** the Anchore scan steps are gated on `steps.load.outcome == 'success'` rather than a bare `if: always()`, so a cache-restore failure surfaces as the load error rather than a confusing "image not found" from the scanner.

**No secrets are used.** The scans need no registry auth (the image is local) and grype/trivy pull their vulnerability DBs unauthenticated, so the `code-scans` job passes no secrets. The existing `ci` job's `secrets: inherit` is left as-is.

## ⚠️ Requires a ruleset change before merging

Deduplicating and renaming the Django CI run changes its check context, and the old name is a required check:

- The `no force pushes to main` ruleset requires the status check **`ci`**.
- That bare `ci` context was produced only by the standalone `pull_request` trigger this PR removes. Reusable-workflow checks are always `caller-job / called-job`, so bare `ci` cannot be reproduced — the run now reports as **`Run Tests / Run Unit Tests`**.

**The ruleset's required check must be changed from `ci` to `Run Tests / Run Unit Tests` before this merges**, otherwise every subsequent PR will block on a check that never reports.

While that ruleset is open, these are the other check names now available if you want them required too: `Code Scans / Build Image`, `Code Scans / Trivy Scan`, `Code Scans / Anchore Scan`, `Code Scans / Dockle Scan`.

## Testing

The workflow parses as valid YAML, the job graph and `uses:` references resolve, and every scan parameter was diffed against the reference workflow.

**Whether the image actually passes these scans is unverified until CI runs on this PR.** The reference workflow scans the image built from this repo's Dockerfile, so behavior should match what the deploy pipeline already sees — and the `FROM scratch` final stage exists specifically to satisfy Dockle — but the first run here is the real test. If findings surface, the fix is either a dependency bump or a new safelist entry in both copies of the relevant config file.
