### PR TITLE
Run apt-get upgrade in Docker builder stage to patch base-image OS CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ FROM python:3.14-slim AS builder
 WORKDIR /app
 
 # Install system dependencies (Debian-based)
+# apt-get upgrade patches base-image OS packages (e.g. util-linux) that carry
+# fixed CVEs Debian has since released but the base image was built before.
 RUN apt-get update && \
+  apt-get upgrade -y && \
   apt-get install -y --no-install-recommends \
   build-essential \
   curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,16 @@ FROM python:3.14-slim AS builder
 WORKDIR /app
 
 # Install system dependencies (Debian-based)
-# apt-get upgrade patches base-image OS packages (e.g. util-linux) that carry
-# fixed CVEs Debian has since released but the base image was built before.
+# The --only-upgrade line patches CVE-2026-13595 and CVE-2026-27456, both Medium,
+# both in the util-linux source package family: bsdutils, libblkid1, liblastlog2-2,
+# libmount1, libsmartcols1, libuuid1, login, mount, util-linux.
+# python:3.14-slim ships 2.41-5. Debian published the fix as 2.41.5-0+deb13u1
+# before the base image was rebuilt, so Anchore/Grype fails on any freshly built
+# image. Upgrading is preferred over a .grype.yml entry because the fix exists.
+# Remove this line once the base image ships util-linux >= 2.41.5-0+deb13u1.
+# Last checked: 08/17/2026
 RUN apt-get update && \
-  apt-get upgrade -y && \
+  apt-get install -y --only-upgrade --no-install-recommends util-linux && \
   apt-get install -y --no-install-recommends \
   build-essential \
   curl \


### PR DESCRIPTION
## Background

The Anchore (Grype) scan (`Code Scans / Anchore Scan`) fails on freshly built images with:

```
Failed minimum severity level. Found vulnerabilities with level 'medium' or higher
```

The two flagged CVEs — `CVE-2026-27456` and `CVE-2026-13595` — affect Debian's `util-linux` package family (`bsdutils`, `libblkid1`, `liblastlog2-2`, `libmount1`, `libsmartcols1`, `libuuid1`, `login`, `mount`, `util-linux`), currently at `2.41-5` in the `python:3.14-slim` base image. Both are fixed in `2.41.5-0+deb13u1`, which Debian has already published — our Dockerfile just never pulls it in, since the builder stage runs `apt-get update && apt-get install ...` but never `apt-get upgrade`.

This isn't caused by any application code change — it's an ambient base-image issue that surfaces on any PR that builds a fresh image, since `main`'s last recorded Anchore run predates these CVEs being disclosed/flagged.

## What changed

- `Dockerfile`: added `apt-get upgrade -y` to the builder stage (after `apt-get update`, before `apt-get install`) so already-installed base-image OS packages pick up Debian's published security patches, not just newly-installed packages.

## Scope / non-goals

- No application code, dependency, or test changes.
- Doesn't touch the `.grype.yml` ignore list — the packages here have a real, available fix, so upgrading is preferred over allowlisting.

## Test plan

- CI: `Code Scans / Anchore Scan` should pass on a freshly built image.
- CI: `Code Scans / Trivy Scan` and `Code Scans / Dockle Scan` should be unaffected.
- CI: `Run Tests / Run Unit Tests` should be unaffected (no code changes).
