### PR TITLE
Default NIH-group NOFO imports to the eRA "Before you begin" page

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1694,6 +1694,13 @@ def suggest_nofo_cover(nofo_theme):
     return "nofo--cover-page--medium"
 
 
+def suggest_nofo_before_you_begin(nofo_group):
+    if nofo_group == "nih":
+        return "era"
+
+    return "full"
+
+
 def suggest_nofo_theme(nofo_number, opdiv=""):
     opdiv_lower = (opdiv or "").lower()
     if "national institutes of health" in opdiv_lower or re.search(
@@ -1826,6 +1833,10 @@ def suggest_all_nofo_fields(nofo, soup):
         )  # guess the NOFO theme
     if first_time_import:
         nofo.cover = suggest_nofo_cover(nofo.theme)  # guess the NOFO cover
+    if first_time_import:
+        nofo.before_you_begin = suggest_nofo_before_you_begin(
+            nofo.group
+        )  # guess the NOFO "Before you begin" page
 
 
 ###########################################################

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -71,6 +71,7 @@ from .nofo import (
     suggest_nofo_agency,
     suggest_nofo_application_deadline,
     suggest_nofo_author,
+    suggest_nofo_before_you_begin,
     suggest_nofo_cover,
     suggest_nofo_keywords,
     suggest_nofo_opdiv,
@@ -4070,6 +4071,20 @@ class HTMLSuggestCoverTests(TestCase):
         self.assertEqual(suggest_nofo_cover(""), nofo_cover)
 
 
+class HTMLSuggestBeforeYouBeginTests(TestCase):
+    def test_suggest_nofo_before_you_begin_nih_returns_era(self):
+        self.assertEqual(suggest_nofo_before_you_begin("nih"), "era")
+
+    def test_suggest_nofo_before_you_begin_bloom_returns_full(self):
+        self.assertEqual(suggest_nofo_before_you_begin("bloom"), "full")
+
+    def test_suggest_nofo_before_you_begin_other_group_returns_full(self):
+        self.assertEqual(suggest_nofo_before_you_begin("hrsa"), "full")
+
+    def test_suggest_nofo_before_you_begin_empty_string_returns_full(self):
+        self.assertEqual(suggest_nofo_before_you_begin(""), "full")
+
+
 class SuggestNofoOpDivTests(TestCase):
     def test_opdiv_present_in_paragraph(self):
         html = "<div><p>Opdiv: Center for Awesome NOFOs</p></div>"
@@ -4541,6 +4556,7 @@ class SuggestNofoFieldsTests(TestCase):
         )
         self.assertEqual(self.nofo.theme, "portrait-hrsa-white")
         self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
+        self.assertEqual(self.nofo.before_you_begin, "full")
 
     def test_suggest_all_nofo_fields_with_missing_data(self):
         # HTML content with some missing fields
@@ -4571,6 +4587,15 @@ class SuggestNofoFieldsTests(TestCase):
         # still get set
         self.assertEqual(self.nofo.theme, "portrait-hrsa-white")
         self.assertEqual(self.nofo.cover, "nofo--cover-page--text")
+        self.assertEqual(self.nofo.before_you_begin, "full")
+
+    def test_suggest_all_nofo_fields_nih_group_sets_before_you_begin_era(self):
+        """A NOFO belonging to the NIH group defaults its BYB page to the eRA variant."""
+        self.nofo.group = "nih"
+        suggest_all_nofo_fields(self.nofo, self.soup)
+        self.nofo.save()
+
+        self.assertEqual(self.nofo.before_you_begin, "era")
 
     def test_suggest_all_nofo_fields_overwrite_empty_fields(self):
         suggest_all_nofo_fields(self.nofo, self.soup)

--- a/nofos/nofos/tests_nofos/test_before_you_begin_import.py
+++ b/nofos/nofos/tests_nofos/test_before_you_begin_import.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup
+from django.test import RequestFactory, TestCase
+from users.models import BloomUser
+
+from nofos.models import Nofo
+from nofos.views import NofosImportNewView
+
+
+class NofoBeforeYouBeginAutoAssignTest(TestCase):
+    """Tests that importing a NOFO sets 'before_you_begin' based on the importing user's group.
+
+    This exercises the real handle_nofo_create() -> suggest_all_nofo_fields()
+    call, rather than mocking suggest_all_nofo_fields() away, because the
+    behavior under test depends on nofo.group being assigned *before*
+    suggest_all_nofo_fields() runs.
+    """
+
+    def _make_user(self, email, group):
+        return BloomUser.objects.create_user(
+            email=email,
+            password="testpass123",
+            full_name="Test User",
+            group=group,
+            force_password_reset=False,
+        )
+
+    def _call_handle_nofo_create(self, user):
+        # Pre-create the Nofo that the mocked create_nofo will return.
+        nofo = Nofo.objects.create(title="Test NOFO", opdiv="HHS")
+        # suggest_all_nofo_fields() re-derives opdiv from the soup, so it must
+        # be present here too, or the NOFO fails full_clean() (opdiv is required).
+        soup = BeautifulSoup("<html><body><p>OpDiv: HHS</p></body></html>", "html.parser")
+
+        request = RequestFactory().post("/")
+        request.user = user
+
+        view = NofosImportNewView()
+
+        with patch("nofos.views.create_nofo", return_value=nofo), patch(
+            "nofos.views.suggest_nofo_title", return_value="Test NOFO"
+        ), patch("nofos.views.suggest_nofo_opdiv", return_value="HHS"), patch(
+            "nofos.views.add_headings_to_document"
+        ), patch(
+            "nofos.views.add_page_breaks_to_headings"
+        ), patch(
+            "nofos.views.create_nofo_audit_event"
+        ):
+            view.handle_nofo_create(request, soup, [], "test.html")
+
+        nofo.refresh_from_db()
+        return nofo
+
+    def test_nih_group_import_defaults_before_you_begin_to_era(self):
+        user = self._make_user("nih@example.com", group="nih")
+        nofo = self._call_handle_nofo_create(user)
+
+        self.assertEqual(nofo.group, "nih")
+        self.assertEqual(nofo.before_you_begin, "era")
+
+    def test_non_nih_group_import_leaves_before_you_begin_full(self):
+        user = self._make_user("bloom@example.com", group="bloom")
+        nofo = self._call_handle_nofo_create(user)
+
+        self.assertEqual(nofo.group, "bloom")
+        self.assertEqual(nofo.before_you_begin, "full")

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -644,9 +644,11 @@ class NofosImportNewView(BaseNofoImportView):
             nofo = create_nofo(nofo_title, sections, opdiv)
             add_headings_to_document(nofo)
             add_page_breaks_to_headings(nofo)
+            # group must be set before suggest_all_nofo_fields() so it can key
+            # group-specific defaults (e.g. the NIH "before you begin" page) off it
+            nofo.group = request.user.group
             suggest_all_nofo_fields(nofo, soup)
             nofo.filename = filename
-            nofo.group = request.user.group
             nofo.designer = (request.user.full_name or "").strip()
             nofo.save()
 


### PR DESCRIPTION
## Background

When a NOFO is imported and NOFO Builder determines it belongs to the NIH group, the design theme is already suggested correctly (NIH's "portrait-nih-white" theme). Separately, every NOFO has a "Before you begin" (BYB) page setting (`Nofo.before_you_begin`) with four choices: `full` (current default for every group), `era` ("BYB page with eRA", referencing eRA Commons, NIH's grants system), `sole_source`, and `none`.

Today, `before_you_begin` defaults to `full` for every group, including NIH — there's no logic giving NIH NOFOs the eRA-specific variant automatically. This PR adds that: new NOFOs imported by an NIH-group user get `before_you_begin = "era"` automatically, the same way `theme`/`cover` already get NIH-aware defaults on import.

## What changed

- `nofos/nofos/nofo.py`: added `suggest_nofo_before_you_begin(nofo_group)`, wired into `suggest_all_nofo_fields()` alongside the existing theme/cover first-time-import defaults.
- `nofos/nofos/views.py`: reordered `NofosImportNewView.handle_nofo_create()` so `nofo.group` is set before `suggest_all_nofo_fields()` runs (previously set after — the NIH check needs it available).
- Tests: unit tests for the new helper, an NIH-group case added to `suggest_all_nofo_fields` tests, and an integration test exercising the real import call path end-to-end.

## Scope / non-goals

- Only affects new imports going forward — no existing NOFOs are touched, no migration involved.
- The global model default (`before_you_begin="full"`) is unchanged, since it's shared by every group.
- Reimporting an already-populated NIH NOFO won't reset a coach's manually chosen BYB page (gated by the existing `first_time_import` check).

## Acceptance criteria

- [x] New NIH-group import sets `before_you_begin` to `era`
- [x] New non-NIH import leaves `before_you_begin` at `full`
- [x] Reimport of an existing NOFO doesn't change `before_you_begin`
- [x] No existing NOFO rows modified by this change
- [x] Full test suite passes

## Test plan

- `poetry run python manage.py test` — full suite passes
- New/updated tests: `test_nofo.py::HTMLSuggestBeforeYouBeginTests`, `test_nofo.py::SuggestNofoFieldsTests::test_suggest_all_nofo_fields_nih_group_sets_before_you_begin_era`, `tests_nofos/test_before_you_begin_import.py`
