### PR TITLE
Drop the clearance summary's non-working section links

### DIFF
--- a/nofos/nofos/templates/nofos/includes/nofo_export_clearance_summary.html
+++ b/nofos/nofos/templates/nofos/includes/nofo_export_clearance_summary.html
@@ -1,4 +1,3 @@
-{% load truncate_anchor_links_for_docx %}
 <div class="clearance-summary">
   <h2>Clearance Review Summary (Generated)</h2>
   <p class="text-italic">
@@ -45,11 +44,11 @@
     {% if clearance_summary.flagged %}
       <li>
         {{ clearance_summary.flagged|length }} section{{ clearance_summary.flagged|length|pluralize }}
-        flagged below for review:
+        flagged for review (see the flag noted inline at each section below):
         <ul>
           {% for subsection in clearance_summary.flagged %}
             <li>
-              <a href="#{{ subsection.html_id|truncate_heading_ids_for_docx }}">{{ subsection.name }}</a>
+              {{ subsection.name }}
               — {{ subsection.get_policy_language_status_display }}
               {% if subsection.policy_language_slot.flag_prominently %}(priority review){% endif %}
             </li>

--- a/nofos/nofos/tests_nofos/test_policy_language_export.py
+++ b/nofos/nofos/tests_nofos/test_policy_language_export.py
@@ -281,7 +281,7 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         self.assertIn(
             "1 section matched current HHS Department Governance language", summary_text
         )
-        self.assertIn("2 sections flagged below for review", summary_text)
+        self.assertIn("2 sections flagged for review", summary_text)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_clearance_summary_lists_missing_required_slots(self):
@@ -290,16 +290,19 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         self.assertIn("Missing expected Department Governance language", body)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
-    def test_clearance_summary_anchor_links_resolve_to_real_elements(self):
+    def test_clearance_summary_flagged_entries_are_plain_text_not_links(self):
+        # GrabzIt's HTML->DOCX conversion doesn't turn a same-document
+        # #anchor link into a working "jump to bookmark" link in Word - it
+        # was landing readers somewhere unrelated instead. The flag is
+        # still visible inline at the actual section (see
+        # test_flag_on_stripped_export_flags_altered_sections), so the
+        # summary just names it rather than offering a link that doesn't
+        # work in the exported document.
         resp = self.client.get(self.export_url + "?policy_stripped=1")
         soup = BeautifulSoup(resp.content, "html.parser")
-        links = soup.select(".clearance-summary a")
-        self.assertTrue(links)
-        for link in links:
-            target_id = link["href"].lstrip("#")
-            self.assertIsNotNone(
-                soup.find(id=target_id), f"anchor target #{target_id} not found"
-            )
+        self.assertFalse(soup.select(".clearance-summary a"))
+        summary_text = soup.select_one(".clearance-summary").get_text(" ", strip=True)
+        self.assertIn(self.altered_slot.name, summary_text)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_clearance_summary_includes_readability_metrics_when_available(self):


### PR DESCRIPTION
GrabzIt's HTML→DOCX conversion doesn't turn a same-document #anchor link into a working "jump to bookmark" link in the exported Word file — it landed the reader somewhere unrelated instead. The flag itself is still shown inline at the actual section, so the summary now just lists flagged section names/statuses as plain text instead of offering a link that doesn't work once exported.

Test plan: full policy-language suite passes (69 tests), including a new test asserting the summary contains no links.