### PR TITLE
Prevent Key Dates field values from line-wrapping mid-date on import

### DIFF
--- a/nofos/nofos/nofo.py
+++ b/nofos/nofos/nofo.py
@@ -3460,6 +3460,89 @@ def add_final_subsection_to_step_3(sections):
             break
 
 
+# Matches a short "field name" label, eg "Award date" or "Anticipated start date" -
+# not a full sentence like "Note" in "Note: applications received after this date
+# won't be reviewed" would still match (that's fine, it's field-name-shaped too), but
+# a long sentence with a stray colon in it won't.
+KEY_DATES_FIELD_NAME_WORD_RE = re.compile(r"^[A-Za-z][A-Za-z'-]*$")
+
+
+def add_line_breaks_to_key_dates_values(sections):
+    """
+    This function accepts a list of section dicts, _not_ Section objects, and mutates
+    the paragraph tags inside them in place.
+
+    The "Key dates" callout box is a narrow, right-aligned component, and its "field
+    name: value" paragraphs (eg, "Award date: 00/00/0000") can wrap in the middle of
+    the value there, breaking a date format like "00/00/0000" across two lines.
+
+    Within the "Key dates" callout box only, this inserts a line break right after the
+    colon in any such "field name:" paragraph, so the value always starts on its own
+    line. A paragraph with no field-name colon (eg, a plain descriptive sentence ending
+    in a period) is left untouched, as is every other section/subsection in the NOFO.
+
+    Args:
+        sections (list of dict): A list of section dictionaries, where each section may
+            contain a "subsections" (list of dict) key. Each subsection's "body" is
+            either a single BeautifulSoup Tag (a callout box's extracted cell) or a
+            list of BeautifulSoup Tag objects (an ordinary subsection) - see
+            `get_subsections_from_sections`.
+
+    Side Effects:
+        - Modifies the "Key dates" subsection's paragraph tags in place, splitting a
+          "field name:" text node into a "field name:" node, a new <br> tag, and the
+          remaining text.
+    """
+
+    def _looks_like_field_name(text):
+        # Real field names are short labels (eg, "Award date", "Anticipated start
+        # date"), not a full clause. 4 words comfortably covers realistic field
+        # names while still excluding longer sentence fragments.
+        words = text.strip().split()
+        return 1 <= len(words) <= 4 and all(
+            KEY_DATES_FIELD_NAME_WORD_RE.match(word) for word in words
+        )
+
+    def _get_paragraphs(body):
+        if hasattr(body, "find_all"):
+            # a callout box's body is a single extracted <div> cell
+            return body.find_all("p")
+        # an ordinary subsection's body is a list of top-level tags
+        return [tag for tag in body if getattr(tag, "name", None) == "p"]
+
+    for section in sections:
+        for subsection in section.get("subsections", []):
+            if (subsection.get("name") or "").strip().casefold() != "key dates":
+                continue
+
+            for paragraph in _get_paragraphs(subsection["body"]):
+                if paragraph.find("br"):
+                    continue
+
+                first_text_with_colon = next(
+                    (
+                        node
+                        for node in paragraph.contents
+                        if isinstance(node, NavigableString) and ":" in node
+                    ),
+                    None,
+                )
+                if first_text_with_colon is None:
+                    continue
+
+                before, _, after = str(first_text_with_colon).partition(":")
+                if not _looks_like_field_name(before):
+                    continue
+
+                label_node = NavigableString(before.strip() + ":")
+                first_text_with_colon.replace_with(label_node)
+
+                br_tag = paragraph.new_tag("br")
+                label_node.insert_after(br_tag)
+                if after.strip():
+                    br_tag.insert_after(after.strip())
+
+
 def modifications_update_announcement_text(nofo):
     """
     Update announcement text in all subsection bodies of a given NOFO.

--- a/nofos/nofos/test_nofo.py
+++ b/nofos/nofos/test_nofo.py
@@ -27,6 +27,7 @@ from .nofo import (
     add_final_subsection_to_step_3,
     add_headings_to_document,
     add_instructions_to_subsections,
+    add_line_breaks_to_key_dates_values,
     add_missing_alt_text_to_imgs,
     add_page_breaks_to_headings,
     add_strongs_to_soup,
@@ -966,6 +967,109 @@ class KeyCalloutHeadingImportTests(TestCase):
 
         self.assertEqual(subsections[0]["name"], "Key Facts")
         self.assertEqual(subsections[0]["tag"], "h5")
+
+
+class TestAddLineBreaksToKeyDatesValues(TestCase):
+    def get_sections(self, html, top_heading_level="h1"):
+        soup = BeautifulSoup(html, "html.parser")
+        sections = get_sections_from_soup(soup, top_heading_level=top_heading_level)
+        return get_subsections_from_sections(
+            sections, top_heading_level=top_heading_level
+        )
+
+    def test_adds_break_after_colon_in_callout_box_table(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <table><tr><td><h4>Key Dates</h4><p>Award date: 00/00/0000</p></td></tr></table>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        key_dates_subsection = sections[0]["subsections"][0]
+        self.assertEqual(key_dates_subsection["name"], "Key dates")
+        self.assertEqual(
+            str(key_dates_subsection["body"]),
+            "<div><p>Award date:<br/>00/00/0000</p></div>",
+        )
+
+    def test_adds_break_for_multi_word_field_name(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <table><tr><td><h4>Key Dates</h4><p>Anticipated start date: 00/00/0000</p></td></tr></table>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        body = sections[0]["subsections"][0]["body"]
+        self.assertIn("<p>Anticipated start date:<br/>00/00/0000</p>", str(body))
+
+    def test_leaves_plain_sentence_without_colon_untouched(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <table><tr><td><h4>Key Dates</h4><p>Award date: 00/00/0000</p><p>Dates are subject to change.</p></td></tr></table>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        body = sections[0]["subsections"][0]["body"]
+        self.assertIn("<p>Dates are subject to change.</p>", str(body))
+
+    def test_adds_break_after_short_single_word_label(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <table><tr><td><h4>Key Dates</h4><p>Note: applications received after this date will not be reviewed.</p></td></tr></table>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        body = sections[0]["subsections"][0]["body"]
+        self.assertIn(
+            "<p>Note:<br/>applications received after this date will not be reviewed.</p>",
+            str(body),
+        )
+
+    def test_leaves_sentence_with_many_words_before_colon_untouched(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <table><tr><td><h4>Key Dates</h4><p>For more information about this timeline: visit our website.</p></td></tr></table>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        body = sections[0]["subsections"][0]["body"]
+        self.assertIn(
+            "<p>For more information about this timeline: visit our website.</p>",
+            str(body),
+        )
+
+    def test_does_not_touch_key_facts_callout_box(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <table><tr><td><h4>Key Facts</h4><p>Funding type: Grant</p></td></tr></table>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        body = sections[0]["subsections"][0]["body"]
+        self.assertIn("<p>Funding type: Grant</p>", str(body))
+
+    def test_adds_break_in_non_callout_box_key_dates_subsection(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <h4>Key Dates</h4>
+            <p>Award date: 00/00/0000</p>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        subsection = sections[0]["subsections"][0]
+        self.assertEqual(subsection["name"], "Key Dates")
+        self.assertEqual(
+            str(subsection["body"][0]), "<p>Award date:<br/>00/00/0000</p>"
+        )
+
+    def test_skips_paragraph_that_already_has_a_break(self):
+        sections = self.get_sections("""
+            <h1>Basic information</h1>
+            <table><tr><td><h4>Key Dates</h4><p>Award date:<br>00/00/0000</p></td></tr></table>
+            """)
+        add_line_breaks_to_key_dates_values(sections)
+
+        body = sections[0]["subsections"][0]["body"]
+        self.assertEqual(str(body).count("<br"), 1)
 
 
 class HTMLSubsectionTestsH2(TestCase):

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -94,6 +94,7 @@ from .nofo import (
     END_NOTES_SECTION_NAME,
     add_final_subsection_to_step_3,
     add_headings_to_document,
+    add_line_breaks_to_key_dates_values,
     add_page_breaks_to_headings,
     count_page_breaks_nofo,
     count_page_breaks_subsection,
@@ -716,6 +717,7 @@ class BaseNofoImportView(View):
         filename = uploaded_file.name.strip()
 
         add_final_subsection_to_step_3(sections)
+        add_line_breaks_to_key_dates_values(sections)
 
         # 6. Hand off to child for nofo creation
         return self.handle_nofo_create(


### PR DESCRIPTION
## Summary

Closes HHS/simpler-grants-pdf-builder#846.

The "Key Dates" callout box is a narrow, right-aligned component, so a "field name: value" paragraph (eg, "Award date: 00/00/0000") can wrap in the middle of the value there, breaking a date format across two lines in both the PDF and HTML output.

## What changed

- **`nofos/nofos/nofo.py`** — new `add_line_breaks_to_key_dates_values(sections)`, run during import (wired into the same place as `add_final_subsection_to_step_3`). Scoped strictly to the "Key dates" callout box subsection, it finds any "field name:" paragraph (a short, 1–4 word label followed by a colon, eg "Award date:", "Anticipated start date:") and inserts a line break right after the colon, so the value always starts on its own line. A plain paragraph with no field-name colon (eg, a descriptive sentence ending in a period) is left untouched, and nothing outside the Key Dates box is touched at all.
- **`nofos/nofos/views.py`** — wires the new function into the import pipeline.

## Tests

- 8 new unit tests covering: the callout-box-table form of Key Dates, the plain-heading form, multi-word field names, a plain sentence with no colon, a long clause with a stray colon (correctly left alone), a short single-word label, the "Key facts" box being unaffected, and idempotency (a paragraph that already has a break is skipped).
- Full existing test suite (1331 tests) passes with no regressions; `black`/`isort` clean.

## Acceptance criteria

- [x] Importing a Word doc with a Key Dates heading and "field name:" paragraphs (eg, "Award date: 00/00/0000") adds a line break right after the colon
- [x] A paragraph under Key Dates with no colon-terminated field name is left unchanged
- [x] Content outside the Key Dates section is unaffected