### PR TITLE
Update landing page copy to reflect Word import workflow and add accessibility check step

### DIFF
--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -34,7 +34,7 @@
 
   <h1 class="font-heading-xl margin-y-0">Generate NOFOs from Word Documents</h1>
   <p class="usa-intro">
-    Simplify the process of publishing Notices of Financial Opportunity (NOFOs).
+    Simplify the process of designing and publishing Notices of Financial Opportunity (NOFOs).
   </p>
   <p class="usa-intro">
     Import your NOFOs and turn them into accessible PDF files.
@@ -49,8 +49,7 @@
 
   <p>At a glance:</p>
   <ol class="usa-list">
-    <li>Export your completed NOFO document as an HTML file</li>
-    <li>Import the HTML file into the NOFO builder</li>
+    <li>Import your completed NOFO Word document into the NOFO builder</li>
     <li>Edit the NOFO to make small changes or correct metadata (author, date, number, tagline, etc.)</li>
     <li>Select the right theme: default or light</li>
     <li>Print your NOFO as a PDF file</li>

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -51,7 +51,7 @@
   <ol class="usa-list">
     <li>Import your approved NOFO Word document into the NOFO Builder</li>
     <li>Check for any accessibility warnings, such as broken internal links or non-sequential headings</li>
-    <li>Edit the NOFO to make small changes or correct metadata (author, date, number, tagline, etc.)</li>
+    <li>Edit the NOFO to make minor text edits or correct metadata (author, date, number, tagline, etc.)</li>
     <li>Select your design theme: default or light</li>
     <li>Download your NOFO as a PDF</li>
   </ol>

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -53,6 +53,6 @@
     <li>Check for any accessibility warnings, such as broken internal links or non-sequential headings</li>
     <li>Edit the NOFO to make minor text edits or correct metadata (author, date, number, tagline, etc.)</li>
     <li>Select your design theme: default or light</li>
-    <li>Download your NOFO as a PDF</li>
+    <li>Preview your PDF, then download your PDF file</li>
   </ol>
 {% endblock %}

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -49,7 +49,7 @@
 
   <p>At a glance:</p>
   <ol class="usa-list">
-    <li>Import your completed NOFO Word document into the NOFO builder</li>
+    <li>Import your approved NOFO Word document into the NOFO Builder</li>
     <li>Edit the NOFO to make small changes or correct metadata (author, date, number, tagline, etc.)</li>
     <li>Select the right theme: default or light</li>
     <li>Print your NOFO as a PDF file</li>

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -50,6 +50,7 @@
   <p>At a glance:</p>
   <ol class="usa-list">
     <li>Import your approved NOFO Word document into the NOFO Builder</li>
+    <li>Correct any accessibility warnings, such as broken internal links or non-sequential headings</li>
     <li>Edit the NOFO to make small changes or correct metadata (author, date, number, tagline, etc.)</li>
     <li>Select your design theme: default or light</li>
     <li>Print your NOFO as a PDF file</li>

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -50,7 +50,7 @@
   <p>At a glance:</p>
   <ol class="usa-list">
     <li>Import your approved NOFO Word document into the NOFO Builder</li>
-    <li>Correct any accessibility warnings, such as broken internal links or non-sequential headings</li>
+    <li>Check for any accessibility warnings, such as broken internal links or non-sequential headings</li>
     <li>Edit the NOFO to make small changes or correct metadata (author, date, number, tagline, etc.)</li>
     <li>Select your design theme: default or light</li>
     <li>Download your NOFO as a PDF</li>

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -53,6 +53,6 @@
     <li>Correct any accessibility warnings, such as broken internal links or non-sequential headings</li>
     <li>Edit the NOFO to make small changes or correct metadata (author, date, number, tagline, etc.)</li>
     <li>Select your design theme: default or light</li>
-    <li>Print your NOFO as a PDF file</li>
+    <li>Download your NOFO as a PDF</li>
   </ol>
 {% endblock %}

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -43,7 +43,7 @@
     {% if user.is_authenticated %}
       All NOFOs
     {% else %}
-      Login to see NOFOs
+      Log in to access NOFOs
     {% endif %}
   </a>
 

--- a/nofos/bloom_nofos/templates/index.html
+++ b/nofos/bloom_nofos/templates/index.html
@@ -51,7 +51,7 @@
   <ol class="usa-list">
     <li>Import your approved NOFO Word document into the NOFO Builder</li>
     <li>Edit the NOFO to make small changes or correct metadata (author, date, number, tagline, etc.)</li>
-    <li>Select the right theme: default or light</li>
+    <li>Select your design theme: default or light</li>
     <li>Print your NOFO as a PDF file</li>
   </ol>
 {% endblock %}


### PR DESCRIPTION
## Summary
- The landing page ("At a glance" steps) described an outdated HTML-export
  workflow. The NOFO Builder now accepts .docx files directly, so the copy
  is updated to match the current process.
- Added a new step for checking accessibility warnings (broken internal
  links, non-sequential headings) after import, before editing.
- Minor wording refinements throughout: "Log in" (verb) instead of "Login",
  avoided directional language ("access" instead of "see"), and clarified
  the preview/download step for the final PDF.

## Before / current text
See the live page (before this change): https://nofos.simpler.grants.gov/
File: `nofos/bloom_nofos/templates/index.html`

## Changes
1. Import your approved NOFO Word document into the NOFO Builder
2. Check for any accessibility warnings, such as broken internal links or non-sequential headings
3. Edit the NOFO to make minor text edits or correct metadata (author, date, number, tagline, etc.)
4. Select your design theme: default or light
5. Preview your PDF, then download your PDF file

Also updated the intro line to "Simplify the process of designing and
publishing Notices of Financial Opportunity (NOFOs)" and the login button
to "Log in to access NOFOs".

## Test plan
- [ ] Load the landing page (logged out) and confirm the copy renders correctly
- [ ] Confirm the login button reads "Log in to access NOFOs" and links correctly