### PR TITLE
fix: capitalize NOFO in group filter label on NOFO index page

### DIFF
--- a/nofos/nofos/templates/nofos/nofo_index.html
+++ b/nofos/nofos/templates/nofos/nofo_index.html
@@ -34,7 +34,7 @@
 
 	{% if user.group == 'bloom' %}
     <p class="nofo_index--filter">
-				<label class="usa-label display-inline-block font-sans-md margin-top-0" for="group-filter">Nofo Group:</label>
+				<label class="usa-label display-inline-block font-sans-md margin-top-0" for="group-filter">NOFO Group:</label>
 				<select class="usa-select border-2px width-auto display-inline-block margin-top-0" name="group-filter" id="group-filter" onchange="location = this.value;">
 					<option value="{% url 'nofos:nofo_index' %}?status={{ nofo_status }}&group=bloom" {% if nofo_group == 'bloom' %}selected{% endif %}>Bloom</option>
 					<option value="{% url 'nofos:nofo_index' %}?status={{ nofo_status }}&group=all" {% if nofo_group == 'all' %}selected{% endif %}>All</option>


### PR DESCRIPTION
## Problem
On the NOFO index page (`/nofos/`), Bloom group users see a filter control for switching between the "Bloom" and "All" NOFO groups. Its label reads "Nofo Group:" — inconsistent with the "NOFO" (all-caps) capitalization used everywhere else in the app, including the page title ("Bloom in progress NOFOs") and nav links ("In progress NOFOs", "Published NOFOs", etc.).

## Solution
Updated the label text in `nofos/nofos/templates/nofos/nofo_index.html` from "Nofo Group:" to "NOFO Group:", keeping the trailing colon. This is a static template text change only — no logic, styling, or behavior is affected.

## Acceptance criteria
- [ ] The group filter label on `/nofos/` reads "NOFO Group:" (not "Nofo Group:")
- [ ] The trailing colon is preserved
- [ ] The filter dropdown itself (Bloom / All options and its `onchange` behavior) is unchanged
- [ ] No other instances of "Nofo Group" remain in the codebase

## Test plan
- [ ] Log in as a user in the `bloom` group and visit `/nofos/`
- [ ] Confirm the label next to the group dropdown reads "NOFO Group:"
- [ ] Confirm switching between "Bloom" and "All" in the dropdown still filters the NOFO list as before
- [ ] Confirm the label does not appear (or filter is hidden) for non-Bloom users, per existing `{% if user.group == 'bloom' %}` condition