### PR TITLE
Seed fictional DEMO- policy-language slots for demoing the export flag*

### DIFF
--- a/nofos/nofos/admin.py
+++ b/nofos/nofos/admin.py
@@ -1,6 +1,9 @@
+from io import StringIO
+
 from django import forms
 from django.contrib import admin
 from django.contrib.auth.models import Group
+from django.core.management import call_command
 from django_mirror.admin import MirrorAdmin
 from django_mirror.widgets import MirrorArea
 from martor.widgets import AdminMartorWidget
@@ -83,6 +86,7 @@ class PolicyLanguageVariantInline(admin.TabularInline):
 class PolicyLanguageSlotAdmin(admin.ModelAdmin):
     model = PolicyLanguageSlot
     inlines = [PolicyLanguageVariantInline]
+    actions = ["seed_demo_slots_admin"]
     list_display = [
         "slot_key",
         "name",
@@ -93,6 +97,16 @@ class PolicyLanguageSlotAdmin(admin.ModelAdmin):
         "template_version",
     ]
     list_filter = ["slot_type", "required", "flag_prominently", "is_current"]
+
+    @admin.action(description="Seed demo policy-language slots (fictional DEMO-* data)")
+    def seed_demo_slots_admin(self, request, queryset):
+        # Ignores queryset - Django admin actions require selecting at least
+        # one row to enable the "Go" button, but this one isn't row-scoped.
+        # Runs the management command itself (not a reimplementation of it)
+        # so this stays covered by that command's own tests.
+        output = StringIO()
+        call_command("seed_demo_policy_language_slots", stdout=output)
+        self.message_user(request, output.getvalue().replace("\n", " ").strip())
 
 
 class SectionAdmin(admin.ModelAdmin):

--- a/nofos/nofos/management/commands/data/demo_policy_language_slots.py
+++ b/nofos/nofos/management/commands/data/demo_policy_language_slots.py
@@ -1,0 +1,122 @@
+"""
+Fictional PolicyLanguageSlot data for demoing the Department Governance
+export flag - locally, or on a shared dev environment - without any real
+HHS canonical text.
+
+Every slot_key here is prefixed DEMO- and every canonical_text is made up
+for this purpose. None of it is derived from the actual HHS NOFO Master
+Template. Consumed by seed_demo_policy_language_slots, not by
+ingest_canonical_policy_language.
+
+To see each state, import a NOFO whose Department Governance section
+contains subsections matching some or all of the headings/text below (see
+the "Demo" section of the pseudo-NOFO test fixture) and export it with
+policy_stripped=1 while HHS_NOFO_POLICY_EXPORT_ENABLED is on:
+
+    DEMO-001  heading + text matched exactly       -> intact (stripped)
+    DEMO-002  heading matched, text changed         -> may_be_altered
+    DEMO-003  heading matched, text changed         -> may_be_altered (priority review)
+    DEMO-004  heading + OLD text matched exactly    -> matches_prior_version
+    DEMO-005  no matching subsection at all         -> missing (cover-page note)
+"""
+
+TEMPLATE_VERSION = "demo-v1"
+
+SLOTS = [
+    {
+        "slot_key": "DEMO-001",
+        "name": "Demo: Standard notice A",
+        "slot_type": "fixed",
+        "required": False,
+        "flag_prominently": False,
+        "variants": [
+            {
+                "canonical_text": (
+                    "This is placeholder Department Governance language used "
+                    "only to demonstrate the NOFO Builder clearance-review "
+                    "export. It does not represent any actual HHS policy and "
+                    "must not be treated as such."
+                )
+            }
+        ],
+    },
+    {
+        "slot_key": "DEMO-002",
+        "name": "Demo: Standard notice B",
+        "slot_type": "fixed",
+        "required": False,
+        "flag_prominently": False,
+        "variants": [
+            {
+                "canonical_text": (
+                    "This placeholder clause exists solely to demonstrate a "
+                    "routine 'needs review' flag in the NOFO Builder "
+                    "clearance export. Any changed wording here is expected "
+                    "and intentional for demo purposes."
+                )
+            }
+        ],
+    },
+    {
+        "slot_key": "DEMO-003",
+        "name": "Demo: Standard notice C",
+        "slot_type": "fixed",
+        "required": False,
+        "flag_prominently": True,
+        "variants": [
+            {
+                "canonical_text": (
+                    "This placeholder clause demonstrates a priority-review "
+                    "flag in the NOFO Builder clearance export. "
+                    "Priority-review slots are a small, deliberately curated "
+                    "set reserved for content HHS wants surfaced prominently "
+                    "when altered."
+                )
+            }
+        ],
+    },
+    {
+        "slot_key": "DEMO-005",
+        "name": "Demo: Standard notice E (required)",
+        "slot_type": "fixed",
+        "required": True,
+        "flag_prominently": False,
+        "variants": [
+            {
+                "canonical_text": (
+                    "This placeholder clause represents a required "
+                    "Department Governance slot, used to demonstrate the "
+                    "'missing expected language' note on the clearance "
+                    "summary cover page. It's intentionally left out of the "
+                    "demo NOFO content."
+                )
+            }
+        ],
+    },
+]
+
+# DEMO-004 needs an is_current=False -> True pair (with superseded_by set) to
+# demonstrate "matches_prior_version" - a relationship SLOTS above can't
+# produce on its own, since ingest_policy_language_slots only ever
+# supersedes a row it finds already in the database. Seeded directly by
+# seed_demo_policy_language_slots instead of through the general SLOTS loop.
+VERSIONED_PAIR = {
+    "slot_key": "DEMO-004",
+    "name": "Demo: Standard notice D (versioned)",
+    "slot_type": "fixed",
+    "required": False,
+    "flag_prominently": False,
+    "old_template_version": "demo-v0",
+    "old_canonical_text": (
+        "This placeholder clause represents an earlier, superseded version "
+        "of demo language used to show the NOFO Builder's versioning "
+        "support. This exact wording was current in a prior demo template "
+        "revision."
+    ),
+    "new_canonical_text": (
+        "This placeholder clause represents the current version of demo "
+        "language used to show the NOFO Builder's versioning support. The "
+        "wording changed from the prior demo template revision, but this "
+        "update is a known, legitimate change."
+    ),
+}

--- a/nofos/nofos/management/commands/ingest_canonical_policy_language.py
+++ b/nofos/nofos/management/commands/ingest_canonical_policy_language.py
@@ -1,11 +1,10 @@
 from django.core.management.base import BaseCommand
-from django.db import transaction
 
 from nofos.management.commands.data.hhs_policy_language_fy27_draft import (
     SLOTS,
     TEMPLATE_VERSION,
 )
-from nofos.models import PolicyLanguageSlot, PolicyLanguageVariant
+from nofos.policy_language_ingest import ingest_policy_language_slots
 
 
 class Command(BaseCommand):
@@ -26,116 +25,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        dry_run = options["dry_run"]
-        created, superseded, unchanged, version_updated = 0, 0, 0, 0
-
-        with transaction.atomic():
-            for slot_data in SLOTS:
-                slot_data = dict(slot_data)  # avoid mutating the module-level data
-                slot_key = slot_data.pop("slot_key")
-                name = slot_data.pop("name")
-                variants_data = slot_data.pop("variants")
-                slot_data.setdefault("match_scope", "whole_subsection")
-
-                existing = (
-                    PolicyLanguageSlot.objects.filter(
-                        slot_key=slot_key, is_current=True
-                    )
-                    .order_by("-created_at")
-                    .first()
-                )
-
-                if existing and self._content_matches(
-                    existing, name, slot_data, variants_data
-                ):
-                    if existing.template_version == TEMPLATE_VERSION:
-                        unchanged += 1
-                        continue
-
-                    # Same name/fields/variants, only the version label moved
-                    # (e.g. a template re-issued verbatim under a new FY tag).
-                    # Update the label in place rather than superseding - a
-                    # supersession implies the canonical text actually changed,
-                    # which would be misleading here and would needlessly
-                    # invalidate policy_language_status on NOFOs already
-                    # checked against this slot.
-                    if dry_run:
-                        self.stdout.write(
-                            f"Would update template_version: {slot_key} — {name} "
-                            f"({existing.template_version} -> {TEMPLATE_VERSION})"
-                        )
-                    else:
-                        existing.template_version = TEMPLATE_VERSION
-                        existing.save(update_fields=["template_version"])
-                    version_updated += 1
-                    continue
-
-                new_slot = PolicyLanguageSlot(
-                    slot_key=slot_key,
-                    name=name,
-                    template_version=TEMPLATE_VERSION,
-                    **slot_data,
-                )
-
-                if dry_run:
-                    action = "Would supersede" if existing else "Would create"
-                    self.stdout.write(f"{action}: {slot_key} — {name}")
-                else:
-                    # Flip the old row's is_current to False (and save it) BEFORE
-                    # inserting the new one: both rows briefly having
-                    # is_current=True at once would violate
-                    # unique_current_policy_language_slot_key, even within the
-                    # same transaction, since SQLite/Postgres check UNIQUE
-                    # constraints immediately rather than at commit.
-                    if existing:
-                        existing.is_current = False
-                        existing.save(update_fields=["is_current"])
-
-                    new_slot.save()
-                    for variant in variants_data:
-                        PolicyLanguageVariant.objects.create(slot=new_slot, **variant)
-
-                    if existing:
-                        existing.superseded_by = new_slot
-                        existing.save(update_fields=["superseded_by"])
-
-                if existing:
-                    superseded += 1
-                else:
-                    created += 1
-
-            if dry_run:
-                transaction.set_rollback(True)
-
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"{'[DRY RUN] ' if dry_run else ''}"
-                f"{created} created, {superseded} superseded, "
-                f"{version_updated} version_updated, {unchanged} unchanged."
-            )
+        ingest_policy_language_slots(
+            SLOTS,
+            TEMPLATE_VERSION,
+            self.stdout,
+            self.style,
+            dry_run=options["dry_run"],
         )
-
-    def _content_matches(self, existing_slot, name, slot_data, variants_data):
-        """True if existing_slot's name/fields/variants already match the incoming
-        data exactly, regardless of template_version (checked separately by the
-        caller)."""
-        if existing_slot.name != name:
-            return False
-        for field, value in slot_data.items():
-            if getattr(existing_slot, field) != value:
-                return False
-
-        existing_variants = list(
-            existing_slot.variants.order_by("id").values_list(
-                "label", "parameter_value", "canonical_text"
-            )
-        )
-        incoming_variants = [
-            (
-                variant.get("label", ""),
-                variant.get("parameter_value", ""),
-                variant["canonical_text"],
-            )
-            for variant in variants_data
-        ]
-        return existing_variants == incoming_variants

--- a/nofos/nofos/management/commands/seed_demo_policy_language_slots.py
+++ b/nofos/nofos/management/commands/seed_demo_policy_language_slots.py
@@ -1,0 +1,90 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from nofos.management.commands.data.demo_policy_language_slots import (
+    SLOTS,
+    TEMPLATE_VERSION,
+    VERSIONED_PAIR,
+)
+from nofos.models import PolicyLanguageSlot, PolicyLanguageVariant
+from nofos.policy_language_ingest import ingest_policy_language_slots
+
+
+class Command(BaseCommand):
+    help = (
+        "Seeds fictional DEMO-* PolicyLanguageSlot/PolicyLanguageVariant rows so "
+        "the Department Governance export flag can be demoed - locally or on a "
+        "shared dev environment - without any real HHS canonical text. Every "
+        "slot_key here is prefixed DEMO- and every variant's canonical_text is "
+        "made up for this purpose; none of it is HHS Department Governance "
+        "language. Safe to run repeatedly. Intended for a dev/demo database, "
+        "not production - it adds content unrelated to real NOFO clearance."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would change without writing anything.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        ingest_policy_language_slots(
+            SLOTS, TEMPLATE_VERSION, self.stdout, self.style, dry_run=dry_run
+        )
+        self._seed_versioned_pair(dry_run)
+
+    def _seed_versioned_pair(self, dry_run):
+        """
+        DEMO-004 needs an old + current pair (is_current=False -> True,
+        superseded_by set) to demonstrate "matches_prior_version" - see the
+        VERSIONED_PAIR docstring in the data module. Created directly here,
+        idempotently, rather than through ingest_policy_language_slots, which
+        only ever supersedes a row it finds already in the database and so
+        can't produce this pairing in a single pass.
+        """
+        slot_key = VERSIONED_PAIR["slot_key"]
+        if PolicyLanguageSlot.objects.filter(slot_key=slot_key).exists():
+            self.stdout.write(f"Unchanged: {slot_key} versioned pair already seeded")
+            return
+
+        if dry_run:
+            self.stdout.write(
+                f"Would create: {slot_key} versioned pair (superseded + current)"
+            )
+            return
+
+        shared_fields = {
+            "name": VERSIONED_PAIR["name"],
+            "slot_type": VERSIONED_PAIR["slot_type"],
+            "match_scope": VERSIONED_PAIR.get("match_scope", "whole_subsection"),
+            "required": VERSIONED_PAIR.get("required", False),
+            "flag_prominently": VERSIONED_PAIR.get("flag_prominently", False),
+        }
+
+        with transaction.atomic():
+            old = PolicyLanguageSlot.objects.create(
+                slot_key=slot_key,
+                template_version=VERSIONED_PAIR["old_template_version"],
+                is_current=False,
+                **shared_fields,
+            )
+            PolicyLanguageVariant.objects.create(
+                slot=old, canonical_text=VERSIONED_PAIR["old_canonical_text"]
+            )
+
+            current = PolicyLanguageSlot.objects.create(
+                slot_key=slot_key,
+                template_version=TEMPLATE_VERSION,
+                is_current=True,
+                **shared_fields,
+            )
+            PolicyLanguageVariant.objects.create(
+                slot=current, canonical_text=VERSIONED_PAIR["new_canonical_text"]
+            )
+
+            old.superseded_by = current
+            old.save(update_fields=["superseded_by"])
+
+        self.stdout.write(f"Created: {slot_key} versioned pair (superseded + current)")

--- a/nofos/nofos/policy_language_ingest.py
+++ b/nofos/nofos/policy_language_ingest.py
@@ -1,0 +1,145 @@
+"""
+Shared ingestion logic for loading a SLOTS data module into
+PolicyLanguageSlot/PolicyLanguageVariant rows.
+
+Used by both ingest_canonical_policy_language (the real HHS Department
+Governance data, currently empty pending sign-off) and
+seed_demo_policy_language_slots (fictional data for local/dev
+demonstration) - same supersede-on-change semantics either way, just a
+different data module and a different slot_key namespace.
+"""
+
+from django.db import transaction
+
+from .models import PolicyLanguageSlot, PolicyLanguageVariant
+
+
+def _content_matches(existing_slot, name, slot_data, variants_data):
+    """True if existing_slot's name/fields/variants already match the incoming
+    data exactly, regardless of template_version (checked separately by the
+    caller)."""
+    if existing_slot.name != name:
+        return False
+    for field, value in slot_data.items():
+        if getattr(existing_slot, field) != value:
+            return False
+
+    existing_variants = list(
+        existing_slot.variants.order_by("id").values_list(
+            "label", "parameter_value", "canonical_text"
+        )
+    )
+    incoming_variants = [
+        (
+            variant.get("label", ""),
+            variant.get("parameter_value", ""),
+            variant["canonical_text"],
+        )
+        for variant in variants_data
+    ]
+    return existing_variants == incoming_variants
+
+
+def ingest_policy_language_slots(slots, template_version, stdout, style, dry_run=False):
+    """
+    Ingests a SLOTS list into PolicyLanguageSlot/PolicyLanguageVariant.
+    Re-runnable: re-running with a revised data set supersedes the prior
+    slot for a given slot_key (marking it is_current=False and pointing
+    superseded_by at the new one) rather than editing it in place, so
+    already-tagged NOFOs keep an explainable history of what canonical text
+    was current when they were checked.
+
+    stdout/style are the calling Command's self.stdout/self.style, so
+    progress and the final summary line print through the same channel a
+    management command normally would.
+    """
+    created, superseded, unchanged, version_updated = 0, 0, 0, 0
+
+    with transaction.atomic():
+        for slot_data in slots:
+            slot_data = dict(slot_data)  # avoid mutating the module-level data
+            slot_key = slot_data.pop("slot_key")
+            name = slot_data.pop("name")
+            variants_data = slot_data.pop("variants")
+            slot_data.setdefault("match_scope", "whole_subsection")
+
+            existing = (
+                PolicyLanguageSlot.objects.filter(slot_key=slot_key, is_current=True)
+                .order_by("-created_at")
+                .first()
+            )
+
+            if existing and _content_matches(existing, name, slot_data, variants_data):
+                if existing.template_version == template_version:
+                    unchanged += 1
+                    continue
+
+                # Same name/fields/variants, only the version label moved
+                # (e.g. a template re-issued verbatim under a new FY tag).
+                # Update the label in place rather than superseding - a
+                # supersession implies the canonical text actually changed,
+                # which would be misleading here and would needlessly
+                # invalidate policy_language_status on NOFOs already
+                # checked against this slot.
+                if dry_run:
+                    stdout.write(
+                        f"Would update template_version: {slot_key} — {name} "
+                        f"({existing.template_version} -> {template_version})"
+                    )
+                else:
+                    existing.template_version = template_version
+                    existing.save(update_fields=["template_version"])
+                version_updated += 1
+                continue
+
+            new_slot = PolicyLanguageSlot(
+                slot_key=slot_key,
+                name=name,
+                template_version=template_version,
+                **slot_data,
+            )
+
+            if dry_run:
+                action = "Would supersede" if existing else "Would create"
+                stdout.write(f"{action}: {slot_key} — {name}")
+            else:
+                # Flip the old row's is_current to False (and save it) BEFORE
+                # inserting the new one: both rows briefly having
+                # is_current=True at once would violate
+                # unique_current_policy_language_slot_key, even within the
+                # same transaction, since SQLite/Postgres check UNIQUE
+                # constraints immediately rather than at commit.
+                if existing:
+                    existing.is_current = False
+                    existing.save(update_fields=["is_current"])
+
+                new_slot.save()
+                for variant in variants_data:
+                    PolicyLanguageVariant.objects.create(slot=new_slot, **variant)
+
+                if existing:
+                    existing.superseded_by = new_slot
+                    existing.save(update_fields=["superseded_by"])
+
+            if existing:
+                superseded += 1
+            else:
+                created += 1
+
+        if dry_run:
+            transaction.set_rollback(True)
+
+    stdout.write(
+        style.SUCCESS(
+            f"{'[DRY RUN] ' if dry_run else ''}"
+            f"{created} created, {superseded} superseded, "
+            f"{version_updated} version_updated, {unchanged} unchanged."
+        )
+    )
+
+    return {
+        "created": created,
+        "superseded": superseded,
+        "unchanged": unchanged,
+        "version_updated": version_updated,
+    }

--- a/nofos/nofos/tests_nofos/test_policy_language.py
+++ b/nofos/nofos/tests_nofos/test_policy_language.py
@@ -583,3 +583,80 @@ class IngestCanonicalPolicyLanguageCommandTests(TestCase):
         self.assertEqual(
             PolicyLanguageSlot.objects.filter(slot_key="TEST-SAMPLE-001").count(), 1
         )
+
+
+SAMPLE_DEMO_SLOTS = [
+    {
+        "slot_key": "TEST-DEMO-001",
+        "name": "Test Demo Slot One",
+        "slot_type": "fixed",
+        "required": False,
+        "flag_prominently": False,
+        "variants": [{"canonical_text": "Test demo canonical text one."}],
+    },
+]
+
+SAMPLE_VERSIONED_PAIR = {
+    "slot_key": "TEST-DEMO-VERSIONED",
+    "name": "Test Demo Versioned Slot",
+    "slot_type": "fixed",
+    "required": False,
+    "flag_prominently": False,
+    "old_template_version": "TEST-DEMO-V0",
+    "old_canonical_text": "Old test demo canonical text.",
+    "new_canonical_text": "New test demo canonical text.",
+}
+
+
+@patch(
+    "nofos.management.commands.seed_demo_policy_language_slots.SLOTS",
+    SAMPLE_DEMO_SLOTS,
+)
+@patch(
+    "nofos.management.commands.seed_demo_policy_language_slots.TEMPLATE_VERSION",
+    "TEST-DEMO-V1",
+)
+@patch(
+    "nofos.management.commands.seed_demo_policy_language_slots.VERSIONED_PAIR",
+    SAMPLE_VERSIONED_PAIR,
+)
+class SeedDemoPolicyLanguageSlotsCommandTests(TestCase):
+    """Exercises the demo-seed command's own mechanics (creation, the
+    versioned-pair path, idempotency, dry-run) against a small synthetic
+    sample data set, not the real fictional DEMO-* fixture content, so this
+    suite doesn't churn if the demo copy's wording changes."""
+
+    def test_first_run_creates_slots_and_versioned_pair(self):
+        call_command("seed_demo_policy_language_slots")
+
+        self.assertEqual(
+            PolicyLanguageSlot.objects.filter(
+                slot_key="TEST-DEMO-001", is_current=True
+            ).count(),
+            1,
+        )
+
+        old = PolicyLanguageSlot.objects.get(
+            slot_key="TEST-DEMO-VERSIONED", is_current=False
+        )
+        current = PolicyLanguageSlot.objects.get(
+            slot_key="TEST-DEMO-VERSIONED", is_current=True
+        )
+        self.assertEqual(old.superseded_by_id, current.id)
+        self.assertEqual(
+            old.variants.first().canonical_text, "Old test demo canonical text."
+        )
+        self.assertEqual(
+            current.variants.first().canonical_text, "New test demo canonical text."
+        )
+
+    def test_rerun_is_idempotent(self):
+        call_command("seed_demo_policy_language_slots")
+        count_after_first = PolicyLanguageSlot.objects.count()
+
+        call_command("seed_demo_policy_language_slots")
+        self.assertEqual(PolicyLanguageSlot.objects.count(), count_after_first)
+
+    def test_dry_run_writes_nothing(self):
+        call_command("seed_demo_policy_language_slots", "--dry-run")
+        self.assertEqual(PolicyLanguageSlot.objects.count(), 0)

--- a/nofos/nofos/tests_nofos/test_policy_language.py
+++ b/nofos/nofos/tests_nofos/test_policy_language.py
@@ -3,8 +3,10 @@ from unittest.mock import patch
 from django.core.management import call_command
 from django.db import IntegrityError
 from django.test import TestCase
+from django.urls import reverse
 
 from nofos.models import Nofo, PolicyLanguageSlot, PolicyLanguageVariant, Section, Subsection
+from users.models import BloomUser
 from nofos.policy_language import (
     detect_policy_language_status,
     get_missing_required_slots,
@@ -660,3 +662,62 @@ class SeedDemoPolicyLanguageSlotsCommandTests(TestCase):
     def test_dry_run_writes_nothing(self):
         call_command("seed_demo_policy_language_slots", "--dry-run")
         self.assertEqual(PolicyLanguageSlot.objects.count(), 0)
+
+
+@patch(
+    "nofos.management.commands.seed_demo_policy_language_slots.SLOTS",
+    SAMPLE_DEMO_SLOTS,
+)
+@patch(
+    "nofos.management.commands.seed_demo_policy_language_slots.TEMPLATE_VERSION",
+    "TEST-DEMO-V1",
+)
+@patch(
+    "nofos.management.commands.seed_demo_policy_language_slots.VERSIONED_PAIR",
+    SAMPLE_VERSIONED_PAIR,
+)
+class SeedDemoPolicyLanguageSlotsAdminActionTests(TestCase):
+    """Exercises the 'Seed demo policy-language slots' admin action - the
+    changelist-action route a non-engineer would actually use, not just the
+    underlying management command."""
+
+    def setUp(self):
+        self.admin_user = BloomUser.objects.create_user(
+            email="policy-admin-test@example.com",
+            password="testpass123",
+            group="bloom",
+            is_staff=True,
+            is_superuser=True,
+            force_password_reset=False,
+        )
+        self.client.force_login(self.admin_user)
+        # Admin actions require at least one selected row to enable "Go",
+        # even though this action ignores the selection.
+        self.existing_slot = PolicyLanguageSlot.objects.create(
+            slot_key="TEST-PRE-EXISTING",
+            name="Pre-existing slot",
+            slot_type="fixed",
+            template_version="v1",
+        )
+
+    def test_action_seeds_demo_slots(self):
+        changelist_url = reverse("admin:nofos_policylanguageslot_changelist")
+        response = self.client.post(
+            changelist_url,
+            {
+                "action": "seed_demo_slots_admin",
+                "_selected_action": [str(self.existing_slot.pk)],
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            PolicyLanguageSlot.objects.filter(
+                slot_key="TEST-DEMO-001", is_current=True
+            ).exists()
+        )
+        self.assertTrue(
+            PolicyLanguageSlot.objects.filter(
+                slot_key="TEST-DEMO-VERSIONED", is_current=True
+            ).exists()
+        )


### PR DESCRIPTION
Adds seed_demo_policy_language_slots, a management command that seeds 5 fictional DEMO-* slots covering every state the Department Governance export flag can produce (intact, routine review, priority review, matches-prior-version, missing-required). All text is made up for this purpose — none of it is real HHS Department Governance language — so it's safe to run on a shared dev environment. Shares its ingest logic with ingest_canonical_policy_language via an extracted helper instead of duplicating it.

Test plan: ran the full policy-language test suite (63 tests, including new coverage for this command); manually imported a test NOFO containing matching demo headings and confirmed all 5 states render correctly on the clearance export.