### PR TITLE
Make the Import NOFO action easier to find

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -751,7 +751,20 @@ label.usa-label {
 }
 
 .nofo_index--header--view {
-  top: 10px;
+  top: 4px;
+  align-items: center;
+}
+
+@media all and (max-width: 39.99em) {
+  .nofo_index--header h1 {
+    width: 100%;
+  }
+
+  .nofo_index--header--view {
+    position: static;
+    justify-content: flex-start;
+    margin-top: 0.75rem;
+  }
 }
 
 .nofo_edit--audit-widget {

--- a/nofos/nofos/templates/nofos/nofo_index.html
+++ b/nofos/nofos/templates/nofos/nofo_index.html
@@ -20,6 +20,7 @@
 		</h1>
 		<div class="nofo_index--header--view font-sans-md">
 			<a class="search-nofos-link" href="{% url 'nofos:nofo_search' %}">Search NOFOs</a>
+			<a class="usa-button margin-0" href="{% url 'nofos:nofo_import' %}">Import NOFO</a>
 		</div>
 	</div>
 

--- a/nofos/nofos/tests_nofos/test_index.py
+++ b/nofos/nofos/tests_nofos/test_index.py
@@ -1,0 +1,27 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+User = get_user_model()
+
+
+class NofoIndexViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="index-test@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client.login(email="index-test@example.com", password="testpass123")
+
+    def test_import_action_appears_at_top_and_bottom_of_page(self):
+        response = self.client.get(reverse("nofos:nofo_index"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f'href="{reverse("nofos:nofo_import")}"',
+            count=2,
+        )
+        self.assertContains(response, "Import NOFO", count=2)


### PR DESCRIPTION
## What changed

- Added an **Import NOFO** button to the page header beside **Search NOFOs**, so it remains visible even when the NOFO list is long.
- Kept the existing import action at the bottom of the page for current users.
- Adjusted the header actions for narrow screens so they move below the page title instead of overlapping it.
- Added regression coverage confirming both import entry points remain available.

## Why

New users often need to import a NOFO first, but the existing action can sit far below the initial viewport when the workspace contains many records.

## Validation

- Focused Django view test passes.
- Black, isort, and repository pre-commit checks pass.
- Ben approved the additive header placement in #784.

## Screenshot

![Import NOFO action in the page header beside Search NOFOs](https://github.com/user-attachments/assets/72d9948b-c4b8-4d97-a70b-7f13b3e83192)

Closes #784
