### PR TITLE
Page-break the clearance cover content from the actual NOFO body

### DIFF
--- a/nofos/nofos/templates/nofos/includes/nofo_export_document.html
+++ b/nofos/nofos/templates/nofos/includes/nofo_export_document.html
@@ -6,6 +6,7 @@
       Abbreviated version generated to support review under HHS's NOFO clearance process. Formatting may not fully reflect the original NOFO due to this abbreviated export process; consult the full PDF version for the authoritative content and layout.
     </div>
     {% include "nofos/includes/nofo_export_clearance_summary.html" %}
+    <span class="page-break"></span>
   {% endif %}
   <!-- Render each section with all its subsections -->
   {% for section in nofo.sections.all|dictsort:"order" %}

--- a/nofos/nofos/tests_nofos/test_policy_language_export.py
+++ b/nofos/nofos/tests_nofos/test_policy_language_export.py
@@ -242,6 +242,26 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         self.assertIn("PRE-DECISIONAL", body)
         self.assertIn("NOT THE OFFICIAL SUBMISSION COPY", body)
 
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_flag_on_stripped_export_page_breaks_after_clearance_summary(self):
+        # The watermark/clearance-summary "cover page" content should end on
+        # its own page, separate from the actual NOFO content that follows -
+        # not run directly into the first real section.
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        summary = soup.select_one(".clearance-summary")
+        page_break = summary.find_next_sibling()
+        self.assertEqual(page_break.name, "span")
+        self.assertIn("page-break", page_break.get("class", []))
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_flag_on_plain_export_has_no_cover_page_break(self):
+        # The page break is part of the stripped-export cover content - a
+        # plain export (no cover page at all) shouldn't have one injected.
+        resp = self.client.get(self.export_url)
+        body = resp.content.decode()
+        self.assertNotIn("page-break", body)
+
     # --- The generated page-1 clearance summary -----------------------------
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)


### PR DESCRIPTION
### Overview
The stripped/clearance export's "cover page" content (pre-decisional watermark + generated Clearance Review Summary) was running directly into the first real NOFO section with no separation. This adds a page break right after the summary, using the same mechanism (`<span class="page-break">`, backed by an existing `break-after: page` CSS rule) already used elsewhere in this same template for subsection-level page breaks — no new CSS, no new pattern.

### What Changed
- `nofo_export_document.html`: one `<span class="page-break"></span>` added right after the clearance summary include, only inside the `strip_policy_language` branch (the plain export is unaffected).

### Testing & Validation
- New regression test confirming the page break immediately follows the clearance summary in the stripped export
- New regression test confirming the plain (non-stripped) export has no page break injected
- `nofos.tests_nofos.test_policy_language_export` (31 tests) — all pass
- Manually verified the rendered HTML directly: page break sits between the summary's closing `</div>` and the first `<section>`
