### PR TITLE
Add "Add end notes" action to NOFO actions menu

### DIFF
--- a/nofos/nofos/forms.py
+++ b/nofos/nofos/forms.py
@@ -327,6 +327,18 @@ class SubsectionCreateForm(forms.ModelForm):
         return cleaned_data
 
 
+# Used only by NofoAddEndNotesSectionView. The Endnotes section's name and
+# html_id are fixed (not user-editable) so the ".section--endnotes" CSS hook
+# and the "Endnotes" import-detection convention keep working; the only
+# thing a user can change is the initial subsection's content.
+class EndNotesSectionCreateForm(forms.ModelForm):
+    body = MartorFormField(required=False, label="Subsection content")
+
+    class Meta:
+        model = Subsection
+        fields = ["body"]
+
+
 # Simple form for URL input
 class CheckNOFOLinkSingleForm(forms.Form):
     url = forms.URLField(

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1361,6 +1361,41 @@ def _update_link_statuses(all_links):
                 print(f"Error checking link {link['url']}: {e}")
 
 
+END_NOTES_SECTION_NAME = "Endnotes"
+END_NOTES_SECTION_HTML_ID = "endnotes"
+
+# Matches the "docx-style" endnote id/href convention this app already
+# recognizes elsewhere (see get_footnote_type in templatetags/utils), so the
+# link-numbering/backlink logic that already runs on subsection bodies keeps
+# working on this content unmodified.
+END_NOTES_PLACEHOLDER_BODY = """<ol>
+ <li id="endnote-1" tabindex="-1">
+  <p>
+   Placeholder paragraph text goes here. Replace this with your citation or note.
+   <a href="#endnote-ref-1">
+    ↑
+   </a>
+  </p>
+ </li>
+ <li id="endnote-2" tabindex="-1">
+  <p>
+   Placeholder paragraph text goes here.
+   <a href="https://example.com">
+    Placeholder link text goes here
+   </a>
+   .
+   <a href="#endnote-ref-2">
+    ↑
+   </a>
+  </p>
+ </li>
+</ol>"""
+
+
+def nofo_has_end_notes_section(nofo):
+    return nofo.sections.filter(name__iexact=END_NOTES_SECTION_NAME).exists()
+
+
 def get_nofo_action_links(nofo):
     # Canonical action builders
     def _link_compare(nofo):
@@ -1408,32 +1443,62 @@ def get_nofo_action_links(nofo):
             "href": reverse_lazy("nofos:nofo_find_replace", args=[nofo.pk]),
         }
 
+    def _link_add_end_notes(nofo):
+        return {
+            "key": "add_end_notes",
+            "label": "Add end notes",
+            "href": reverse_lazy("nofos:section_add_end_notes", args=[nofo.pk]),
+        }
+
     # Status → allowed actions
     _STATUS_ACTIONS = {
         "draft": (
             "find_replace",
             "compare",
             "duplicate",
+            "add_end_notes",
             "reimport",
             "export",
             "delete",
         ),
-        "active": ("find_replace", "compare", "duplicate", "reimport", "export"),
-        "ready-for-qa": ("find_replace", "compare", "duplicate", "reimport", "export"),
+        "active": (
+            "find_replace",
+            "compare",
+            "duplicate",
+            "add_end_notes",
+            "reimport",
+            "export",
+        ),
+        "ready-for-qa": (
+            "find_replace",
+            "compare",
+            "duplicate",
+            "add_end_notes",
+            "reimport",
+            "export",
+        ),
         "review": (
             "find_replace",
             "compare",
             "duplicate",
+            "add_end_notes",
             "export",
         ),
         "doge": (
             "find_replace",
             "compare",
             "duplicate",
+            "add_end_notes",
             "export",
         ),  # Deputy Secretary review
         "published": ("export",),
-        "paused": ("find_replace", "compare", "duplicate", "export"),
+        "paused": (
+            "find_replace",
+            "compare",
+            "duplicate",
+            "add_end_notes",
+            "export",
+        ),
         "cancelled": ("export",),
     }
 
@@ -1445,6 +1510,7 @@ def get_nofo_action_links(nofo):
         "find_replace": lambda: _link_find_replace(nofo),
         "compare": lambda: _link_compare(nofo),
         "duplicate": lambda: _link_duplicate(nofo),
+        "add_end_notes": lambda: _link_add_end_notes(nofo),
         "reimport": lambda: _link_reimport(nofo),
         "export": lambda: _link_export(nofo),
         "delete": lambda: _link_delete(nofo),
@@ -1452,6 +1518,10 @@ def get_nofo_action_links(nofo):
 
     links = []
     for key in actions:
+        # A NOFO can only ever have one Endnotes section.
+        if key == "add_end_notes" and nofo_has_end_notes_section(nofo):
+            continue
+
         build = link_builders.get(key)
         if build:
             links.append(build())

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -1446,7 +1446,7 @@ def get_nofo_action_links(nofo):
     def _link_add_end_notes(nofo):
         return {
             "key": "add_end_notes",
-            "label": "Add end notes",
+            "label": "Add Endnotes",
             "href": reverse_lazy("nofos:section_add_end_notes", args=[nofo.pk]),
         }
 

--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -33,8 +33,8 @@ from .import_transforms import (
 )
 from .models import Nofo, Section, Subsection
 from .nofo_markdown import MISSING_ALT_TEXT_ATTR, PRESERVE_BOOKMARK_TARGET_ATTR, md
-from .policy_language import detect_policy_language_status, get_candidate_slots
 from .pdf_metadata import normalize_pdf_metadata_value
+from .policy_language import detect_policy_language_status, get_candidate_slots
 from .utils import (
     add_html_id_to_subsection,
     clean_string,
@@ -1393,7 +1393,7 @@ END_NOTES_PLACEHOLDER_BODY = """<ol>
 
 
 def nofo_has_end_notes_section(nofo):
-    return nofo.sections.filter(name__iexact=END_NOTES_SECTION_NAME).exists()
+    return nofo.sections.filter(html_id=END_NOTES_SECTION_HTML_ID).exists()
 
 
 def get_nofo_action_links(nofo):

--- a/nofos/nofos/templates/nofos/section_add_end_notes.html
+++ b/nofos/nofos/templates/nofos/section_add_end_notes.html
@@ -2,7 +2,7 @@
 {% load static whitespaceless %}
 
 {% block title %}
-  Add end notes
+  Add Endnotes
 {% endblock %}
 
 {% block css %}
@@ -18,7 +18,7 @@
     <a class="usa-button--icon--before usa-button--icon--usa-blue usa-button--arrow_back" href="{{ cancel_url }}">Back</a>
   </div>
   <div class="section_edit--header">
-    <h1 class="font-heading-xl margin-y-0">Add end notes</h1>
+    <h1 class="font-heading-xl margin-y-0">Add Endnotes</h1>
   </div>
 
   <p>

--- a/nofos/nofos/templates/nofos/section_add_end_notes.html
+++ b/nofos/nofos/templates/nofos/section_add_end_notes.html
@@ -1,0 +1,81 @@
+{% extends 'base.html' %}
+{% load static whitespaceless %}
+
+{% block title %}
+  Add end notes
+{% endblock %}
+
+{% block css %}
+  <link href="{% static 'plugins/css/bootstrap.min.css' %}" type="text/css" media="all" rel="stylesheet">
+  <link href="{% static 'plugins/css/ace.min.css' %}" type="text/css" media="all" rel="stylesheet">
+  <link href="{% static 'martor/css/martor.bootstrap.min.css' %}" type="text/css" media="all" rel="stylesheet">
+{% endblock %}
+
+{% block body_class %}section_add_end_notes{% endblock %}
+
+{% block content %}
+  <div class="back-link font-body-md margin-bottom-105">
+    <a class="usa-button--icon--before usa-button--icon--usa-blue usa-button--arrow_back" href="{{ cancel_url }}">Back</a>
+  </div>
+  <div class="section_edit--header">
+    <h1 class="font-heading-xl margin-y-0">Add end notes</h1>
+  </div>
+
+  <p>
+    This adds a new “Endnotes” section to the end of “{{ nofo.title }}”, with a starter list of end notes below.
+    Edit the content now, or save it as-is and edit it later.
+  </p>
+
+  <h2 class="font-serif-lg margin-top-5 margin-bottom-0">Endnotes content</h2>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    <fieldset class="usa-fieldset">
+
+      {% if form.non_field_errors %}
+        <legend class="legend--bootstrap">
+          <div class="usa-error-message">
+            Error: {{ form.non_field_errors.0 }}
+          </div>
+        </legend>
+      {% endif %}
+
+      <!-- body -->
+      <div class="form-group margin-top-4">
+        <label class="usa-label" for="body">Subsection content</label>
+        <div
+        {% whitespaceless %}
+          class="
+                margin-top-1
+                main-martor--container
+                {% if form.errors.body %}
+                  main-martor--container--error
+                {% endif %}
+              "
+        {% endwhitespaceless %} id="{{ form.body.name }}" tabIndex="-1" {% if form.errors.body %}aria-describedby="body--error-message"{% endif %}>
+          {{ form.body }}
+        </div>
+      </div>
+    </fieldset>
+    <div class="form-group">
+      <button class="usa-button usa-button--green margin-top-3" type="submit">Save section</button>
+    </div>
+  </form>
+{% endblock %}
+
+{% block js_footer %}
+  <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/jquery.min.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/bootstrap.min.js' %}"></script>
+
+  <script type="text/javascript" src="{% static 'plugins/js/ace.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/mode-markdown.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/ext-language_tools.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/theme-github.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/typo.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/spellcheck.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/highlight.min.js' %}"></script>
+  <script type="text/javascript" src="{% static 'plugins/js/emojis.min.js' %}"></script>
+  <script type="text/javascript" src="{% static 'martor/js/martor.bootstrap.min.js' %}"></script>
+{% endblock %}

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3183,6 +3183,30 @@ class TestBuildNofoActionLinks(TestCase):
             ["find-replace", "compare", "duplicate", "reimport", "export", "delete"],
         )
 
+    def test_add_end_notes_absent_when_html_id_exists_under_another_name(self):
+        Section.objects.create(
+            nofo=self.nofo,
+            name="References",
+            html_id="endnotes",
+            has_section_page=False,
+        )
+
+        links = get_nofo_action_links(self.nofo)
+
+        self.assertNotIn("add_end_notes", [link["key"] for link in links])
+
+    def test_add_end_notes_present_when_only_section_name_matches(self):
+        Section.objects.create(
+            nofo=self.nofo,
+            name="Endnotes",
+            html_id="references",
+            has_section_page=False,
+        )
+
+        links = get_nofo_action_links(self.nofo)
+
+        self.assertIn("add_end_notes", [link["key"] for link in links])
+
 
 class TestFindExternalLinks(TestCase):
     def setUp(self):

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3061,7 +3061,7 @@ class TestBuildNofoActionLinks(TestCase):
         self._assert_link(
             links[3],
             key="add_end_notes",
-            label="Add end notes",
+            label="Add Endnotes",
             url_name="nofos:section_add_end_notes",
         )
         self._assert_link(

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -3028,7 +3028,15 @@ class TestBuildNofoActionLinks(TestCase):
         links = get_nofo_action_links(self.nofo)
         self.assertEqual(
             [l["key"] for l in links],
-            ["find-replace", "compare", "duplicate", "reimport", "export", "delete"],
+            [
+                "find-replace",
+                "compare",
+                "duplicate",
+                "add_end_notes",
+                "reimport",
+                "export",
+                "delete",
+            ],
         )
 
         self._assert_link(
@@ -3052,19 +3060,25 @@ class TestBuildNofoActionLinks(TestCase):
         )
         self._assert_link(
             links[3],
+            key="add_end_notes",
+            label="Add end notes",
+            url_name="nofos:section_add_end_notes",
+        )
+        self._assert_link(
+            links[4],
             key="reimport",
             label="Re-import NOFO",
             url_name="nofos:nofo_import_overwrite",
         )
         self._assert_link(
-            links[4],
+            links[5],
             key="export",
             label="Export Word doc",
             url_name="nofos:nofo_export",
             external=True,
         )
         self._assert_link(
-            links[5],
+            links[6],
             key="delete",
             label="Delete NOFO",
             url_name="nofos:nofo_archive",
@@ -3078,7 +3092,14 @@ class TestBuildNofoActionLinks(TestCase):
         links = get_nofo_action_links(self.nofo)
         self.assertEqual(
             [l["key"] for l in links],
-            ["find-replace", "compare", "duplicate", "reimport", "export"],
+            [
+                "find-replace",
+                "compare",
+                "duplicate",
+                "add_end_notes",
+                "reimport",
+                "export",
+            ],
         )
 
     def test_ready_for_qa_has_findreplace_compare_reimport(self):
@@ -3088,7 +3109,14 @@ class TestBuildNofoActionLinks(TestCase):
         links = get_nofo_action_links(self.nofo)
         self.assertEqual(
             [l["key"] for l in links],
-            ["find-replace", "compare", "duplicate", "reimport", "export"],
+            [
+                "find-replace",
+                "compare",
+                "duplicate",
+                "add_end_notes",
+                "reimport",
+                "export",
+            ],
         )
 
     def test_review_has_findreplace_compare(self):
@@ -3098,7 +3126,7 @@ class TestBuildNofoActionLinks(TestCase):
         links = get_nofo_action_links(self.nofo)
         self.assertEqual(
             [l["key"] for l in links],
-            ["find-replace", "compare", "duplicate", "export"],
+            ["find-replace", "compare", "duplicate", "add_end_notes", "export"],
         )
 
     def test_doge_has_findreplace_compare(self):
@@ -3108,7 +3136,7 @@ class TestBuildNofoActionLinks(TestCase):
         links = get_nofo_action_links(self.nofo)
         self.assertEqual(
             [l["key"] for l in links],
-            ["find-replace", "compare", "duplicate", "export"],
+            ["find-replace", "compare", "duplicate", "add_end_notes", "export"],
         )
 
     def test_published_has_no_actions(self):
@@ -3128,7 +3156,7 @@ class TestBuildNofoActionLinks(TestCase):
         links = get_nofo_action_links(self.nofo)
         self.assertEqual(
             [l["key"] for l in links],
-            ["find-replace", "compare", "duplicate", "export"],
+            ["find-replace", "compare", "duplicate", "add_end_notes", "export"],
         )
 
     def test_cancelled_has_no_actions(self):
@@ -3137,6 +3165,23 @@ class TestBuildNofoActionLinks(TestCase):
 
         links = get_nofo_action_links(self.nofo)
         self.assertEqual([l["key"] for l in links], ["export"])
+
+    def test_add_end_notes_absent_when_endnotes_section_already_exists(self):
+        self.nofo.status = "draft"
+        self.nofo.save()
+        Section.objects.create(
+            nofo=self.nofo,
+            name="Endnotes",
+            html_id="endnotes",
+            has_section_page=False,
+        )
+
+        links = get_nofo_action_links(self.nofo)
+        self.assertNotIn("add_end_notes", [l["key"] for l in links])
+        self.assertEqual(
+            [l["key"] for l in links],
+            ["find-replace", "compare", "duplicate", "reimport", "export", "delete"],
+        )
 
 
 class TestFindExternalLinks(TestCase):

--- a/nofos/nofos/tests_nofos/test_section_add_end_notes.py
+++ b/nofos/nofos/tests_nofos/test_section_add_end_notes.py
@@ -1,0 +1,138 @@
+from django.contrib.messages import get_messages
+from django.test import Client, TestCase
+from django.urls import reverse
+from users.models import BloomUser
+
+from nofos.models import Nofo, Section, Subsection
+from nofos.nofo import END_NOTES_PLACEHOLDER_BODY
+
+
+class NofoAddEndNotesSectionViewTests(TestCase):
+    def setUp(self):
+        self.user = BloomUser.objects.create_user(
+            email="test@example.com",
+            password="testpass123",
+            force_password_reset=False,
+            group="bloom",
+        )
+        self.client = Client()
+        self.client.login(email="test@example.com", password="testpass123")
+
+        self.nofo = Nofo.objects.create(
+            title="Test NOFO",
+            short_name="test-nofo",
+            number="NOFO-ACF-001",
+            opdiv="ACF",
+            group="bloom",
+            status="draft",
+        )
+
+        self.section = Section.objects.create(
+            nofo=self.nofo,
+            name="Section 1",
+            order=1,
+        )
+
+        self.url = reverse("nofos:section_add_end_notes", kwargs={"pk": self.nofo.id})
+
+    def test_get_request_renders_template_with_prepopulated_body(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "nofos/section_add_end_notes.html")
+        self.assertEqual(
+            response.context["form"].initial.get("body"), END_NOTES_PLACEHOLDER_BODY
+        )
+
+    def test_post_creates_endnotes_section_and_subsection(self):
+        response = self.client.post(
+            self.url, {"body": "<ol><li>My endnote</li></ol>"}, follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+
+        section = self.nofo.sections.get(name="Endnotes")
+        self.assertEqual(section.html_id, "endnotes")
+        self.assertFalse(section.has_section_page)
+        self.assertEqual(section.order, 2)  # after the one existing section
+
+        subsections = section.subsections.all()
+        self.assertEqual(subsections.count(), 1)
+        self.assertEqual(subsections[0].name, "")
+        self.assertEqual(subsections[0].tag, "")
+        self.assertEqual(subsections[0].body, "<ol><li>My endnote</li></ol>")
+        self.assertEqual(subsections[0].order, 1)
+
+        messages = [msg.message for msg in get_messages(response.wsgi_request)]
+        self.assertTrue(any("Added new section" in m for m in messages))
+
+    def test_post_with_no_body_uses_placeholder_content(self):
+        # The form field is not required, but the page always ships with the
+        # placeholder prefilled - simulate a real submit of that value.
+        self.client.post(self.url, {"body": END_NOTES_PLACEHOLDER_BODY}, follow=True)
+
+        section = self.nofo.sections.get(name="Endnotes")
+        self.assertEqual(section.subsections.first().body, END_NOTES_PLACEHOLDER_BODY)
+
+    def test_post_inserts_endnotes_directly_above_existing_modifications_section(self):
+        modifications_section = Section.objects.create(
+            nofo=self.nofo, name="Modifications", html_id="modifications", order=2
+        )
+
+        self.client.post(self.url, {"body": "content"}, follow=True)
+
+        section = self.nofo.sections.get(name="Endnotes")
+        modifications_section.refresh_from_db()
+
+        self.assertEqual(section.order, 2)
+        self.assertEqual(modifications_section.order, 3)
+        self.assertLess(section.order, modifications_section.order)
+
+    def test_get_redirects_when_endnotes_section_already_exists(self):
+        Section.objects.create(
+            nofo=self.nofo, name="Endnotes", html_id="endnotes", order=2
+        )
+
+        response = self.client.get(self.url, follow=True)
+        self.assertRedirects(
+            response, reverse("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
+        )
+
+        messages = [msg.message for msg in get_messages(response.wsgi_request)]
+        self.assertTrue(any("already has an Endnotes section" in m for m in messages))
+
+    def test_post_does_not_duplicate_endnotes_section(self):
+        Section.objects.create(
+            nofo=self.nofo, name="Endnotes", html_id="endnotes", order=2
+        )
+
+        self.client.post(self.url, {"body": "content"}, follow=True)
+
+        self.assertEqual(self.nofo.sections.filter(name="Endnotes").count(), 1)
+        self.assertEqual(Subsection.objects.filter(section__nofo=self.nofo).count(), 0)
+
+    def test_prevents_add_on_published_nofo(self):
+        self.nofo.status = "published"
+        self.nofo.save()
+
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(self.url, {"body": "content"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response, "Endnotes can’t be added to published NOFOs.", status_code=400
+        )
+        self.assertFalse(self.nofo.sections.filter(name="Endnotes").exists())
+
+    def test_prevents_add_on_archived_nofo(self):
+        from django.utils import timezone
+
+        self.nofo.archived = timezone.now().date()
+        self.nofo.save()
+
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(self.url, {"body": "content"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response, "Endnotes can’t be added to archived NOFOs.", status_code=400
+        )
+        self.assertFalse(self.nofo.sections.filter(name="Endnotes").exists())

--- a/nofos/nofos/tests_nofos/test_section_add_end_notes.py
+++ b/nofos/nofos/tests_nofos/test_section_add_end_notes.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.contrib.messages import get_messages
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -86,6 +88,24 @@ class NofoAddEndNotesSectionViewTests(TestCase):
         self.assertEqual(modifications_section.order, 3)
         self.assertLess(section.order, modifications_section.order)
 
+    def test_post_shifts_sections_after_nonfinal_modifications_without_collision(self):
+        modifications_section = Section.objects.create(
+            nofo=self.nofo, name="Modifications", html_id="modifications", order=2
+        )
+        appendix_section = Section.objects.create(
+            nofo=self.nofo, name="Appendix", html_id="appendix", order=3
+        )
+
+        response = self.client.post(self.url, {"body": "content"})
+
+        self.assertEqual(response.status_code, 302)
+        endnotes_section = self.nofo.sections.get(html_id="endnotes")
+        modifications_section.refresh_from_db()
+        appendix_section.refresh_from_db()
+        self.assertEqual(endnotes_section.order, 2)
+        self.assertEqual(modifications_section.order, 3)
+        self.assertEqual(appendix_section.order, 4)
+
     def test_get_redirects_when_endnotes_section_already_exists(self):
         Section.objects.create(
             nofo=self.nofo, name="Endnotes", html_id="endnotes", order=2
@@ -109,6 +129,20 @@ class NofoAddEndNotesSectionViewTests(TestCase):
         self.assertEqual(self.nofo.sections.filter(name="Endnotes").count(), 1)
         self.assertEqual(Subsection.objects.filter(section__nofo=self.nofo).count(), 0)
 
+    def test_post_does_not_duplicate_endnotes_html_id_under_another_name(self):
+        Section.objects.create(
+            nofo=self.nofo,
+            name="References",
+            html_id="endnotes",
+            order=2,
+        )
+
+        response = self.client.post(self.url, {"body": "content"})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.nofo.sections.filter(html_id="endnotes").count(), 1)
+        self.assertEqual(Subsection.objects.filter(section__nofo=self.nofo).count(), 0)
+
     def test_prevents_add_on_published_nofo(self):
         self.nofo.status = "published"
         self.nofo.save()
@@ -121,6 +155,20 @@ class NofoAddEndNotesSectionViewTests(TestCase):
             response, "Endnotes can’t be added to published NOFOs.", status_code=400
         )
         self.assertFalse(self.nofo.sections.filter(name="Endnotes").exists())
+
+    def test_prevents_add_on_published_nofo_with_modifications(self):
+        self.nofo.status = "published"
+        self.nofo.modifications = date(2026, 8, 28)
+        self.nofo.save()
+
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(self.url, {"body": "content"})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response, "Endnotes can’t be added to published NOFOs.", status_code=400
+        )
+        self.assertFalse(self.nofo.sections.filter(html_id="endnotes").exists())
 
     def test_prevents_add_on_archived_nofo(self):
         from django.utils import timezone
@@ -136,3 +184,24 @@ class NofoAddEndNotesSectionViewTests(TestCase):
             response, "Endnotes can’t be added to archived NOFOs.", status_code=400
         )
         self.assertFalse(self.nofo.sections.filter(name="Endnotes").exists())
+
+    def test_checks_group_access_before_revealing_existing_endnotes(self):
+        self.nofo.group = "acf"
+        self.nofo.save()
+        Section.objects.create(
+            nofo=self.nofo,
+            name="Endnotes",
+            html_id="endnotes",
+            order=2,
+        )
+        other_user = BloomUser.objects.create_user(
+            email="other@example.com",
+            password="testpass123",
+            force_password_reset=False,
+            group="hrsa",
+        )
+        self.client.force_login(other_user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)

--- a/nofos/nofos/urls.py
+++ b/nofos/nofos/urls.py
@@ -158,6 +158,11 @@ urlpatterns = [
     ),
     path("<uuid:pk>/print", views.PrintNofoAsPDFView.as_view(), name="print_pdf"),
     path(
+        "<uuid:pk>/section/add-end-notes",
+        views.NofoAddEndNotesSectionView.as_view(),
+        name="section_add_end_notes",
+    ),
+    path(
         "<uuid:pk>/section/<uuid:section_pk>/subsection/create",
         views.NofoSubsectionCreateView.as_view(),
         name="subsection_create",

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -56,6 +56,7 @@ from .forms import (
     NIH_ALLOWED_CHOICES,
     NIH_THEME_DEFAULTS,
     CheckNOFOLinkSingleForm,
+    EndNotesSectionCreateForm,
     InsertOrderSpaceForm,
     NofoAgencyForm,
     NofoApplicationDeadlineForm,
@@ -88,6 +89,9 @@ from .mixins import (
 )
 from .models import THEME_CHOICES, Nofo, Section, Subsection
 from .nofo import (
+    END_NOTES_PLACEHOLDER_BODY,
+    END_NOTES_SECTION_HTML_ID,
+    END_NOTES_SECTION_NAME,
     add_final_subsection_to_step_3,
     add_headings_to_document,
     add_page_breaks_to_headings,
@@ -110,6 +114,7 @@ from .nofo import (
     get_step_2_section,
     get_subsections_from_sections,
     modifications_update_announcement_text,
+    nofo_has_end_notes_section,
     overwrite_nofo,
     parse_uploaded_file_as_html_string,
     preserve_subsection_metadata,
@@ -2093,6 +2098,98 @@ class PrintNofoAsPDFView(GroupAccessObjectMixin, DetailView):
 ###########################################################
 ##################### SECTION VIEWS #######################
 ###########################################################
+
+
+class NofoAddEndNotesSectionView(
+    PreventIfArchivedOrCancelledMixin,
+    PreventIfPublishedMixin,
+    GroupAccessObjectMixin,
+    CreateView,
+):
+    """
+    Creates a NOFO's "Endnotes" section along with its one initial
+    Subsection, whose body is prepopulated with placeholder endnote content
+    the user can edit before saving.
+
+    The section's name/html_id are fixed here, not accepted from the
+    request - this is intentionally the only way to create a Section from
+    the UI, and it can only ever create this one specific section.
+    """
+
+    model = Subsection
+    form_class = EndNotesSectionCreateForm
+    template_name = "nofos/section_add_end_notes.html"
+
+    published_error_message = "Endnotes can’t be added to published NOFOs."
+    archived_error_message = "Endnotes can’t be added to archived NOFOs."
+
+    def dispatch(self, request, *args, **kwargs):
+        self.nofo = get_object_or_404(Nofo, pk=kwargs.get("pk"))
+
+        if nofo_has_end_notes_section(self.nofo):
+            messages.warning(request, "This NOFO already has an Endnotes section.")
+            return redirect("nofos:nofo_edit", pk=self.nofo.pk)
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_initial(self):
+        initial = super().get_initial()
+        initial["body"] = END_NOTES_PLACEHOLDER_BODY
+        return initial
+
+    def form_valid(self, form):
+        with transaction.atomic():
+            # Modifications should always stay the NOFO's last section, so
+            # slot Endnotes in directly above it if it already exists.
+            modifications_section = self.nofo.sections.filter(
+                name="Modifications"
+            ).first()
+
+            if modifications_section:
+                order = modifications_section.order
+                modifications_section.order = order + 1
+                modifications_section.save()
+            else:
+                order = Section.get_next_order(self.nofo)
+
+            self.section = Section.objects.create(
+                nofo=self.nofo,
+                name=END_NOTES_SECTION_NAME,
+                html_id=END_NOTES_SECTION_HTML_ID,
+                has_section_page=False,
+                order=order,
+            )
+
+            form.instance.section = self.section
+            form.instance.name = ""
+            form.instance.tag = ""
+            form.instance.order = 1
+
+            response = super().form_valid(form)
+
+        messages.success(
+            self.request,
+            "Added new section: “<a href='#{}'>{}</a>”".format(
+                self.section.html_id, self.section.name
+            ),
+        )
+
+        return response
+
+    def get_success_url(self):
+        return "{}#{}".format(
+            reverse_lazy("nofos:nofo_edit", kwargs={"pk": self.nofo.id}),
+            self.section.html_id,
+        )
+
+    def get_cancel_url(self):
+        return reverse_lazy("nofos:nofo_edit", kwargs={"pk": self.nofo.id})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["nofo"] = self.nofo
+        context["cancel_url"] = self.get_cancel_url()
+        return context
 
 
 class NofoSectionDetailView(GroupAccessObjectMixin, DetailView):

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -2101,9 +2101,9 @@ class PrintNofoAsPDFView(GroupAccessObjectMixin, DetailView):
 
 
 class NofoAddEndNotesSectionView(
+    GroupAccessObjectMixin,
     PreventIfArchivedOrCancelledMixin,
     PreventIfPublishedMixin,
-    GroupAccessObjectMixin,
     CreateView,
 ):
     """
@@ -2123,14 +2123,33 @@ class NofoAddEndNotesSectionView(
     published_error_message = "Endnotes can’t be added to published NOFOs."
     archived_error_message = "Endnotes can’t be added to archived NOFOs."
 
-    def dispatch(self, request, *args, **kwargs):
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
         self.nofo = get_object_or_404(Nofo, pk=kwargs.get("pk"))
+
+    def _guard_add_end_notes(self, request):
+        # Unlike normal subsection editing after a modifications date is set,
+        # this action is never available once the NOFO has been published.
+        if self.nofo.status == "published":
+            return self.render_response(self.published_error_message)
 
         if nofo_has_end_notes_section(self.nofo):
             messages.warning(request, "This NOFO already has an Endnotes section.")
             return redirect("nofos:nofo_edit", pk=self.nofo.pk)
 
-        return super().dispatch(request, *args, **kwargs)
+        return None
+
+    def get(self, request, *args, **kwargs):
+        response = self._guard_add_end_notes(request)
+        if response:
+            return response
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        response = self._guard_add_end_notes(request)
+        if response:
+            return response
+        return super().post(request, *args, **kwargs)
 
     def get_initial(self):
         initial = super().get_initial()
@@ -2139,16 +2158,25 @@ class NofoAddEndNotesSectionView(
 
     def form_valid(self, form):
         with transaction.atomic():
-            # Modifications should always stay the NOFO's last section, so
-            # slot Endnotes in directly above it if it already exists.
-            modifications_section = self.nofo.sections.filter(
-                name="Modifications"
-            ).first()
+            # Serialize this single-purpose section creation and re-check after
+            # acquiring the lock so concurrent submissions cannot create two
+            # Endnotes sections.
+            self.nofo = Nofo.objects.select_for_update().get(pk=self.nofo.pk)
+            response = self._guard_add_end_notes(self.request)
+            if response:
+                return response
+
+            # Slot Endnotes directly above Modifications when it exists.
+            sections = self.nofo.sections.select_for_update()
+            modifications_section = sections.filter(name="Modifications").first()
 
             if modifications_section:
                 order = modifications_section.order
-                modifications_section.order = order + 1
-                modifications_section.save()
+                # Shift in descending order to preserve the unique (nofo, order)
+                # constraint even when Modifications is not currently last.
+                for section in sections.filter(order__gte=order).order_by("-order"):
+                    section.order += 1
+                    section.save(update_fields=["order"])
             else:
                 order = Section.get_next_order(self.nofo)
 


### PR DESCRIPTION
## Summary
- Adds an "Add Endnotes" item to the NOFO actions dropdown, shown under the same status rules as Find & Replace / Compare / Duplicate NOFO (visible while a NOFO is still editable; hidden once published or cancelled), and hidden once the NOFO already has an Endnotes section (matched by `html_id == "endnotes"`).
- Selecting it opens a dedicated page — not the generic "create subsection" page — that creates the NOFO's "Endnotes" section (fixed `name`/`html_id`, not user-editable) together with one initial subsection, prepopulated with placeholder endnote HTML (two example references) that the user can edit or just save as-is.
- New sections are always appended at the end of the NOFO, or slotted in directly above an existing "Modifications" section so Modifications stays last.
- This intentionally isn't a general "create section" flow — the section's name/html_id are fixed server-side, not accepted from the request, so it can only ever create this one specific section.

## Acceptance criteria / how to test
1. Open an existing NOFO for editing and click **NOFO actions**.
2. **"Add Endnotes" should only appear when:**
   - the NOFO's status allows editing (same rule as Find & Replace / Compare / Duplicate NOFO — hidden for `published` and `cancelled`), **and**
   - the NOFO doesn't already have a section with html_id `endnotes`.
3. Selecting "Add Endnotes" navigates to a page specific to this action (name/html_id are fixed, not editable).
4. The content editor on that page is prepopulated with a two-item placeholder endnotes list (HTML `<ol>` with two example references/backlinks).
5. Clicking **Save** with no changes creates the section successfully.
6. The new "Endnotes" section is added as the last section in the NOFO — or, if a "Modifications" section exists, directly above it, so Modifications stays last.
7. In the rendered NOFO view, since Endnotes doesn't have its own section page and its heading renders as `<h2>`, it shows up in the Table of Contents as a sub-page-style entry (indented, no icon) — consistent with how Modifications/References/Appendix/Glossary already behave — appearing right after whichever section precedes it (typically directly under "Contacts & support" in a standard NOFO).

## Test plan
- [x] Added/updated unit tests for the action-link visibility rules (`TestBuildNofoActionLinks`) and the new view (`test_section_add_end_notes.py`)
- [x] Full `nofos` app test suite passes (1320 tests)
- [x] `black`/`isort` clean on all changed files
