### PR TITLE
Replace the demo-seed admin action with a changelist button

### DIFF
--- a/nofos/nofos/admin.py
+++ b/nofos/nofos/admin.py
@@ -1,15 +1,16 @@
-from io import StringIO
-
 from django import forms
 from django.contrib import admin
 from django.contrib.auth.models import Group
-from django.core.management import call_command
 from django_mirror.admin import MirrorAdmin
 from django_mirror.widgets import MirrorArea
 from martor.widgets import AdminMartorWidget
 
 from .models import Nofo, PolicyLanguageSlot, PolicyLanguageVariant, Section, Subsection
-from .views import duplicate_nofo, insert_order_space_view
+from .views import (
+    duplicate_nofo,
+    insert_order_space_view,
+    seed_demo_policy_language_slots_view,
+)
 
 # Remove Groups from admin
 admin.site.unregister(Group)
@@ -86,7 +87,7 @@ class PolicyLanguageVariantInline(admin.TabularInline):
 class PolicyLanguageSlotAdmin(admin.ModelAdmin):
     model = PolicyLanguageSlot
     inlines = [PolicyLanguageVariantInline]
-    actions = ["seed_demo_slots_admin"]
+    change_list_template = "admin/nofos/policylanguageslot/change_list.html"
     list_display = [
         "slot_key",
         "name",
@@ -98,15 +99,18 @@ class PolicyLanguageSlotAdmin(admin.ModelAdmin):
     ]
     list_filter = ["slot_type", "required", "flag_prominently", "is_current"]
 
-    @admin.action(description="Seed demo policy-language slots (fictional DEMO-* data)")
-    def seed_demo_slots_admin(self, request, queryset):
-        # Ignores queryset - Django admin actions require selecting at least
-        # one row to enable the "Go" button, but this one isn't row-scoped.
-        # Runs the management command itself (not a reimplementation of it)
-        # so this stays covered by that command's own tests.
-        output = StringIO()
-        call_command("seed_demo_policy_language_slots", stdout=output)
-        self.message_user(request, output.getvalue().replace("\n", " ").strip())
+    def get_urls(self):
+        from django.urls import path
+
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "seed-demo/",
+                self.admin_site.admin_view(seed_demo_policy_language_slots_view),
+                name="nofos_policylanguageslot_seed_demo",
+            ),
+        ]
+        return custom_urls + urls
 
 
 class SectionAdmin(admin.ModelAdmin):

--- a/nofos/nofos/templates/admin/nofos/policylanguageslot/change_list.html
+++ b/nofos/nofos/templates/admin/nofos/policylanguageslot/change_list.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools-items %}
+  <li>
+    <form method="post" action="{% url 'admin:nofos_policylanguageslot_seed_demo' %}">
+      {% csrf_token %}
+      <button type="submit" class="button">
+        Seed demo policy-language slots
+      </button>
+    </form>
+  </li>
+  {{ block.super }}
+{% endblock %}

--- a/nofos/nofos/tests_nofos/test_policy_language.py
+++ b/nofos/nofos/tests_nofos/test_policy_language.py
@@ -676,10 +676,11 @@ class SeedDemoPolicyLanguageSlotsCommandTests(TestCase):
     "nofos.management.commands.seed_demo_policy_language_slots.VERSIONED_PAIR",
     SAMPLE_VERSIONED_PAIR,
 )
-class SeedDemoPolicyLanguageSlotsAdminActionTests(TestCase):
-    """Exercises the 'Seed demo policy-language slots' admin action - the
-    changelist-action route a non-engineer would actually use, not just the
-    underlying management command."""
+class SeedDemoPolicyLanguageSlotsAdminButtonTests(TestCase):
+    """Exercises the 'Seed demo policy-language slots' changelist button - a
+    dedicated view rather than a Django admin bulk action, since a bulk
+    action can't run without an existing row selected, which is exactly the
+    state this table starts in (see test_button_works_on_empty_table)."""
 
     def setUp(self):
         self.admin_user = BloomUser.objects.create_user(
@@ -691,25 +692,13 @@ class SeedDemoPolicyLanguageSlotsAdminActionTests(TestCase):
             force_password_reset=False,
         )
         self.client.force_login(self.admin_user)
-        # Admin actions require at least one selected row to enable "Go",
-        # even though this action ignores the selection.
-        self.existing_slot = PolicyLanguageSlot.objects.create(
-            slot_key="TEST-PRE-EXISTING",
-            name="Pre-existing slot",
-            slot_type="fixed",
-            template_version="v1",
-        )
+        self.seed_url = reverse("admin:nofos_policylanguageslot_seed_demo")
 
-    def test_action_seeds_demo_slots(self):
-        changelist_url = reverse("admin:nofos_policylanguageslot_changelist")
-        response = self.client.post(
-            changelist_url,
-            {
-                "action": "seed_demo_slots_admin",
-                "_selected_action": [str(self.existing_slot.pk)],
-            },
-            follow=True,
-        )
+    def test_button_works_on_empty_table(self):
+        self.assertEqual(PolicyLanguageSlot.objects.count(), 0)
+
+        response = self.client.post(self.seed_url, follow=True)
+
         self.assertEqual(response.status_code, 200)
         self.assertTrue(
             PolicyLanguageSlot.objects.filter(
@@ -721,3 +710,19 @@ class SeedDemoPolicyLanguageSlotsAdminActionTests(TestCase):
                 slot_key="TEST-DEMO-VERSIONED", is_current=True
             ).exists()
         )
+
+    def test_changelist_shows_button_on_empty_table(self):
+        changelist_url = reverse("admin:nofos_policylanguageslot_changelist")
+        response = self.client.get(changelist_url)
+        self.assertContains(response, self.seed_url)
+
+    def test_get_is_rejected(self):
+        response = self.client.get(self.seed_url)
+        self.assertEqual(response.status_code, 405)
+        self.assertEqual(PolicyLanguageSlot.objects.count(), 0)
+
+    def test_anonymous_user_is_redirected_to_login(self):
+        self.client.logout()
+        response = self.client.post(self.seed_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(PolicyLanguageSlot.objects.count(), 0)

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -20,6 +20,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.management import call_command
 from django.db import transaction
 from django.db.models import Q, prefetch_related_objects
 from django.forms.models import model_to_dict
@@ -29,6 +30,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils import dateformat, dateparse, timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.views.decorators.http import require_POST
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -231,6 +233,20 @@ def insert_order_space_view(request, section_id):
 
     context = {"form": form, "title": "Insert Order Space", "section": section}
     return render(request, "admin/insert_order_space.html", context)
+
+
+@staff_member_required
+@require_POST
+def seed_demo_policy_language_slots_view(request):
+    # A changelist button rather than a Django admin bulk action: bulk
+    # actions require selecting an existing row, which is exactly what's
+    # unavailable the first time this runs against an empty table. Runs the
+    # management command itself (not a reimplementation of it) so this
+    # stays covered by that command's own tests.
+    output = io.StringIO()
+    call_command("seed_demo_policy_language_slots", stdout=output)
+    messages.success(request, output.getvalue().replace("\n", " ").strip())
+    return redirect("admin:nofos_policylanguageslot_changelist")
 
 
 ###########################################################


### PR DESCRIPTION
A Django admin bulk action requires selecting an existing row before it can run — exactly what's unavailable the first time the PolicyLanguageSlot table is used, since it starts empty. Swaps the "Seed demo policy-language slots" bulk action (added in [#827](https://github.com/benbrasso/simpler-grants-pdf-builder/issues/827)) for a dedicated button next to "Add policy language slot," backed by a small POST-only view, so it works regardless of row count.

Test plan: added a regression test asserting the button works against an empty table; full policy-language suite passes (69 tests).