### PR TITLE
Add spacing above the summary, box the intact/stripped note too

### DIFF
--- a/nofos/bloom_nofos/static/theme-export.css
+++ b/nofos/bloom_nofos/static/theme-export.css
@@ -231,8 +231,11 @@ span.page-break {
   color: #b50909;
 }
 
-.nofo_view .policy-language-stripped-note {
+.nofo_view .policy-language-stripped-box td {
+  border: 1px solid #73b3e7;
+  background-color: #d9e8f6;
   color: #71767a;
+  padding: 8px 12px;
   font-style: italic;
   font-size: 12px;
 }

--- a/nofos/nofos/templates/nofos/includes/nofo_export_document.html
+++ b/nofos/nofos/templates/nofos/includes/nofo_export_document.html
@@ -10,6 +10,7 @@
         </td>
       </tr>
     </table>
+    <p>&nbsp;</p>
     {% include "nofos/includes/nofo_export_clearance_summary.html" %}
     <span class="page-break"></span>
   {% endif %}
@@ -59,7 +60,7 @@
                       {% endwith %}
                       <div class="{% if not subsection.name and not subsection.callout_box %}margin-top-2 {% endif %}styled-subsection-body">
                         {% if strip_policy_language and subsection.policy_language_status == "intact" %}
-                          <p class="policy-language-stripped-note"><em>Standard HHS Department Governance language — omitted from this abbreviated review copy.</em></p>
+                          <p>&nbsp;</p><table class="policy-language-stripped-box"><tr><td><em>Standard HHS Department Governance language — omitted from this abbreviated review copy.</em></td></tr></table>
                         {% else %}
                           {% if strip_policy_language %}{% with note=subsection|policy_language_export_note %}{% if note %}<p>&nbsp;</p><table class="policy-language-flag-box{% if subsection|policy_language_flag_is_prominent %} policy-language-flag-box--priority{% endif %}"><tr><td>{{ note }}</td></tr></table>{% endif %}{% endwith %}{% endif %}
                           {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|truncate_anchor_links_for_docx }}
@@ -75,7 +76,7 @@
                 {% if subsection.body %}
                   <div class="{% if not subsection.name %}margin-top-2 {% endif %}styled-subsection-body">
                     {% if strip_policy_language and subsection.policy_language_status == "intact" %}
-                      <p class="policy-language-stripped-note"><em>Standard HHS Department Governance language — omitted from this abbreviated review copy.</em></p>
+                      <p>&nbsp;</p><table class="policy-language-stripped-box"><tr><td><em>Standard HHS Department Governance language — omitted from this abbreviated review copy.</em></td></tr></table>
                     {% else %}
                       {% if strip_policy_language %}{% with note=subsection|policy_language_export_note %}{% if note %}<p>&nbsp;</p><table class="policy-language-flag-box{% if subsection|policy_language_flag_is_prominent %} policy-language-flag-box--priority{% endif %}"><tr><td>{{ note }}</td></tr></table>{% endif %}{% endwith %}{% endif %}
                       {{ subsection.body|safe_markdown|add_footnote_ids|add_classes_to_paragraphs|add_captions_to_tables|add_classes_to_lists|convert_paragraphs_to_hrs|truncate_anchor_links_for_docx }}

--- a/nofos/nofos/tests_nofos/test_policy_language_export.py
+++ b/nofos/nofos/tests_nofos/test_policy_language_export.py
@@ -216,7 +216,7 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         resp = self.client.get(self.export_url + "?policy_stripped=1")
         body = resp.content.decode()
         self.assertNotIn(self.sam_slot.variants.first().canonical_text, body)
-        self.assertIn("policy-language-stripped-note", body)
+        self.assertIn("policy-language-stripped-box", body)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_flags_altered_sections(self):
@@ -254,6 +254,16 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         watermark = soup.select_one("table.policy-export-watermark")
         self.assertIsNotNone(watermark)
         self.assertIn("PRE-DECISIONAL", watermark.select_one("td").get_text())
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_flag_on_stripped_export_stripped_note_is_table_cell(self):
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        box = soup.select_one("table.policy-language-stripped-box")
+        self.assertIsNotNone(box)
+        self.assertIn(
+            "omitted from this abbreviated review copy", box.select_one("td").get_text()
+        )
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_flag_box_is_table_cell(self):
@@ -568,7 +578,7 @@ class NofoExportPolicyLanguageFreshnessTests(TestCase):
         # a review flag.
         self.assertIn("This paragraph has been substantively rewritten.", body)
         self.assertIn("REVIEW: This section corresponds to", body)
-        self.assertNotIn("policy-language-stripped-note", body)
+        self.assertNotIn("policy-language-stripped-box", body)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_duplicated_nofo_reflects_edits_made_after_duplication(self):
@@ -596,7 +606,7 @@ class NofoExportPolicyLanguageFreshnessTests(TestCase):
 
         self.assertIn("The duplicated content was then rewritten.", body)
         self.assertIn("REVIEW: This section corresponds to", body)
-        self.assertNotIn("policy-language-stripped-note", body)
+        self.assertNotIn("policy-language-stripped-box", body)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_canonical_slot_revision_is_reflected_without_reimporting(self):
@@ -632,7 +642,7 @@ class NofoExportPolicyLanguageFreshnessTests(TestCase):
         # superseded rather than current - it should be flagged as matching
         # a prior version (content stays visible, same as any other
         # non-intact status), not silently stripped as "intact".
-        self.assertNotIn("policy-language-stripped-note", body)
+        self.assertNotIn("policy-language-stripped-box", body)
         self.assertIn("REVIEW: This section matches a prior version of", body)
         self.assertIn(old_canonical_text, body)  # visible, not stripped
 


### PR DESCRIPTION
- Adds a blank paragraph between the watermark table and the clearance summary on page 1, so they don't run directly into each other.
- The "omitted" note for intact/stripped sections now gets the same one-cell-table treatment as the review flags, but in light blue rather than yellow/red — it's informational, not something that needs review, so it should read differently at a glance.

Test plan: full policy-language suite passes (78 tests), including new coverage confirming the stripped note renders as a table cell.