### PR TITLE
Wrap the clearance modal's pre-decisional notice in a usa-summary-box

### DIFF
--- a/nofos/bloom_nofos/templates/includes/docx_download_button_form.html
+++ b/nofos/bloom_nofos/templates/includes/docx_download_button_form.html
@@ -32,7 +32,11 @@
         {{ modal_heading|default:"Generating Word document…" }}
       </h2>
       {% if modal_notice %}
-        <p class="usa-prose text-italic margin-top-0">{{ modal_notice }}</p>
+        <div class="usa-summary-box margin-top-0 margin-bottom-2" role="region" aria-label="Pre-decisional notice">
+          <div class="usa-summary-box__body">
+            <p class="usa-summary-box__text margin-y-0">{{ modal_notice }}</p>
+          </div>
+        </div>
       {% endif %}
 
       <div class="usa-prose" id="docx-modal-body{{ id_suffix }}">


### PR DESCRIPTION
### Overview
Small visual tweak to the "Download for Clearance" modal: the pre-decisional notice was a plain italicized paragraph. This wraps it in the same `usa-summary-box` component already used for the light-blue status callout on the NOFO edit page, so it's visually consistent with an existing pattern elsewhere in the app rather than introducing a new one-off style.

### What Changed
- `docx_download_button_form.html`: the notice paragraph is now wrapped in a `usa-summary-box` — no new CSS, it's a standard USWDS component already loaded on this page.

### Testing & Validation
- `nofos.tests_nofos.test_policy_language_export` (29 tests) — all pass (existing test only asserts the notice text is present, unaffected by the wrapping markup)
- Manually verified in a local dev environment
