### PR TITLE
Warn on unconverted footnotes left over from Word imports

### DIFF
--- a/nofos/bloom_nofos/static/styles.css
+++ b/nofos/bloom_nofos/static/styles.css
@@ -821,6 +821,40 @@ label.usa-label {
   padding: 4px 6px;
 }
 
+/* On small screens, shrink tabs to fit on one row instead of wrapping, and
+   truncate the tab label (keeping the count visible) instead of hiding
+   tabs or scrolling. The full label is still exposed via aria-label. */
+@media all and (max-width: 39.99em) {
+  .nofo_edit [role="tablist"] {
+    display: flex;
+    flex-wrap: nowrap;
+  }
+
+  .nofo_edit [role="tab"] {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .nofo_edit [role="tab"] span.focus {
+    display: flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    min-width: 0;
+  }
+
+  .nofo_edit [role="tab"] .nofo_edit--tab-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .nofo_edit [role="tab"] .nofo_edit--tab-count {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+}
+
 .nofo_edit [role="tabpanel"] {
   padding: 5px;
   border: 2px solid hsl(219deg 1% 72%);

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1716,12 +1716,16 @@ def find_broken_links(nofo):
 UNCONVERTED_FOOTNOTE_RE = re.compile(r"\[\d{1,3}\]")
 
 # Real Word footnotes/endnotes get auto-labeled "Endnotes" on import (see
-# `add_endnotes_header_if_exists`'s `_match_endnotes`). A subsection literally headed
-# "Footnotes" (singular or plural) means the source document's footnotes were typed
-# manually - eg, GSAM's export template - instead of inserted with Word's built-in
-# footnote/endnote tool, so they were never recognized or linked up on import.
-UNCONVERTED_FOOTNOTES_HEADING_RE = re.compile(r"^footnotes?$", re.IGNORECASE)
-FOOTNOTE_HEADING_TAGS = ("h2", "h3", "h4", "h5", "h6")
+# `add_endnotes_header_if_exists`'s `_match_endnotes`). A section or subsection
+# literally headed "Footnote" or "Footnotes" means the source document's footnotes
+# may have been typed manually instead of inserted with Word's built-in tool. A trailing
+# colon is allowed because it does not change the heading's meaning.
+UNCONVERTED_FOOTNOTES_HEADING_RE = re.compile(r"footnotes?\s*:?\s*", re.IGNORECASE)
+FOOTNOTE_HEADING_TAGS = ("h2", "h3", "h4", "h5", "h6", "h7")
+
+
+def _is_footnotes_heading(value):
+    return bool(UNCONVERTED_FOOTNOTES_HEADING_RE.fullmatch((value or "").strip()))
 
 
 def find_unconverted_footnotes(nofo):
@@ -1738,14 +1742,16 @@ def find_unconverted_footnotes(nofo):
     numbers as footnotes, this function requires the first structural signal before it
     considers the second:
 
-    1. A subsection heading (h2-h6) literally titled "Footnotes" - the un-converted
-       counterpart of the "Endnotes" heading NOFO Builder adds on a successful import.
+    1. A section or subsection heading literally titled "Footnote" or "Footnotes" -
+       the un-converted counterpart of the "Endnotes" section NOFO Builder adds on a
+       successful import. A trailing colon is ignored.
     2. A short "[1]"-style reference elsewhere in the document that isn't inside a link
        or code element (eg, an in-text citation like "...evidence[1]").
 
-    The Footnotes subsection is included once in the result as the primary structural
-    signal, followed by any unlinked numeric reference locations. If there is no
-    Footnotes subsection, the function returns no results.
+    The Footnotes section or subsection is included once in the result as the primary
+    structural signal, along with any unlinked numeric reference locations. Its note-list
+    body is not scanned separately. If there is no Footnotes heading, the function returns
+    no results.
 
     Args:
         nofo (Nofo): A Nofo object which contains sections and subsections. Each
@@ -1758,63 +1764,77 @@ def find_unconverted_footnotes(nofo):
                       [
                           {
                               "section": <Section object>,
-                              "subsection": <Subsection object>,
+                              "subsection": <Subsection object or None>,
                               "footnote_text": "[1]",
                           },
                           ...
                       ]
     """
-    subsections = []
+    sections = [
+        (section, list(section.subsections.all().order_by("order")))
+        for section in nofo.sections.all().order_by("order")
+    ]
+    footnotes_section_ids = {
+        section.id for section, _ in sections if _is_footnotes_heading(section.name)
+    }
+    footnotes_subsection_ids = {
+        subsection.id
+        for _, subsections in sections
+        for subsection in subsections
+        if subsection.tag in FOOTNOTE_HEADING_TAGS
+        and _is_footnotes_heading(subsection.name)
+    }
 
-    for section in nofo.sections.all().order_by("order"):
-        for subsection in section.subsections.all().order_by("order"):
-            subsections.append((section, subsection))
-
-    has_footnotes_heading = any(
-        subsection.tag in FOOTNOTE_HEADING_TAGS
-        and UNCONVERTED_FOOTNOTES_HEADING_RE.match((subsection.name or "").strip())
-        for _, subsection in subsections
-    )
-    if not has_footnotes_heading:
+    if not footnotes_section_ids and not footnotes_subsection_ids:
         return []
 
     unconverted_footnotes = []
 
-    for section, subsection in subsections:
-        if (
-            subsection.tag in FOOTNOTE_HEADING_TAGS
-            and UNCONVERTED_FOOTNOTES_HEADING_RE.match((subsection.name or "").strip())
-        ):
+    for section, subsections in sections:
+        if section.id in footnotes_section_ids:
             unconverted_footnotes.append(
                 {
                     "section": section,
-                    "subsection": subsection,
-                    "footnote_text": subsection.name,
+                    "subsection": None,
+                    "footnote_text": section.name,
                 }
             )
-            # This subsection is the structural prerequisite and is already
-            # reported, so don't count its note-list entries as references too.
+            # The whole section is the structural prerequisite and note list.
+            # Report it once instead of counting each note-list marker.
             continue
 
-        soup = BeautifulSoup(
-            markdown.markdown(subsection.body, extensions=["extra"]), "html.parser"
-        )
-
-        for text_node in soup.find_all(string=UNCONVERTED_FOOTNOTE_RE):
-            # Existing links already have a working destination (or are handled by
-            # the broken-links warning), and bracketed numbers in code are content,
-            # not reference markers.
-            if text_node.find_parent(("a", "code", "pre")):
-                continue
-
-            for match in UNCONVERTED_FOOTNOTE_RE.finditer(text_node):
+        for subsection in subsections:
+            if subsection.id in footnotes_subsection_ids:
                 unconverted_footnotes.append(
                     {
                         "section": section,
                         "subsection": subsection,
-                        "footnote_text": match.group(),
+                        "footnote_text": subsection.name,
                     }
                 )
+                # This subsection is the structural prerequisite and is already
+                # reported, so don't count its note-list entries as references too.
+                continue
+
+            soup = BeautifulSoup(
+                markdown.markdown(subsection.body, extensions=["extra"]), "html.parser"
+            )
+
+            for text_node in soup.find_all(string=UNCONVERTED_FOOTNOTE_RE):
+                # Existing links already have a working destination (or are handled by
+                # the broken-links warning), and bracketed numbers in code are content,
+                # not reference markers.
+                if text_node.find_parent(("a", "code", "pre")):
+                    continue
+
+                for match in UNCONVERTED_FOOTNOTE_RE.finditer(text_node):
+                    unconverted_footnotes.append(
+                        {
+                            "section": section,
+                            "subsection": subsection,
+                            "footnote_text": match.group(),
+                        }
+                    )
 
     return unconverted_footnotes
 

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -35,6 +35,7 @@ from .models import Nofo, Section, Subsection
 from .nofo_markdown import MISSING_ALT_TEXT_ATTR, PRESERVE_BOOKMARK_TARGET_ATTR, md
 from .pdf_metadata import normalize_pdf_metadata_value
 from .policy_language import detect_policy_language_status, get_candidate_slots
+from .templatetags.utils import get_footnote_type
 from .utils import (
     add_html_id_to_subsection,
     clean_string,
@@ -1708,6 +1709,97 @@ def find_broken_links(nofo):
                     )
 
     return broken_links
+
+
+# Matches footnote/endnote reference text as this app renders it on a successful
+# import, eg "[1]", "[23]" (see `is_footnote_ref` in templatetags/utils).
+UNCONVERTED_FOOTNOTE_RE = re.compile(r"\[\d+\]")
+
+# Real Word footnotes/endnotes get auto-labeled "Endnotes" on import (see
+# `add_endnotes_header_if_exists`'s `_match_endnotes`). A subsection literally headed
+# "Footnotes" (singular or plural) means the source document's footnotes were typed
+# manually - eg, GSAM's export template - instead of inserted with Word's built-in
+# footnote/endnote tool, so they were never recognized or linked up on import.
+UNCONVERTED_FOOTNOTES_HEADING_RE = re.compile(r"^footnotes?$", re.IGNORECASE)
+FOOTNOTE_HEADING_TAGS = ("h2", "h3", "h4", "h5", "h6")
+
+
+def find_unconverted_footnotes(nofo):
+    """
+    Identifies footnotes that were typed directly into the source Word document's text
+    instead of being inserted with Word's built-in footnote/endnote tool.
+
+    NOFO Builder's import process converts real Word footnotes/endnotes (inserted via
+    Word's References > Insert Footnote/Endnote tool) into linked endnotes, wrapping the
+    in-text reference in an `<a>` tag recognized by `get_footnote_type` (eg,
+    `<a href="#footnote-1">[1]</a>`), and labelling the endnotes list "Endnotes" on import.
+    A footnote reference that was typed manually has no such link, so it survives import
+    unlinked and won't work in the final PDF. This function looks for two signs of that:
+
+    1. A subsection heading (h2-h6) literally titled "Footnotes" - the un-converted
+       counterpart of the "Endnotes" heading NOFO Builder adds on a successful import.
+    2. A "[1]"-style reference elsewhere in a subsection's body that isn't wrapped in a
+       recognized footnote/endnote link (eg, an in-text citation like "...evidence[1]").
+
+    Args:
+        nofo (Nofo): A Nofo object which contains sections and subsections. Each
+                     subsection's body is expected to be in markdown format.
+
+    Returns:
+        list of dict: A list of dictionaries, one per unconverted footnote found, each
+                      with the section and subsection it was found in, and the raw
+                      footnote text. The structure is as follows:
+                      [
+                          {
+                              "section": <Section object>,
+                              "subsection": <Subsection object>,
+                              "footnote_text": "[1]",
+                          },
+                          ...
+                      ]
+    """
+    unconverted_footnotes = []
+
+    for section in nofo.sections.all().order_by("order"):
+        for subsection in section.subsections.all().order_by("order"):
+            if (
+                subsection.tag in FOOTNOTE_HEADING_TAGS
+                and UNCONVERTED_FOOTNOTES_HEADING_RE.match(
+                    (subsection.name or "").strip()
+                )
+            ):
+                unconverted_footnotes.append(
+                    {
+                        "section": section,
+                        "subsection": subsection,
+                        "footnote_text": subsection.name,
+                    }
+                )
+                # this subsection's body is the footnotes list itself; it's already
+                # flagged by its heading, so skip the in-body scan below for it
+                continue
+
+            soup = BeautifulSoup(
+                markdown.markdown(subsection.body, extensions=["extra"]), "html.parser"
+            )
+
+            for text_node in soup.find_all(string=UNCONVERTED_FOOTNOTE_RE):
+                parent_link = text_node.find_parent("a")
+                # skip real footnote/endnote references, which are already wrapped in a
+                # recognized link on import
+                if parent_link and get_footnote_type(parent_link):
+                    continue
+
+                for match in UNCONVERTED_FOOTNOTE_RE.finditer(text_node):
+                    unconverted_footnotes.append(
+                        {
+                            "section": section,
+                            "subsection": subsection,
+                            "footnote_text": match.group(),
+                        }
+                    )
+
+    return unconverted_footnotes
 
 
 def get_side_nav_links(nofo):

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -35,7 +35,6 @@ from .models import Nofo, Section, Subsection
 from .nofo_markdown import MISSING_ALT_TEXT_ATTR, PRESERVE_BOOKMARK_TARGET_ATTR, md
 from .pdf_metadata import normalize_pdf_metadata_value
 from .policy_language import detect_policy_language_status, get_candidate_slots
-from .templatetags.utils import get_footnote_type
 from .utils import (
     add_html_id_to_subsection,
     clean_string,
@@ -1711,9 +1710,10 @@ def find_broken_links(nofo):
     return broken_links
 
 
-# Matches footnote/endnote reference text as this app renders it on a successful
-# import, eg "[1]", "[23]" (see `is_footnote_ref` in templatetags/utils).
-UNCONVERTED_FOOTNOTE_RE = re.compile(r"\[\d+\]")
+# Matches the short numeric reference markers used by imported footnotes/endnotes,
+# eg "[1]" and "[23]". Limiting the length avoids treating bracketed years as
+# footnotes; the structural "Footnotes" heading check below is also required.
+UNCONVERTED_FOOTNOTE_RE = re.compile(r"\[\d{1,3}\]")
 
 # Real Word footnotes/endnotes get auto-labeled "Endnotes" on import (see
 # `add_endnotes_header_if_exists`'s `_match_endnotes`). A subsection literally headed
@@ -1731,24 +1731,30 @@ def find_unconverted_footnotes(nofo):
 
     NOFO Builder's import process converts real Word footnotes/endnotes (inserted via
     Word's References > Insert Footnote/Endnote tool) into linked endnotes, wrapping the
-    in-text reference in an `<a>` tag recognized by `get_footnote_type` (eg,
-    `<a href="#footnote-1">[1]</a>`), and labelling the endnotes list "Endnotes" on import.
+    in-text reference in a link (eg, `<a href="#footnote-1">[1]</a>`), and labelling
+    the endnotes list "Endnotes" on import.
     A footnote reference that was typed manually has no such link, so it survives import
-    unlinked and won't work in the final PDF. This function looks for two signs of that:
+    unlinked and won't work in the final PDF. To avoid treating unrelated bracketed
+    numbers as footnotes, this function requires the first structural signal before it
+    considers the second:
 
     1. A subsection heading (h2-h6) literally titled "Footnotes" - the un-converted
        counterpart of the "Endnotes" heading NOFO Builder adds on a successful import.
-    2. A "[1]"-style reference elsewhere in a subsection's body that isn't wrapped in a
-       recognized footnote/endnote link (eg, an in-text citation like "...evidence[1]").
+    2. A short "[1]"-style reference elsewhere in the document that isn't inside a link
+       or code element (eg, an in-text citation like "...evidence[1]").
+
+    The Footnotes subsection is included once in the result as the primary structural
+    signal, followed by any unlinked numeric reference locations. If there is no
+    Footnotes subsection, the function returns no results.
 
     Args:
         nofo (Nofo): A Nofo object which contains sections and subsections. Each
                      subsection's body is expected to be in markdown format.
 
     Returns:
-        list of dict: A list of dictionaries, one per unconverted footnote found, each
-                      with the section and subsection it was found in, and the raw
-                      footnote text. The structure is as follows:
+        list of dict: A list of dictionaries for locations to review, each with the
+                      section and subsection it was found in, and the raw signal text.
+                      The structure is as follows:
                       [
                           {
                               "section": <Section object>,
@@ -1758,46 +1764,57 @@ def find_unconverted_footnotes(nofo):
                           ...
                       ]
     """
-    unconverted_footnotes = []
+    subsections = []
 
     for section in nofo.sections.all().order_by("order"):
         for subsection in section.subsections.all().order_by("order"):
-            if (
-                subsection.tag in FOOTNOTE_HEADING_TAGS
-                and UNCONVERTED_FOOTNOTES_HEADING_RE.match(
-                    (subsection.name or "").strip()
-                )
-            ):
+            subsections.append((section, subsection))
+
+    has_footnotes_heading = any(
+        subsection.tag in FOOTNOTE_HEADING_TAGS
+        and UNCONVERTED_FOOTNOTES_HEADING_RE.match((subsection.name or "").strip())
+        for _, subsection in subsections
+    )
+    if not has_footnotes_heading:
+        return []
+
+    unconverted_footnotes = []
+
+    for section, subsection in subsections:
+        if (
+            subsection.tag in FOOTNOTE_HEADING_TAGS
+            and UNCONVERTED_FOOTNOTES_HEADING_RE.match((subsection.name or "").strip())
+        ):
+            unconverted_footnotes.append(
+                {
+                    "section": section,
+                    "subsection": subsection,
+                    "footnote_text": subsection.name,
+                }
+            )
+            # This subsection is the structural prerequisite and is already
+            # reported, so don't count its note-list entries as references too.
+            continue
+
+        soup = BeautifulSoup(
+            markdown.markdown(subsection.body, extensions=["extra"]), "html.parser"
+        )
+
+        for text_node in soup.find_all(string=UNCONVERTED_FOOTNOTE_RE):
+            # Existing links already have a working destination (or are handled by
+            # the broken-links warning), and bracketed numbers in code are content,
+            # not reference markers.
+            if text_node.find_parent(("a", "code", "pre")):
+                continue
+
+            for match in UNCONVERTED_FOOTNOTE_RE.finditer(text_node):
                 unconverted_footnotes.append(
                     {
                         "section": section,
                         "subsection": subsection,
-                        "footnote_text": subsection.name,
+                        "footnote_text": match.group(),
                     }
                 )
-                # this subsection's body is the footnotes list itself; it's already
-                # flagged by its heading, so skip the in-body scan below for it
-                continue
-
-            soup = BeautifulSoup(
-                markdown.markdown(subsection.body, extensions=["extra"]), "html.parser"
-            )
-
-            for text_node in soup.find_all(string=UNCONVERTED_FOOTNOTE_RE):
-                parent_link = text_node.find_parent("a")
-                # skip real footnote/endnote references, which are already wrapped in a
-                # recognized link on import
-                if parent_link and get_footnote_type(parent_link):
-                    continue
-
-                for match in UNCONVERTED_FOOTNOTE_RE.finditer(text_node):
-                    unconverted_footnotes.append(
-                        {
-                            "section": section,
-                            "subsection": subsection,
-                            "footnote_text": match.group(),
-                        }
-                    )
 
     return unconverted_footnotes
 

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -398,7 +398,7 @@ Edit “{{ nofo|nofo_name }}”
                     {% endfor %}
                   </ol>
                   <p>
-                    These footnotes weren't recognized or converted on import, so they won't link correctly in the final PDF. In the source Word document, recreate them with Word's built-in endnote tool (References &gt; Insert Endnote) instead of typing them manually, then reimport the document. {% include "includes/feedback_link.html" with link_text="Give us feedback" %} if you need help.
+                    These footnotes weren't recognized or converted on import, so they won't link correctly in the final PDF. In the source Word document, recreate them with Word's built-in endnote tool (References &gt; Insert Endnote) instead of typing them manually, then reimport the document. For troubleshooting support, submit a request using the {% include "includes/feedback_link.html" with link_text="NOFO Builder Feedback Form" %}.
                   </p>
                 </div>
               </details>

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -398,7 +398,9 @@ Edit “{{ nofo|nofo_name }}”
                     {% endfor %}
                   </ol>
                   <p>
-                    These footnotes weren't recognized or converted on import, so they won't link correctly in the final PDF. In the source Word document, recreate them with Word's built-in endnote tool (References &gt; Insert Endnote) instead of typing them manually, then reimport the document. For troubleshooting support, submit a request using the {% include "includes/feedback_link.html" with link_text="NOFO Builder Feedback Form" %}.
+                    These footnotes weren't recognized or converted on import, so they won't link correctly in the final PDF. Endnotes must be added using Word's built-in endnote tool — not typed manually.
+                    <a class="usa-link usa-link--external" rel="noreferrer" target="_blank" href="https://support.microsoft.com/en-us/office/insert-footnotes-and-endnotes-in-word-61f3fb1a-4717-414c-9a8f-015a5f3ff4cb">Learn how to use Microsoft Word's endnote tool</a>.
+                    Fix this in the source Word document, then reimport it. For troubleshooting support, submit a request using the {% include "includes/feedback_link.html" with link_text="NOFO Builder Feedback Form" %}.
                   </p>
                 </div>
               </details>

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -273,6 +273,19 @@ Edit “{{ nofo|nofo_name }}”
           </span>
         </button>
       {% endif %}
+      {% if has_unconverted_footnotes %}
+        <button id="tab-4"
+                type="button"
+                role="tab"
+                class="secondary-darker"
+                aria-selected="false"
+                aria-controls="tabpanel-4"
+                tabindex="-1">
+          <span class="focus">
+            Check unconverted footnotes ({{ unconverted_footnotes|length }})
+          </span>
+        </button>
+      {% endif %}
     </div>
     {% if has_broken_links %}
       <div id="tabpanel-1" role="tabpanel" class="accent-warm-dark" tabindex="0" aria-labelledby="tab-1">
@@ -355,6 +368,37 @@ Edit “{{ nofo|nofo_name }}”
                   <p>
                     <a href="{% url 'nofos:nofo_edit_metadata' nofo.id %}">Edit NOFO metadata</a>
                     before publishing this PDF to Grants.gov. You can still preview or download the PDF while this warning is present.
+                  </p>
+                </div>
+              </details>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    {% if has_unconverted_footnotes %}
+      <div id="tabpanel-4" role="tabpanel" class="secondary-darker is-hidden" tabindex="0" aria-labelledby="tab-4">
+        <div class="usa-alert">
+          <div class="usa-alert__body">
+            <h3 class="usa-alert__heading">Warning: some footnotes weren't converted</h3>
+            <div>
+              <details>
+                <summary>
+                  {% if unconverted_footnotes|length == 1 %}
+                  <span>There is 1 unconverted footnote</span>
+                  {% else %}
+                  <span>There are {{ unconverted_footnotes|length }} unconverted footnotes</span>
+                  {% endif %}
+                </summary>
+                <div>
+                  <ol class="usa-list usa-list--no-max-width">
+                    {% for unconverted_footnote in unconverted_footnotes %}
+                    <li><a href="#{{ unconverted_footnote.subsection.html_id }}">{{ unconverted_footnote.footnote_text }}</a> ({{ unconverted_footnote.section.name }}, {{ unconverted_footnote.subsection|subsection_name_or_order }})</li>
+                    {% endfor %}
+                  </ol>
+                  <p>
+                    These footnotes weren't recognized or converted on import, so they won't link correctly in the final PDF. In the source Word document, recreate them with Word's built-in endnote tool (References &gt; Insert Endnote) instead of typing them manually, then reimport the document. {% include "includes/feedback_link.html" with link_text="Give us feedback" %} if you need help.
                   </p>
                 </div>
               </details>

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -241,9 +241,11 @@ Edit “{{ nofo|nofo_name }}”
                 role="tab"
                 class="accent-warm-dark"
                 aria-selected="true"
-                aria-controls="tabpanel-1">
+                aria-controls="tabpanel-1"
+                aria-label="Check broken links ({{ broken_links|length }})">
           <span class="focus">
-            Check broken links ({{ broken_links|length }})
+            <span class="nofo_edit--tab-label">Check broken links</span>
+            <span class="nofo_edit--tab-count">({{ broken_links|length }})</span>
           </span>
         </button>
       {% endif %}
@@ -254,9 +256,11 @@ Edit “{{ nofo|nofo_name }}”
                 class="secondary-darker"
                 aria-selected="false"
                 aria-controls="tabpanel-2"
-                tabindex="-1">
+                tabindex="-1"
+                aria-label="Check heading levels ({{ heading_errors|length }})">
           <span class="focus">
-            Check heading levels ({{ heading_errors|length }})
+            <span class="nofo_edit--tab-label">Check heading levels</span>
+            <span class="nofo_edit--tab-count">({{ heading_errors|length }})</span>
           </span>
         </button>
       {% endif %}
@@ -267,9 +271,11 @@ Edit “{{ nofo|nofo_name }}”
                 class="secondary-darker"
                 aria-selected="false"
                 aria-controls="tabpanel-3"
-                tabindex="-1">
+                tabindex="-1"
+                aria-label="Check PDF metadata ({{ missing_metadata_fields|length }})">
           <span class="focus">
-            Check PDF metadata ({{ missing_metadata_fields|length }})
+            <span class="nofo_edit--tab-label">Check PDF metadata</span>
+            <span class="nofo_edit--tab-count">({{ missing_metadata_fields|length }})</span>
           </span>
         </button>
       {% endif %}
@@ -280,9 +286,11 @@ Edit “{{ nofo|nofo_name }}”
                 class="secondary-darker"
                 aria-selected="false"
                 aria-controls="tabpanel-4"
-                tabindex="-1">
+                tabindex="-1"
+                aria-label="Check unconverted footnotes ({{ unconverted_footnotes|length }})">
           <span class="focus">
-            Check unconverted footnotes ({{ unconverted_footnotes|length }})
+            <span class="nofo_edit--tab-label">Check unconverted footnotes</span>
+            <span class="nofo_edit--tab-count">({{ unconverted_footnotes|length }})</span>
           </span>
         </button>
       {% endif %}

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -287,9 +287,9 @@ Edit “{{ nofo|nofo_name }}”
                 aria-selected="false"
                 aria-controls="tabpanel-4"
                 tabindex="-1"
-                aria-label="Check unconverted footnotes ({{ unconverted_footnotes|length }})">
+                aria-label="Check possible unconverted footnotes ({{ unconverted_footnotes|length }})">
           <span class="focus">
-            <span class="nofo_edit--tab-label">Check unconverted footnotes</span>
+            <span class="nofo_edit--tab-label">Check possible unconverted footnotes</span>
             <span class="nofo_edit--tab-count">({{ unconverted_footnotes|length }})</span>
           </span>
         </button>
@@ -389,14 +389,14 @@ Edit “{{ nofo|nofo_name }}”
       <div id="tabpanel-4" role="tabpanel" class="secondary-darker is-hidden" tabindex="0" aria-labelledby="tab-4">
         <div class="usa-alert">
           <div class="usa-alert__body">
-            <h3 class="usa-alert__heading">Warning: some footnotes weren't converted</h3>
+            <h3 class="usa-alert__heading">Warning: review possible unconverted footnotes</h3>
             <div>
               <details>
                 <summary>
                   {% if unconverted_footnotes|length == 1 %}
-                  <span>There is 1 unconverted footnote</span>
+                  <span>There is 1 location to review</span>
                   {% else %}
-                  <span>There are {{ unconverted_footnotes|length }} unconverted footnotes</span>
+                  <span>There are {{ unconverted_footnotes|length }} locations to review</span>
                   {% endif %}
                 </summary>
                 <div>
@@ -406,7 +406,7 @@ Edit “{{ nofo|nofo_name }}”
                     {% endfor %}
                   </ol>
                   <p>
-                    These footnotes weren't recognized or converted on import, so they won't link correctly in the final PDF. Endnotes must be added using Word's built-in endnote tool — not typed manually.
+                    NOFO Builder found a Footnotes section that may contain references that didn't convert correctly. Review these locations in the PDF preview. If the references don't link to their notes, endnotes must be added using Word's built-in endnote tool — not typed manually.
                     <a class="usa-link usa-link--external" rel="noreferrer" target="_blank" href="https://support.microsoft.com/en-us/office/insert-footnotes-and-endnotes-in-word-61f3fb1a-4717-414c-9a8f-015a5f3ff4cb">Learn how to use Microsoft Word's endnote tool</a>.
                     Fix this in the source Word document, then reimport it. For troubleshooting support, submit a request using the {% include "includes/feedback_link.html" with link_text="NOFO Builder Feedback Form" %}.
                   </p>

--- a/nofos/nofos/templates/nofos/nofo_edit.html
+++ b/nofos/nofos/templates/nofos/nofo_edit.html
@@ -402,11 +402,11 @@ Edit “{{ nofo|nofo_name }}”
                 <div>
                   <ol class="usa-list usa-list--no-max-width">
                     {% for unconverted_footnote in unconverted_footnotes %}
-                    <li><a href="#{{ unconverted_footnote.subsection.html_id }}">{{ unconverted_footnote.footnote_text }}</a> ({{ unconverted_footnote.section.name }}, {{ unconverted_footnote.subsection|subsection_name_or_order }})</li>
+                    <li><a href="#{% if unconverted_footnote.subsection %}{{ unconverted_footnote.subsection.html_id }}{% else %}{{ unconverted_footnote.section.html_id }}{% endif %}">{{ unconverted_footnote.footnote_text }}</a> ({{ unconverted_footnote.section.name }}{% if unconverted_footnote.subsection %}, {{ unconverted_footnote.subsection|subsection_name_or_order }}{% endif %})</li>
                     {% endfor %}
                   </ol>
                   <p>
-                    NOFO Builder found a Footnotes section that may contain references that didn't convert correctly. Review these locations in the PDF preview. If the references don't link to their notes, endnotes must be added using Word's built-in endnote tool — not typed manually.
+                    NOFO Builder found a Footnotes section that may contain references that didn't convert correctly. Review these locations in the PDF preview. If the references don't link to their notes, endnotes must be added using Word's built-in endnote tool — not typed manually. Make sure reference numbers are sequential with no repeats and that each reference has a corresponding entry.
                     <a class="usa-link usa-link--external" rel="noreferrer" target="_blank" href="https://support.microsoft.com/en-us/office/insert-footnotes-and-endnotes-in-word-61f3fb1a-4717-414c-9a8f-015a5f3ff4cb">Learn how to use Microsoft Word's endnote tool</a>.
                     Fix this in the source Word document, then reimport it. For troubleshooting support, submit a request using the {% include "includes/feedback_link.html" with link_text="NOFO Builder Feedback Form" %}.
                   </p>

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3595,6 +3595,111 @@ class TestFindUnconvertedFootnotes(TestCase):
 
         self.assertEqual(find_unconverted_footnotes(nofo), [])
 
+    def test_find_unconverted_footnotes_accepts_section_level_heading(self):
+        nofo = Nofo.objects.create(
+            title="Test Nofo with section-level Footnotes", opdiv="test opdiv"
+        )
+        content_section = Section.objects.create(
+            nofo=nofo, name="Main content", html_id="main-content", order=1
+        )
+        Subsection.objects.create(
+            section=content_section,
+            name="Evidence",
+            tag="h3",
+            html_id="evidence",
+            body="This claim has a manually typed reference [1].",
+            order=1,
+        )
+        footnotes_section = Section.objects.create(
+            nofo=nofo, name="Footnotes", html_id="footnotes", order=2
+        )
+        Subsection.objects.create(
+            section=footnotes_section,
+            name="",
+            tag="",
+            body="[1] First note.\n\n[2] Second note.",
+            order=1,
+        )
+
+        results = find_unconverted_footnotes(nofo)
+
+        self.assertEqual(
+            [result["footnote_text"] for result in results], ["[1]", "Footnotes"]
+        )
+        section_heading_result = results[1]
+        self.assertEqual(section_heading_result["section"], footnotes_section)
+        self.assertIsNone(section_heading_result["subsection"])
+
+    def test_find_unconverted_footnotes_accepts_h7_subsection_heading(self):
+        nofo = Nofo.objects.create(
+            title="Test Nofo with h7 Footnotes", opdiv="test opdiv"
+        )
+        section = Section.objects.create(nofo=nofo, name="Main content", order=1)
+        Subsection.objects.create(
+            section=section,
+            name="Footnotes",
+            tag="h7",
+            body="[1] First note.\n\n[2] Second note.",
+            order=1,
+        )
+
+        results = find_unconverted_footnotes(nofo)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["footnote_text"], "Footnotes")
+
+    def test_find_unconverted_footnotes_allows_trailing_heading_colon(self):
+        for heading_location, section_name, subsection_name, tag in (
+            ("section", "Footnote:", "", ""),
+            ("subsection", "Main content", "Footnotes :", "h3"),
+        ):
+            with self.subTest(heading_location=heading_location):
+                nofo = Nofo.objects.create(
+                    title=f"Test Nofo with colon in {heading_location}",
+                    opdiv="test opdiv",
+                )
+                section = Section.objects.create(nofo=nofo, name=section_name, order=1)
+                Subsection.objects.create(
+                    section=section,
+                    name=subsection_name,
+                    tag=tag,
+                    body="[1] First note.",
+                    order=1,
+                )
+
+                results = find_unconverted_footnotes(nofo)
+
+                self.assertEqual(len(results), 1)
+                self.assertEqual(
+                    results[0]["footnote_text"],
+                    section_name if heading_location == "section" else subsection_name,
+                )
+
+    def test_find_unconverted_footnotes_rejects_similar_non_heading_names(self):
+        nofo = Nofo.objects.create(
+            title="Test Nofo with non-footnotes headings", opdiv="test opdiv"
+        )
+        endnotes_section = Section.objects.create(nofo=nofo, name="Endnotes", order=1)
+        Subsection.objects.create(
+            section=endnotes_section,
+            name="",
+            tag="",
+            body="A bracketed number [1].",
+            order=1,
+        )
+        content_section = Section.objects.create(
+            nofo=nofo, name="Main content", order=2
+        )
+        Subsection.objects.create(
+            section=content_section,
+            name="Footnotes guidance",
+            tag="h3",
+            body="A bracketed number [2].",
+            order=1,
+        )
+
+        self.assertEqual(find_unconverted_footnotes(nofo), [])
+
     def test_find_unconverted_footnotes_returns_empty_list_for_no_footnotes(self):
         nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
         subsection = Subsection.objects.get(name="Subsection without any footnotes")

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3486,6 +3486,33 @@ class TestFindUnconvertedFootnotes(TestCase):
             order=8,
         )
 
+        # legitimate bracketed numeric content should not be treated as a footnote
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with bracketed year",
+            tag="h3",
+            body="The prior edition [2025] remains available.",
+            order=9,
+        )
+
+        # code-like tokens should also be ignored
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with code token",
+            tag="h3",
+            body="Use the token `[123]`.",
+            order=10,
+        )
+
+        # a working numeric external link is already linked and should be ignored
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with external numeric link",
+            tag="h3",
+            body='<a href="https://example.com/source">[1]</a> is the source.',
+            order=11,
+        )
+
     def test_find_unconverted_footnotes_identifies_manually_typed_footnotes(self):
         nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
         unconverted_footnotes = find_unconverted_footnotes(nofo)
@@ -3531,6 +3558,42 @@ class TestFindUnconvertedFootnotes(TestCase):
         subsection_names = [f["subsection"].name for f in unconverted_footnotes]
         self.assertNotIn("Subsection with a converted footnote", subsection_names)
         self.assertNotIn("Subsection with a converted HTML footnote", subsection_names)
+
+    def test_find_unconverted_footnotes_ignores_bracketed_year(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        subsection_names = [f["subsection"].name for f in unconverted_footnotes]
+        self.assertNotIn("Subsection with bracketed year", subsection_names)
+
+    def test_find_unconverted_footnotes_ignores_code_token(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        subsection_names = [f["subsection"].name for f in unconverted_footnotes]
+        self.assertNotIn("Subsection with code token", subsection_names)
+
+    def test_find_unconverted_footnotes_ignores_working_external_numeric_link(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        subsection_names = [f["subsection"].name for f in unconverted_footnotes]
+        self.assertNotIn("Subsection with external numeric link", subsection_names)
+
+    def test_find_unconverted_footnotes_requires_footnotes_heading(self):
+        nofo = Nofo.objects.create(
+            title="Test Nofo without Footnotes heading", opdiv="test opdiv"
+        )
+        section = Section.objects.create(nofo=nofo, name="Test Section", order=1)
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with bracketed number",
+            tag="h3",
+            body="This is valid content [1], not a footnote signal by itself.",
+            order=1,
+        )
+
+        self.assertEqual(find_unconverted_footnotes(nofo), [])
 
     def test_find_unconverted_footnotes_returns_empty_list_for_no_footnotes(self):
         nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -45,6 +45,7 @@ from .nofo import (
     find_matches_with_context,
     find_same_or_higher_heading_levels_consecutive,
     find_subsections_with_nofo_field_value,
+    find_unconverted_footnotes,
     get_cover_image,
     get_nofo_action_links,
     get_sections_from_soup,
@@ -3404,6 +3405,140 @@ class TestFindBrokenLinks(TestCase):
             )
         ]
         self.assertEqual(len(valid_links), 0)
+
+
+class TestFindUnconvertedFootnotes(TestCase):
+    def setUp(self):
+        nofo = Nofo.objects.create(
+            title="Test Nofo TestFindUnconvertedFootnotes", opdiv="test opdiv"
+        )
+        section = Section.objects.create(nofo=nofo, name="Test Section", order=1)
+
+        # a footnote reference typed manually as plain text: not a link at all
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with a manually typed footnote",
+            tag="h3",
+            body="This claim needs a citation[1] to back it up.",
+            order=2,
+        )
+
+        # a properly converted docx footnote reference: wrapped in a recognized link
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with a converted footnote",
+            tag="h3",
+            body='This is a real footnote<sup><a href="#footnote-1" id="footnote-ref-1">[1]</a></sup> reference.',
+            order=3,
+        )
+
+        # a properly converted HTML-export (Google Docs style) footnote reference
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with a converted HTML footnote",
+            tag="h3",
+            body='This is a real footnote<a href="#ftnt1">[1]</a> reference.',
+            order=4,
+        )
+
+        # a subsection with no footnote-shaped text at all
+        Subsection.objects.create(
+            section=section,
+            name="Subsection without any footnotes",
+            tag="h3",
+            body="This subsection has no footnotes.",
+            order=5,
+        )
+
+        # multiple manually typed footnotes in one subsection
+        Subsection.objects.create(
+            section=section,
+            name="Subsection with multiple manually typed footnotes",
+            tag="h3",
+            body="First claim[1] and second claim[2] both need citations.",
+            order=6,
+        )
+
+        # a "Footnotes" heading (the GSAM-style, un-converted counterpart of the
+        # "Endnotes" heading NOFO Builder adds on a successful import), whose body is
+        # the actual footnotes list, unlinked
+        Subsection.objects.create(
+            section=section,
+            name="Footnotes",
+            tag="h2",
+            body=(
+                "[1] U.S. Department of Health and Human Services, Office of the "
+                "Assistant Secretary for Planning and Evaluation (ASPE). Access to "
+                "Preventive Services without Cost-Sharing: Evidence from the "
+                "Affordable Care Act (January 2022).\n\n"
+                "[2] [Standards for Developing Trustworthy Clinical Practice "
+                "Guidelines](https://example.com/guidelines)"
+            ),
+            order=7,
+        )
+
+        # a properly converted "Endnotes" heading should never be flagged
+        Subsection.objects.create(
+            section=section,
+            name="Endnotes",
+            tag="h2",
+            body='<ol><li id="footnote-1">A real, converted endnote.</li></ol>',
+            order=8,
+        )
+
+    def test_find_unconverted_footnotes_identifies_manually_typed_footnotes(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        self.assertEqual(len(unconverted_footnotes), 4)
+        self.assertEqual(
+            [f["subsection"].name for f in unconverted_footnotes],
+            [
+                "Subsection with a manually typed footnote",
+                "Subsection with multiple manually typed footnotes",
+                "Subsection with multiple manually typed footnotes",
+                "Footnotes",
+            ],
+        )
+        self.assertEqual(
+            [f["footnote_text"] for f in unconverted_footnotes],
+            ["[1]", "[1]", "[2]", "Footnotes"],
+        )
+
+    def test_find_unconverted_footnotes_identifies_footnotes_heading(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        footnotes_heading_hits = [
+            f for f in unconverted_footnotes if f["subsection"].name == "Footnotes"
+        ]
+        # the "Footnotes" heading is reported once, and its body isn't separately
+        # scanned for "[1]"/"[2]" references (they're implied by the heading itself)
+        self.assertEqual(len(footnotes_heading_hits), 1)
+        self.assertEqual(footnotes_heading_hits[0]["footnote_text"], "Footnotes")
+
+    def test_find_unconverted_footnotes_ignores_endnotes_heading(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        subsection_names = [f["subsection"].name for f in unconverted_footnotes]
+        self.assertNotIn("Endnotes", subsection_names)
+
+    def test_find_unconverted_footnotes_ignores_converted_footnotes(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        subsection_names = [f["subsection"].name for f in unconverted_footnotes]
+        self.assertNotIn("Subsection with a converted footnote", subsection_names)
+        self.assertNotIn("Subsection with a converted HTML footnote", subsection_names)
+
+    def test_find_unconverted_footnotes_returns_empty_list_for_no_footnotes(self):
+        nofo = Nofo.objects.get(title="Test Nofo TestFindUnconvertedFootnotes")
+        subsection = Subsection.objects.get(name="Subsection without any footnotes")
+        unconverted_footnotes = find_unconverted_footnotes(nofo)
+
+        subsection_names = [f["subsection"].name for f in unconverted_footnotes]
+        self.assertNotIn(subsection.name, subsection_names)
 
 
 class TestFindH7Headers(TestCase):

--- a/nofos/nofos/tests_nofos/test_unconverted_footnotes_warning.py
+++ b/nofos/nofos/tests_nofos/test_unconverted_footnotes_warning.py
@@ -1,0 +1,64 @@
+from bs4 import BeautifulSoup
+from django.test import Client, TestCase
+from django.urls import reverse
+from users.models import BloomUser
+
+from nofos.models import Nofo, Section, Subsection
+
+
+class NofoUnconvertedFootnotesWarningTests(TestCase):
+    def setUp(self):
+        user = BloomUser.objects.create_user(
+            email="unconverted-footnotes@example.com",
+            password="testpass123",
+            group="bloom",
+            force_password_reset=False,
+        )
+        self.client = Client()
+        self.client.force_login(user)
+        self.nofo = Nofo.objects.create(
+            title="Unconverted footnotes warning test",
+            short_name="unconverted-footnotes-warning",
+            number="TEST-840",
+            opdiv="TEST",
+            group="bloom",
+            status="draft",
+        )
+        footnotes_section = Section.objects.create(
+            nofo=self.nofo,
+            name="Footnotes",
+            html_id="footnotes",
+            order=1,
+        )
+        Subsection.objects.create(
+            section=footnotes_section,
+            name="",
+            tag="",
+            body="[1] First manually typed note.\n\n[2] Second manually typed note.",
+            order=1,
+        )
+        self.edit_url = reverse("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
+
+    def test_section_level_warning_links_to_section_once_and_includes_required_copy(
+        self,
+    ):
+        response = self.client.get(self.edit_url)
+        soup = BeautifulSoup(response.content, "html.parser")
+
+        self.assertTrue(response.context["has_unconverted_footnotes"])
+        self.assertEqual(len(response.context["unconverted_footnotes"]), 1)
+
+        tab = soup.find(id="tab-4")
+        panel = soup.find(id="tabpanel-4")
+        self.assertIsNotNone(tab)
+        self.assertEqual(
+            tab.get("aria-label"), "Check possible unconverted footnotes (1)"
+        )
+        location_link = panel.select_one("ol li a")
+        self.assertEqual(location_link.get("href"), "#footnotes")
+        self.assertEqual(location_link.get_text(strip=True), "Footnotes")
+
+        panel_text = panel.get_text(" ", strip=True)
+        self.assertIn("There is 1 location to review", panel_text)
+        self.assertIn("reference numbers are sequential with no repeats", panel_text)
+        self.assertIn("each reference has a corresponding entry", panel_text)

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -107,6 +107,7 @@ from .nofo import (
     find_matches_with_context,
     find_same_or_higher_heading_levels_consecutive,
     find_subsections_with_nofo_field_value,
+    find_unconverted_footnotes,
     get_cover_image,
     get_nofo_action_links,
     get_sections_from_soup,
@@ -462,6 +463,7 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
         context["heading_errors"] = find_same_or_higher_heading_levels_consecutive(
             self.object
         ) + find_incorrectly_nested_heading_levels(self.object)
+        context["unconverted_footnotes"] = find_unconverted_footnotes(self.object)
         context["page_breaks_count"] = count_page_breaks_nofo(self.object)
 
         context["side_nav_headings"] = get_side_nav_links(self.object)
@@ -493,6 +495,7 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
         context["has_missing_metadata"] = len(context["missing_metadata_fields"])
         context["has_broken_links"] = len(context["broken_links"])
         context["has_heading_errors"] = len(context["heading_errors"])
+        context["has_unconverted_footnotes"] = len(context["unconverted_footnotes"])
         context["has_external_links"] = len(
             context["external_links"]
         ) and self.object.status in ("draft", "active", "ready-for-qa", "paused")
@@ -500,6 +503,7 @@ class NofosEditView(GroupAccessObjectMixin, DetailView):
             context["has_missing_metadata"]
             or context["has_broken_links"]
             or context["has_heading_errors"]
+            or context["has_unconverted_footnotes"]
             or context["has_external_links"]
         )
 


### PR DESCRIPTION
## Summary

NOFO Builder is designed to convert all Word document references — footnotes or endnotes — into linked endnotes on import. Some Word templates (eg, GSAM's export template) produce footnotes that aren't real Word footnote/endnote fields, just manually typed text styled to look like one. These survive import as plain, unlinked text with no way to fix them in-app today; users have to notice the problem, go correct the source Word doc, and reimport.

This adds a warning to the existing top-of-page warnings group (alongside broken links, heading errors, and missing PDF metadata) that detects this and tells users how to fix it, and fixes a responsive layout gap in that warnings tab row along the way.

Closes HHS/simpler-grants-pdf-builder#840.

## What changed

- **`nofos/nofos/nofo.py`** — new `find_unconverted_footnotes(nofo)`, which flags two signs of an unconverted footnote:
  1. A subsection heading (h2–h6) literally titled **"Footnotes"** — the broken counterpart of the "Endnotes" heading NOFO Builder auto-adds on a successful import.
  2. A `[1]`-style reference elsewhere in a subsection's body that isn't wrapped in a recognized footnote/endnote link (catches stray in-text citation markers too).
- **`nofos/nofos/views.py`** — wires the new check into `NofosEditView.get_context_data()`, folded into the existing `has_warnings` flag.
- **`nofos/nofos/templates/nofos/nofo_edit.html`** — new "Check unconverted footnotes" tab/panel in the warnings group. Copy is aligned with the "Adding endnotes in Word" FAQ ("Endnotes must be added using Word's built-in endnote tool — not typed manually"), links out to the same Microsoft Word endnote-tool support article, and points users to the NOFO Builder Feedback Form for troubleshooting support.
- **`nofos/bloom_nofos/static/styles.css`** — on small screens, the warnings tab row (now up to 4 tabs) had no responsive handling and would wrap awkwardly. Tabs now shrink to fit on one row and truncate their label text with an ellipsis, while each tab's issue count (eg, "(3)") stays visible and un-truncated so severity is still scannable at a glance. Each tab also gets a full-text `aria-label` so the truncation is purely visual and doesn't affect assistive technology.
- **`nofos/nofos/test_nofo.py`** — new `TestFindUnconvertedFootnotes` test class.

## Tests

- 5 new unit tests covering: manually typed footnotes (plain `[1]`/`[2]` text), the "Footnotes" heading signal, correctly converted docx and HTML-export footnotes being ignored, the "Endnotes" heading never being flagged, and subsections with no footnotes at all.
- Full test suite (1295 tests across `nofos.test_nofo` and `nofos.tests_nofos`) passes with no regressions, including existing tests that assert the exact rendered tab markup (`test_metadata_warning`, `test_side_navigation`).

## Acceptance criteria (from HHS/simpler-grants-pdf-builder#840)

- [x] Importing a Word doc with unconverted/unrecognized footnotes triggers a warning in the existing top-of-page warnings group
- [x] Warning message explains the issue and gives correction steps consistent with the "Adding endnotes in Word" FAQ
- [x] Warning does not fire for documents with correctly formatted, converted endnotes
- [x] Reimporting a corrected document clears the warning — the check re-runs live against `Subsection.body` on every page render, the same pattern used by the other three warnings (broken links, heading errors, missing metadata), so there's no stale state to clear
