### PR TITLE
Handle a step section name that has no number

### DIFF
--- a/nofos/nofos/templatetags/nofo_section_name_separator.py
+++ b/nofos/nofos/templatetags/nofo_section_name_separator.py
@@ -14,5 +14,9 @@ def nofo_section_name_separator(section_name):
 
     section_step, section_title, *_ = section_name.split(":")
 
-    section_number = section_step.split(" ")[1]
+    # The part before the colon is not guaranteed to be "Step <n>". A name like
+    # "Steps: Review the Opportunity" passes the checks above but has no space,
+    # so there is no number to take.
+    step_parts = section_step.split(" ")
+    section_number = step_parts[1] if len(step_parts) > 1 else None
     return {"name": section_title, "number": section_number}

--- a/nofos/nofos/tests_nofos/test_templatetags.py
+++ b/nofos/nofos/tests_nofos/test_templatetags.py
@@ -17,6 +17,9 @@ from nofos.templatetags.replace_unicode_with_icon import (
     wrap_td_contents_in_div,
     wrap_text_in_span,
 )
+from nofos.templatetags.nofo_section_name_separator import (
+    nofo_section_name_separator,
+)
 from nofos.templatetags.safe_br import safe_br
 from nofos.templatetags.utils import (
     _add_class_if_not_exists_to_tag,
@@ -1920,3 +1923,48 @@ class WrapTextBeforeColonInStrongTests(TestCase):
 
         expected_html = "<p><strong>Opportunity</strong> Name: NOFO 100</p>"
         self.assertEqual(str(paragraph), expected_html)
+
+
+class NofoSectionNameSeparatorTests(TestCase):
+    def test_step_with_number(self):
+        self.assertEqual(
+            nofo_section_name_separator("Step 1: Review the Opportunity"),
+            {"name": " Review the Opportunity", "number": "1"},
+        )
+
+    def test_step_with_extra_words_takes_first_token(self):
+        self.assertEqual(
+            nofo_section_name_separator("Step 1 of 3: Review"),
+            {"name": " Review", "number": "1"},
+        )
+
+    def test_plural_step_without_a_number(self):
+        # "Steps" starts with "step" and contains a colon, so it reaches the
+        # split, but there is no space and so no number to take.
+        self.assertEqual(
+            nofo_section_name_separator("Steps: Review the Opportunity"),
+            {"name": " Review the Opportunity", "number": None},
+        )
+
+    def test_step_without_a_number(self):
+        self.assertEqual(
+            nofo_section_name_separator("Step: Apply"),
+            {"name": " Apply", "number": None},
+        )
+
+    def test_not_a_step(self):
+        self.assertEqual(
+            nofo_section_name_separator("Other: Contacts"),
+            {"name": "Other: Contacts", "number": None},
+        )
+
+    def test_no_colon(self):
+        self.assertEqual(
+            nofo_section_name_separator("Step 1 Review"),
+            {"name": "Step 1 Review", "number": None},
+        )
+
+    def test_empty_name(self):
+        self.assertEqual(
+            nofo_section_name_separator(""), {"name": "", "number": None}
+        )


### PR DESCRIPTION
`nofo_section_name_separator` guards on the name starting with "step" and containing a colon, then takes the number from the part before the colon:

```python
section_step, section_title, *_ = section_name.split(":")
section_number = section_step.split(" ")[1]
```

Nothing checks that there actually is a space, so a section named `Steps: Review the Opportunity` or `Step: Apply` passes the guard and then raises:

```
File ".../templatetags/nofo_section_name_separator.py", line 17, in nofo_section_name_separator
  section_number = section_step.split(" ")[1]
IndexError: list index out of range
```

That happens inside template rendering, so the page 500s rather than degrading. Section names come from `clean_string(tag.text)` of an imported H1 and are editable in the UI, so this is ordinary content rather than a malformed fixture. The filter is used by `nofo_view.html:262` and by `_side_nav.html`, `composer_section.html` (twice) and `composer_section_edit.html`, so the NOFO view, the side nav and the composer all break for such a section.

Falling back to no number when there is no space:

```
'Step 1: Review'                 -> {'name': ' Review', 'number': '1'}
'Steps: Review the Opportunity'  -> {'name': ' Review the Opportunity', 'number': None}
'Step: Apply'                    -> {'name': ' Apply', 'number': None}
'Step 1 of 3: X'                 -> {'name': ' X', 'number': '1'}
'Other: Contacts'                -> {'name': 'Other: Contacts', 'number': None}
```

I kept `split(" ")` rather than switching to `split(" ", 1)` on purpose, so `Step 1 of 3: X` still gives `1` exactly as it does today instead of `1 of 3`.

The filter had no tests, so this adds seven covering the numbered case, the extra-words case, both no-number shapes, a non-step name, a name with no colon, and the empty string. Two fail without the change with the IndexError above. Suite goes from 202 to 209 passing.
