### PR TITLE
Polish the clearance export's cover page and inline flags

### DIFF
--- a/nofos/bloom_nofos/static/theme-export.css
+++ b/nofos/bloom_nofos/static/theme-export.css
@@ -213,12 +213,16 @@ span.page-break {
 
 /* Policy-language export (prototype) */
 
-.nofo_view .policy-export-watermark {
+/* A table+td, not a plain div/p with background/border - GrabzIt's
+   HTML->DOCX conversion drops background-color and border on block
+   elements like div/p entirely, but preserves them reliably on table
+   cells (same reason the callout-box content above uses a table). Padding
+   on the td keeps the text off the border, per design. */
+.nofo_view .policy-export-watermark td {
   border: 2px solid #b50909;
   background-color: #fdf2f2;
   color: #5c1414;
   padding: 12px 16px;
-  margin-bottom: 24px;
   font-size: 12px;
   line-height: 1.4;
 }
@@ -248,6 +252,24 @@ span.page-break {
   color: #5c1414;
 }
 
+/* The inline flag shown at the actual flagged section (as opposed to
+   .policy-language-flag-note above, which styles the summary's own
+   missing-slots bullet) - a table+td for the same GrabzIt reason as the
+   watermark above. */
+.nofo_view .policy-language-flag-box td {
+  border: 1px solid #ffbe2e;
+  background-color: #faf3d1;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.nofo_view .policy-language-flag-box--priority td {
+  border-color: #b50909;
+  background-color: #fdf2f2;
+  color: #5c1414;
+}
+
 .nofo_view .clearance-summary {
   border: 1px solid #a9aeb1;
   background-color: #f0f0f0;
@@ -255,15 +277,16 @@ span.page-break {
   margin-bottom: 24px;
 }
 
-.nofo_view .clearance-summary h2,
+.nofo_view .clearance-summary h2 {
+  margin-top: 0;
+  margin-bottom: 6px;
+  font-size: 28pt;
+}
+
 .nofo_view .clearance-summary h3 {
   margin-top: 12px;
   margin-bottom: 6px;
-  font-size: 16pt;
-}
-
-.nofo_view .clearance-summary h2 {
-  margin-top: 0;
+  font-size: 22pt;
 }
 
 .nofo_view .clearance-summary-table {

--- a/nofos/bloom_nofos/static/theme-export.css
+++ b/nofos/bloom_nofos/static/theme-export.css
@@ -242,7 +242,7 @@ span.page-break {
   background-color: #faf3d1;
   padding: 8px 12px;
   margin-bottom: 8px;
-  font-size: 12px;
+  font-size: 12pt;
   font-weight: 700;
 }
 

--- a/nofos/nofos/templates/nofos/includes/nofo_export_clearance_summary.html
+++ b/nofos/nofos/templates/nofos/includes/nofo_export_clearance_summary.html
@@ -1,12 +1,17 @@
 <div class="clearance-summary">
-  <h2>Clearance Review Summary (Generated)</h2>
+  <h2>Clearance Review Summary</h2>
   <p class="text-italic">
     Generated from NOFO Builder's current revision, last updated
-    {{ nofo.updated|date:"N j, Y, g:i a" }}. This is a NOFO Builder-generated aid
+    {{ nofo.updated|date:"N j, Y, g:i a" }} This is a NOFO Builder-generated aid
     for this review pass, not a substitute for the official NOFO Summary
     Template still required as part of the Departmental/OMB clearance
     submission.
   </p>
+
+  <h3>{{ nofo.title }}</h3>
+  <p>Opdiv: {{ nofo.opdiv }}</p>
+  {% if nofo.agency %}<p>Agency: {{ nofo.agency }}</p>{% endif %}
+  {% if nofo.number %}<p>Opportunity number: {{ nofo.number }}</p>{% endif %}
 
   {% if clearance_metrics %}
     <h3>Readability metrics</h3>

--- a/nofos/nofos/templates/nofos/includes/nofo_export_clearance_summary.html
+++ b/nofos/nofos/templates/nofos/includes/nofo_export_clearance_summary.html
@@ -1,8 +1,9 @@
+{% load tz %}
 <div class="clearance-summary">
   <h2>Clearance Review Summary</h2>
   <p class="text-italic">
     Generated from NOFO Builder's current revision, last updated
-    {{ nofo.updated|date:"N j, Y, g:i a" }} This is a NOFO Builder-generated aid
+    {{ nofo.updated|timezone:"America/New_York"|date:"N j, Y, g:i a" }} ET. This is a NOFO Builder-generated aid
     for this review pass, not a substitute for the official NOFO Summary
     Template still required as part of the Departmental/OMB clearance
     submission.

--- a/nofos/nofos/templates/nofos/includes/nofo_export_document.html
+++ b/nofos/nofos/templates/nofos/includes/nofo_export_document.html
@@ -1,10 +1,15 @@
 {% load martortags add_footnote_ids add_captions_to_tables add_classes_to_lists add_classes_to_paragraphs convert_paragraphs_to_hrs truncate_anchor_links_for_docx policy_language_export %}
 <div id="download_target" class="nofo_view">
   {% if strip_policy_language %}
-    <div class="policy-export-watermark">
-      <strong>PRE-DECISIONAL — FOR OMB/DEPARTMENTAL REVIEW ONLY. NOT THE OFFICIAL SUBMISSION COPY. NOT FOR PUBLICATION.</strong>
-      Abbreviated version generated to support review under HHS's NOFO clearance process. Formatting may not fully reflect the original NOFO due to this abbreviated export process; consult the full PDF version for the authoritative content and layout.
-    </div>
+    <p>&nbsp;</p> <!-- remove this if grabzit fixes their issue -->
+    <table class="policy-export-watermark">
+      <tr>
+        <td>
+          <strong>PRE-DECISIONAL — FOR OMB/DEPARTMENTAL REVIEW ONLY. NOT THE OFFICIAL SUBMISSION COPY. NOT FOR PUBLICATION.</strong>
+          Abbreviated version generated to support review under HHS's NOFO clearance process. Formatting may not fully reflect the original NOFO due to this abbreviated export process; consult the full PDF version for the authoritative content and layout.
+        </td>
+      </tr>
+    </table>
     {% include "nofos/includes/nofo_export_clearance_summary.html" %}
     <span class="page-break"></span>
   {% endif %}
@@ -56,7 +61,7 @@
                         {% if strip_policy_language and subsection.policy_language_status == "intact" %}
                           <p class="policy-language-stripped-note"><em>Standard HHS Department Governance language — omitted from this abbreviated review copy.</em></p>
                         {% else %}
-                          {% if strip_policy_language %}{% with note=subsection|policy_language_export_note %}{% if note %}<p class="policy-language-flag-note{% if subsection|policy_language_flag_is_prominent %} policy-language-flag-note--priority{% endif %}">{{ note }}</p>{% endif %}{% endwith %}{% endif %}
+                          {% if strip_policy_language %}{% with note=subsection|policy_language_export_note %}{% if note %}<p>&nbsp;</p><table class="policy-language-flag-box{% if subsection|policy_language_flag_is_prominent %} policy-language-flag-box--priority{% endif %}"><tr><td>{{ note }}</td></tr></table>{% endif %}{% endwith %}{% endif %}
                           {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|truncate_anchor_links_for_docx }}
                         {% endif %}
                       </div>
@@ -72,7 +77,7 @@
                     {% if strip_policy_language and subsection.policy_language_status == "intact" %}
                       <p class="policy-language-stripped-note"><em>Standard HHS Department Governance language — omitted from this abbreviated review copy.</em></p>
                     {% else %}
-                      {% if strip_policy_language %}{% with note=subsection|policy_language_export_note %}{% if note %}<p class="policy-language-flag-note{% if subsection|policy_language_flag_is_prominent %} policy-language-flag-note--priority{% endif %}">{{ note }}</p>{% endif %}{% endwith %}{% endif %}
+                      {% if strip_policy_language %}{% with note=subsection|policy_language_export_note %}{% if note %}<p>&nbsp;</p><table class="policy-language-flag-box{% if subsection|policy_language_flag_is_prominent %} policy-language-flag-box--priority{% endif %}"><tr><td>{{ note }}</td></tr></table>{% endif %}{% endwith %}{% endif %}
                       {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|truncate_anchor_links_for_docx }}
                     {% endif %}
                   </div>

--- a/nofos/nofos/tests_nofos/test_policy_language_export.py
+++ b/nofos/nofos/tests_nofos/test_policy_language_export.py
@@ -1,7 +1,9 @@
+import re
 from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 from constance.test import override_config
+from django.contrib.staticfiles import finders
 from django.http import HttpResponse
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -316,7 +318,16 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
             " ", strip=True
         )
         self.assertNotIn("..", intro)
-        self.assertIn("m. This is a NOFO Builder-generated aid", intro)
+        self.assertIn("m. ET. This is a NOFO Builder-generated aid", intro)
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_clearance_summary_timestamp_is_labeled_eastern_time(self):
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        intro = soup.select_one(".clearance-summary p.text-italic").get_text(
+            " ", strip=True
+        )
+        self.assertIn("ET.", intro)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_clearance_summary_shows_nofo_title_opdiv_and_number(self):
@@ -624,3 +635,25 @@ class NofoExportPolicyLanguageFreshnessTests(TestCase):
         self.assertNotIn("policy-language-stripped-note", body)
         self.assertIn("REVIEW: This section matches a prior version of", body)
         self.assertIn(old_canonical_text, body)  # visible, not stripped
+
+
+class ClearanceSummaryMissingSlotsBulletStyleTests(TestCase):
+    """The 'Missing expected Department Governance language' bullet on the
+    clearance summary should match the font size of the plain bullets
+    around it (12pt), not the smaller 12px it was previously set to."""
+
+    def test_missing_slots_bullet_uses_12pt_not_12px(self):
+        css_path = finders.find("theme-export.css")
+        self.assertIsNotNone(
+            css_path, "theme-export.css not found by staticfiles finders"
+        )
+        with open(css_path, encoding="utf-8") as f:
+            css = f.read()
+
+        rule_match = re.search(
+            r"\.nofo_view \.policy-language-flag-note\s*\{([^}]*)\}", css
+        )
+        self.assertIsNotNone(
+            rule_match, "No .policy-language-flag-note rule found in theme-export.css"
+        )
+        self.assertIn("font-size: 12pt", rule_match.group(1))

--- a/nofos/nofos/tests_nofos/test_policy_language_export.py
+++ b/nofos/nofos/tests_nofos/test_policy_language_export.py
@@ -243,6 +243,33 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         self.assertIn("NOT THE OFFICIAL SUBMISSION COPY", body)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_flag_on_stripped_export_watermark_is_table_cell(self):
+        # A plain div/p with background-color/border doesn't survive
+        # GrabzIt's HTML->DOCX conversion - only table-cell shading does
+        # (see the CSS comment on .policy-export-watermark td).
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        watermark = soup.select_one("table.policy-export-watermark")
+        self.assertIsNotNone(watermark)
+        self.assertIn("PRE-DECISIONAL", watermark.select_one("td").get_text())
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_flag_on_stripped_export_flag_box_is_table_cell(self):
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        boxes = soup.select("table.policy-language-flag-box")
+        self.assertTrue(boxes)
+        self.assertIn("REVIEW:", boxes[0].select_one("td").get_text())
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_flag_on_stripped_export_prominent_flag_box_has_priority_class(self):
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        priority_box = soup.select_one("table.policy-language-flag-box--priority")
+        self.assertIsNotNone(priority_box)
+        self.assertIn("PRIORITY REVIEW:", priority_box.select_one("td").get_text())
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_page_breaks_after_clearance_summary(self):
         # The watermark/clearance-summary "cover page" content should end on
         # its own page, separate from the actual NOFO content that follows -
@@ -270,6 +297,37 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         body = resp.content.decode()
         self.assertIn("Clearance Review Summary", body)
         self.assertIn("NOFO Builder", body)
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_clearance_summary_heading_has_no_generated_suffix(self):
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        heading = soup.select_one(".clearance-summary h2")
+        self.assertEqual(heading.get_text(strip=True), "Clearance Review Summary")
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_clearance_summary_date_sentence_has_no_double_period(self):
+        # The date renders via Django's "a" format (e.g. "5:21 p.m."), which
+        # already ends in a period - a literal "." straight after it in the
+        # template would double up ("p.m..").
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        intro = soup.select_one(".clearance-summary p.text-italic").get_text(
+            " ", strip=True
+        )
+        self.assertNotIn("..", intro)
+        self.assertIn("m. This is a NOFO Builder-generated aid", intro)
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_clearance_summary_shows_nofo_title_opdiv_and_number(self):
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        summary_text = soup.select_one(".clearance-summary").get_text(" ", strip=True)
+        self.assertIn(self.nofo.title, summary_text)
+        self.assertIn(f"Opdiv: {self.nofo.opdiv}", summary_text)
+        self.assertIn(f"Opportunity number: {self.nofo.number}", summary_text)
+        # This fixture NOFO has no agency set - the line shouldn't render.
+        self.assertNotIn("Agency:", summary_text)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_clearance_summary_reports_correct_stripped_and_flagged_counts(self):


### PR DESCRIPTION
## Summary

Visual and content fixes to the clearance-review Word export's cover page and inline flags:

- **Visual distinction for flagged content.** The pre-decisional watermark and the inline "REVIEW"/"PRIORITY REVIEW" notes shown at each flagged section had background-color and border CSS defined, but GrabzIt's HTML→DOCX conversion silently drops that styling on plain `div`/`p` elements - only bold, colored text was actually reaching the exported `.docx`. Both are now wrapped in a one-cell table instead (the same pattern the existing `callout-box` content already uses), since table-cell shading survives the conversion reliably where paragraph shading/borders don't.
- **Cover page cleanup.**
  - Dropped the "(Generated)" suffix from the "Clearance Review Summary" heading.
  - Fixed a double period after the timestamp (the "p.m."-style time format already ends in a period; the template was adding a second one).
  - Sized the summary's heading/subheadings to 28pt/22pt, matching the same sizes real section headings use elsewhere in the document, instead of a smaller override that made them hard to visually tell apart.
  - Added the NOFO's title, Opdiv, agency (if set), and opportunity number under the intro paragraph.
  - The "last updated" timestamp was rendering in the server's default timezone (UTC) with no label, reading as if it were local time - now explicitly converted to Eastern and labeled "ET".
  - The "Missing expected Department Governance language" bullet was 12px (~9pt), visibly smaller than the plain bullets around it, which render at the default 12pt body size - now matches.

## Test plan

- Full policy-language test suite passes (77 tests), including new coverage asserting: the watermark and flag notes render as table cells, the priority-review variant gets its own class, the summary heading has no "(Generated)" suffix, the date sentence has no double period and is labeled "ET", the title/Opdiv/agency/number block renders correctly, and the missing-slots bullet's CSS rule is 12pt (not 12px).
- Table-cell shading is based on an existing, working pattern already used elsewhere in this codebase (the Composer instructions box) - not yet confirmed against a real GrabzIt-converted `.docx` from this specific change; will verify against a real export once deployed.