### PR TITLE
Fix summary spacing, sentence-case flag labels, trailing blank page

### DIFF
--- a/nofos/bloom_nofos/static/theme-export.css
+++ b/nofos/bloom_nofos/static/theme-export.css
@@ -123,10 +123,15 @@ body {
 
 /* Section */
 
-section,
+section {
+  break-inside: avoid;
+}
+
+/* Every section starts a fresh page except the last - breaking after it too
+   would leave a trailing blank page with nothing on it. */
+section:not(:last-child),
 span.page-break {
   break-after: page;
-  break-inside: avoid;
 }
 
 /* Lists */
@@ -264,7 +269,6 @@ span.page-break {
   background-color: #faf3d1;
   padding: 8px 12px;
   font-size: 12px;
-  font-weight: 700;
 }
 
 .nofo_view .policy-language-flag-box--priority td {
@@ -281,7 +285,7 @@ span.page-break {
 }
 
 .nofo_view .clearance-summary h2 {
-  margin-top: 0;
+  margin-top: 24px;
   margin-bottom: 6px;
   font-size: 28pt;
 }

--- a/nofos/nofos/policy_language.py
+++ b/nofos/nofos/policy_language.py
@@ -267,8 +267,8 @@ def get_policy_language_export_note(subsection):
     or takes a position on it, and never asserts a conclusion detection
     can't actually verify ("does not match," "please confirm," not "has
     been altered"). A slot's flag_prominently elevates this to a
-    "PRIORITY REVIEW" framing (HHS-locked language); otherwise it's routine
-    "REVIEW" wording. Both are generated generically from the slot's own
+    "Priority review" framing (HHS-locked language); otherwise it's routine
+    "Review" wording. Both are generated generically from the slot's own
     name - never hardcoded per slot_key - so nothing about a specific
     slot's real-world content lives in this module.
     """
@@ -282,13 +282,13 @@ def get_policy_language_export_note(subsection):
     if slot is not None and slot.flag_prominently:
         if status == "matches_prior_version":
             return (
-                f"PRIORITY REVIEW: This section matches an earlier version "
+                f"Priority review: This section matches an earlier version "
                 f"of HHS-locked Department Governance language ({name}), "
                 "not the current canonical text. Please confirm this "
                 "reflects current policy before this NOFO proceeds."
             )
         return (
-            f"PRIORITY REVIEW: This section corresponds to HHS-locked "
+            f"Priority review: This section corresponds to HHS-locked "
             f"Department Governance language ({name}) and does not match "
             "the current canonical text on file. Please confirm this "
             "section's wording before this NOFO proceeds."
@@ -296,13 +296,13 @@ def get_policy_language_export_note(subsection):
 
     if status == "matches_prior_version":
         return (
-            f"REVIEW: This section matches a prior version of {name} "
+            f"Review: This section matches a prior version of {name} "
             "language, not the current canonical text on file. Please "
             "confirm this reflects current policy before this NOFO "
             "proceeds."
         )
     return (
-        f"REVIEW: This section corresponds to {name} language and does not "
+        f"Review: This section corresponds to {name} language and does not "
         "match the current canonical text on file. Please confirm this "
         "section's wording before this NOFO proceeds."
     )

--- a/nofos/nofos/templates/nofos/includes/nofo_export_document.html
+++ b/nofos/nofos/templates/nofos/includes/nofo_export_document.html
@@ -10,7 +10,6 @@
         </td>
       </tr>
     </table>
-    <p>&nbsp;</p>
     {% include "nofos/includes/nofo_export_clearance_summary.html" %}
     <span class="page-break"></span>
   {% endif %}

--- a/nofos/nofos/templatetags/policy_language_export.py
+++ b/nofos/nofos/templatetags/policy_language_export.py
@@ -1,15 +1,24 @@
 from django import template
+from django.utils.html import format_html
 
 from nofos.policy_language import get_policy_language_export_note
 
 register = template.Library()
 
 
-@register.filter()
+@register.filter(is_safe=True)
 def policy_language_export_note(subsection):
-    """The reviewer-facing note for a flagged subsection, or None if it
-    isn't one (see get_policy_language_export_note for the status rules)."""
-    return get_policy_language_export_note(subsection)
+    """The reviewer-facing note for a flagged subsection, as safe HTML with
+    only its leading label ("Review:"/"Priority review:") bolded - the rest
+    renders at normal weight, so the callout doesn't read as one solid
+    block of bold text. Empty string (falsy, same as None in a template
+    {% if %}) if the subsection isn't flagged - see
+    get_policy_language_export_note for the status rules."""
+    note = get_policy_language_export_note(subsection)
+    if not note:
+        return ""
+    label, _, rest = note.partition(":")
+    return format_html("<strong>{}:</strong>{}", label, rest)
 
 
 @register.filter()

--- a/nofos/nofos/tests_nofos/test_policy_language.py
+++ b/nofos/nofos/tests_nofos/test_policy_language.py
@@ -391,8 +391,8 @@ class PolicyLanguageExportNoteTests(TestCase):
             policy_language_status="may_be_altered", policy_language_slot=slot,
         )
         note = get_policy_language_export_note(sub)
-        self.assertIn("REVIEW:", note)
-        self.assertNotIn("PRIORITY REVIEW", note)
+        self.assertIn("Review:", note)
+        self.assertNotIn("Priority review", note)
         self.assertIn("Routine Slot", note)
 
     def test_elevated_note_for_prominent_slot(self):
@@ -411,7 +411,7 @@ class PolicyLanguageExportNoteTests(TestCase):
             policy_language_status="may_be_altered", policy_language_slot=slot,
         )
         note = get_policy_language_export_note(sub)
-        self.assertIn("PRIORITY REVIEW", note)
+        self.assertIn("Priority review", note)
 
 
 class PolicyLanguageExportSummaryTests(TestCase):

--- a/nofos/nofos/tests_nofos/test_policy_language_export.py
+++ b/nofos/nofos/tests_nofos/test_policy_language_export.py
@@ -220,16 +220,22 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_flags_altered_sections(self):
+        # The "Review:" label renders inside its own <strong>, so a raw-HTML
+        # substring check would break on the tag boundary - check the text
+        # content instead (see test_flag_on_stripped_export_flag_box_is_table_cell
+        # for the label/box-structure assertion).
         resp = self.client.get(self.export_url + "?policy_stripped=1")
-        body = resp.content.decode()
-        self.assertIn("This text has clearly been rewritten", body)
-        self.assertIn("REVIEW: This section corresponds to", body)
+        soup = BeautifulSoup(resp.content, "html.parser")
+        text = soup.get_text(" ", strip=True)
+        self.assertIn("This text has clearly been rewritten", text)
+        self.assertIn("Review: This section corresponds to", text)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_elevates_prominent_slot(self):
         resp = self.client.get(self.export_url + "?policy_stripped=1")
-        body = resp.content.decode()
-        self.assertIn("PRIORITY REVIEW: This section corresponds to HHS-locked", body)
+        soup = BeautifulSoup(resp.content, "html.parser")
+        text = soup.get_text(" ", strip=True)
+        self.assertIn("Priority review: This section corresponds to HHS-locked", text)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_leaves_ordinary_content_untouched(self):
@@ -271,7 +277,20 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         soup = BeautifulSoup(resp.content, "html.parser")
         boxes = soup.select("table.policy-language-flag-box")
         self.assertTrue(boxes)
-        self.assertIn("REVIEW:", boxes[0].select_one("td").get_text())
+        self.assertIn("Review:", boxes[0].select_one("td").get_text())
+
+    @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
+    def test_flag_on_stripped_export_only_the_label_is_bold(self):
+        # "Review:"/"Priority review:" stays bold, but the sentence after it
+        # shouldn't - only the label sits inside <strong>.
+        resp = self.client.get(self.export_url + "?policy_stripped=1")
+        soup = BeautifulSoup(resp.content, "html.parser")
+        td = soup.select_one("table.policy-language-flag-box td")
+        strong = td.find("strong")
+        self.assertIsNotNone(strong)
+        self.assertEqual(strong.get_text(strip=True), "Review:")
+        self.assertIn("This section corresponds to", td.get_text())
+        self.assertNotIn("This section corresponds to", strong.get_text())
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_prominent_flag_box_has_priority_class(self):
@@ -279,7 +298,7 @@ class NofoExportPolicyLanguageRenderingTests(TestCase):
         soup = BeautifulSoup(resp.content, "html.parser")
         priority_box = soup.select_one("table.policy-language-flag-box--priority")
         self.assertIsNotNone(priority_box)
-        self.assertIn("PRIORITY REVIEW:", priority_box.select_one("td").get_text())
+        self.assertIn("Priority review:", priority_box.select_one("td").get_text())
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
     def test_flag_on_stripped_export_page_breaks_after_clearance_summary(self):
@@ -577,7 +596,10 @@ class NofoExportPolicyLanguageFreshnessTests(TestCase):
         # would be silently stripped. It must instead render visible with
         # a review flag.
         self.assertIn("This paragraph has been substantively rewritten.", body)
-        self.assertIn("REVIEW: This section corresponds to", body)
+        self.assertIn(
+            "Review: This section corresponds to",
+            BeautifulSoup(resp.content, "html.parser").get_text(" ", strip=True),
+        )
         self.assertNotIn("policy-language-stripped-box", body)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
@@ -605,7 +627,10 @@ class NofoExportPolicyLanguageFreshnessTests(TestCase):
         body = resp.content.decode()
 
         self.assertIn("The duplicated content was then rewritten.", body)
-        self.assertIn("REVIEW: This section corresponds to", body)
+        self.assertIn(
+            "Review: This section corresponds to",
+            BeautifulSoup(resp.content, "html.parser").get_text(" ", strip=True),
+        )
         self.assertNotIn("policy-language-stripped-box", body)
 
     @override_config(HHS_NOFO_POLICY_EXPORT_ENABLED=True)
@@ -643,7 +668,10 @@ class NofoExportPolicyLanguageFreshnessTests(TestCase):
         # a prior version (content stays visible, same as any other
         # non-intact status), not silently stripped as "intact".
         self.assertNotIn("policy-language-stripped-box", body)
-        self.assertIn("REVIEW: This section matches a prior version of", body)
+        self.assertIn(
+            "Review: This section matches a prior version of",
+            BeautifulSoup(resp.content, "html.parser").get_text(" ", strip=True),
+        )
         self.assertIn(old_canonical_text, body)  # visible, not stripped
 
 
@@ -667,3 +695,24 @@ class ClearanceSummaryMissingSlotsBulletStyleTests(TestCase):
             rule_match, "No .policy-language-flag-note rule found in theme-export.css"
         )
         self.assertIn("font-size: 12pt", rule_match.group(1))
+
+
+class ExportDocumentPageBreakCssTests(TestCase):
+    """Every <section> forcing break-after: page - including the last one -
+    left a trailing blank page with nothing on it, in both the plain and
+    stripped exports (a pre-existing rule, not specific to policy-language
+    content). The last section should keep break-inside: avoid but not
+    force a break after itself."""
+
+    def test_last_section_does_not_force_a_break_after(self):
+        css_path = finders.find("theme-export.css")
+        self.assertIsNotNone(
+            css_path, "theme-export.css not found by staticfiles finders"
+        )
+        with open(css_path, encoding="utf-8") as f:
+            css = f.read()
+
+        self.assertIn("section:not(:last-child)", css)
+        # The old blanket rule applying break-after: page to every <section>
+        # (with no :not(:last-child) qualifier) should be gone.
+        self.assertNotRegex(css, r"section,\s*\n\s*span\.page-break\s*\{")


### PR DESCRIPTION
## Summary

Three fixes to the clearance-review Word export, found by testing real generated `.docx` files:

- **Spacing above the summary.** A blank paragraph meant to separate the pre-decisional watermark table from the "Clearance Review Summary" heading was getting silently absorbed into the watermark table's last cell as a line break instead of landing between them - confirmed by inspecting the actual exported XML. Fixed by giving the heading its own top margin instead, the same spacing mechanism already working correctly for every other heading in the document.
- **Sentence-case flag labels.** "REVIEW:"/"PRIORITY REVIEW:" are now "Review:"/"Priority review:", and only the label itself is bold - the sentence that follows now renders at normal weight instead of the whole note being bold.
- **Trailing blank page.** Every `<section>` forced a page break after itself, including the very last one, leaving a blank page at the end of both the plain and stripped Word exports (pre-existing, not specific to policy-language content - it affects the general export template). The last section no longer forces a break after itself.

## Test plan

Full policy-language suite passes (80 tests), including new coverage for the bold-only-the-label behavior and a check that the trailing-section CSS no longer forces a break after the last section.