### PR TITLE
feat: warn editors about long callout boxes

### DIFF
--- a/.github/workflows/django_ci.yml
+++ b/.github/workflows/django_ci.yml
@@ -38,3 +38,7 @@ jobs:
 
       - name: Run tests
         run: poetry run python manage.py test
+
+      - name: Run JavaScript unit tests
+        # Uses Node's built-in test runner (available on ubuntu-latest); no npm dependencies.
+        run: node --test ../tests/js/*.test.cjs

--- a/nofos/bloom_nofos/.env.example
+++ b/nofos/bloom_nofos/.env.example
@@ -11,6 +11,10 @@ DOCRAPTOR_API_KEY="YOUR_API_KEY_HERE"
 GRABZIT_APPLICATION_KEY="YOUR_APPLICATION_KEY_HERE"
 GRABZIT_APPLICATION_SECRET="YOUR_APPLICATION_SECRET_HERE"
 
+# Non-blocking subsection-editor guidance above this estimated word count.
+# Counts whitespace-separated Markdown source words, not rendered PDF height.
+CALLOUT_WORD_WARNING_THRESHOLD=100
+
 # Uses the hhs-nofo-metrics release pinned in pyproject.toml and poetry.lock.
 # This is only the starting value for the HHS_NOFO_METRICS_ENABLED constance
 # setting: once that has been saved in the admin, the saved value wins.

--- a/nofos/bloom_nofos/settings.py
+++ b/nofos/bloom_nofos/settings.py
@@ -571,6 +571,10 @@ DOCRAPTOR_API_KEY = env.get_value("DOCRAPTOR_API_KEY", default="")
 GRABZIT_APPLICATION_KEY = env.get_value("GRABZIT_APPLICATION_KEY", default="")
 GRABZIT_APPLICATION_SECRET = env.get_value("GRABZIT_APPLICATION_SECRET", default="")
 
+# Advisory only: estimated words in the subsection's Markdown source, using the
+# same whitespace count as floating callouts. This is not a publishing limit.
+CALLOUT_WORD_WARNING_THRESHOLD = env.int("CALLOUT_WORD_WARNING_THRESHOLD", default=100)
+
 # Provisional, source-native readability metrics integration. The package is
 # pinned, but each environment opts into the feature explicitly. This env var is
 # only the starting value for the HHS_NOFO_METRICS_ENABLED constance setting,

--- a/nofos/bloom_nofos/static/js/nofos/subsection_edit.js
+++ b/nofos/bloom_nofos/static/js/nofos/subsection_edit.js
@@ -13,3 +13,46 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 });
+
+// Keep this independent of the heading-copy button: unnamed subsections have
+// no copy button, but can still be callouts.
+document.addEventListener("DOMContentLoaded", () => {
+  const checkbox = document.getElementById("callout_box");
+  const warning = document.getElementById("callout-word-warning");
+  // Martor adds a generated suffix to the textarea ID.
+  const body = document.querySelector('.main-martor--container textarea[name="body"]');
+  if (!checkbox || !warning || !body) return;
+
+  const threshold = Number(warning.dataset.wordThreshold);
+  if (!Number.isFinite(threshold)) return;
+
+  let editor;
+  const update = () => {
+    // Advisory estimate, matching Python's body.split() and existing floating
+    // callouts. Markdown syntax may contribute to the count; this is not a
+    // rendered-height or precise readability measurement.
+    const text = editor ? editor.getValue() : body.value;
+    const wordCount = (text.match(/\S+/g) || []).length;
+    const hidden = !checkbox.checked || wordCount <= threshold;
+    if (warning.hidden !== hidden) warning.hidden = hidden;
+  };
+
+  checkbox.addEventListener("change", update);
+  body.addEventListener("input", update);
+
+  // Martor initializes Ace on jQuery ready, which can follow DOMContentLoaded.
+  // Until it is ready, keep the server-rendered warning and textarea fallback.
+  const attachEditor = (attempts = 0) => {
+    const element = document.querySelector(".main-martor--container .ace_editor");
+    if (window.ace && element) {
+      editor = window.ace.edit(element);
+      editor.on("change", update);
+      update();
+    } else if (attempts < 50) {
+      setTimeout(() => attachEditor(attempts + 1), 100);
+    }
+  };
+
+  update();
+  attachEditor();
+});

--- a/nofos/bloom_nofos/static/js/nofos/subsection_edit.js
+++ b/nofos/bloom_nofos/static/js/nofos/subsection_edit.js
@@ -26,8 +26,17 @@ document.addEventListener("DOMContentLoaded", () => {
   const threshold = Number(warning.dataset.wordThreshold);
   if (!Number.isFinite(threshold)) return;
 
+  // Unnamed subsections have no name field. Keep this list in sync with
+  // CALLOUT_WORD_WARNING_EXEMPT_NAMES in nofos/nofos/views.py.
+  const nameField = document.getElementById("name");
+  const exemptNames = new Set(["Key facts", "Key Facts", "Key dates", "Key Dates"]);
+
   let editor;
   const update = () => {
+    if (nameField && exemptNames.has(nameField.value.trim())) {
+      if (!warning.hidden) warning.hidden = true;
+      return;
+    }
     // Advisory estimate, matching Python's body.split() and existing floating
     // callouts. Markdown syntax may contribute to the count; this is not a
     // rendered-height or precise readability measurement.
@@ -39,6 +48,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   checkbox.addEventListener("change", update);
   body.addEventListener("input", update);
+  if (nameField) nameField.addEventListener("input", update);
 
   // Martor initializes Ace on jQuery ready, which can follow DOMContentLoaded.
   // Until it is ready, keep the server-rendered warning and textarea fallback.

--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -135,6 +135,17 @@
         </div>
       </div>
 
+      <div id="callout-word-warning-region" aria-live="polite" aria-atomic="true">
+        <div id="callout-word-warning"
+          data-word-threshold="{{ callout_word_warning_threshold }}"
+          class="margin-top-2 padding-1 border-solid border-top-width-0 border-bottom-width-0 border-right-width-0 border-left-width-05 border-accent-warm-dark text-accent-warm-dark"
+          {% if not show_callout_word_warning %}hidden{% endif %}>
+          <strong>This callout box has a lot of content.</strong>
+          Callouts are meant to highlight one important thing, not a full section.
+          Long callouts are less likely to stand out to applicants — consider moving detailed content into the body.
+        </div>
+      </div>
+
       <!-- html_class -->
       <div class="form-group margin-top-4">
         <fieldset class="usa-fieldset">

--- a/nofos/nofos/templates/nofos/subsection_edit.html
+++ b/nofos/nofos/templates/nofos/subsection_edit.html
@@ -142,7 +142,7 @@
           {% if not show_callout_word_warning %}hidden{% endif %}>
           <strong>This callout box has a lot of content.</strong>
           Callouts are meant to highlight one important thing, not a full section.
-          Long callouts are less likely to stand out to applicants — consider moving detailed content into the body.
+          Long callouts are less likely to stand out to applicants — consider moving detailed content into the body of the section, before or after the callout.
         </div>
       </div>
 

--- a/nofos/nofos/tests_nofos/test_subsection_edit.py
+++ b/nofos/nofos/tests_nofos/test_subsection_edit.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from nofos.models import Nofo, Section, Subsection
+from nofos.views import CALLOUT_WORD_WARNING_EXEMPT_NAMES
 
 User = get_user_model()
 
@@ -350,6 +351,26 @@ class SubsectionCalloutEditingTests(TestCase):
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertFalse(response.context["show_callout_word_warning"])
+
+    def test_key_facts_and_key_dates_names_are_exempt_from_warning(self):
+        for order, name in enumerate(CALLOUT_WORD_WARNING_EXEMPT_NAMES):
+            with self.subTest(name=name):
+                subsection = self.make_warning_subsection(name=name, order=order)
+                response = self.client.get(self.edit_url(subsection))
+                self.assertFalse(response.context["show_callout_word_warning"])
+
+    def test_whitespace_padded_exempt_name_still_matches(self):
+        subsection = self.make_warning_subsection(name="  Key facts  ")
+        response = self.client.get(self.edit_url(subsection))
+        self.assertFalse(response.context["show_callout_word_warning"])
+
+    def test_similarly_named_subsections_still_warn(self):
+        names = ["key facts", "KEY FACTS", "Key Fact", "Key facts and figures"]
+        for order, name in enumerate(names):
+            with self.subTest(name=name):
+                subsection = self.make_warning_subsection(name=name, order=order)
+                response = self.client.get(self.edit_url(subsection))
+                self.assertTrue(response.context["show_callout_word_warning"])
 
 
 class SubsectionCalloutRenderingTests(TestCase):

--- a/nofos/nofos/tests_nofos/test_subsection_edit.py
+++ b/nofos/nofos/tests_nofos/test_subsection_edit.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -269,6 +269,87 @@ class SubsectionCalloutEditingTests(TestCase):
         subsection.refresh_from_db()
         self.assertTrue(subsection.callout_box)
         self.assertEqual(subsection.body, "Updated body")
+
+    def make_warning_subsection(self, **overrides):
+        values = {
+            "section": self.section,
+            "name": "Required format",
+            "tag": "h3",
+            "order": 1,
+            "body": "word " * 101,
+            "callout_box": True,
+        }
+        values.update(overrides)
+        return Subsection.objects.create(**values)
+
+    @override_settings(CALLOUT_WORD_WARNING_THRESHOLD=100)
+    def test_warning_threshold_boundary_and_empty_content(self):
+        subsection = self.make_warning_subsection()
+        for count in [0, 99, 100, 101]:
+            with self.subTest(count=count):
+                subsection.body = "word " * count
+                subsection.save()
+                response = self.client.get(self.edit_url(subsection))
+                self.assertEqual(
+                    response.context["show_callout_word_warning"], count > 100
+                )
+                self.assertContains(response, 'data-word-threshold="100"')
+                self.assertContains(response, 'aria-live="polite"')
+                warning = (
+                    response.content.decode()
+                    .split('id="callout-word-warning"')[1]
+                    .split(">", 1)[0]
+                )
+                self.assertEqual("hidden" in warning, count <= 100)
+
+    @override_settings(CALLOUT_WORD_WARNING_THRESHOLD=2)
+    def test_warning_uses_configured_threshold_and_whitespace_count(self):
+        subsection = self.make_warning_subsection(
+            body="  First\n\nsecond\tthird\u00a0 "
+        )
+        response = self.client.get(self.edit_url(subsection))
+        self.assertTrue(response.context["show_callout_word_warning"])
+        self.assertContains(response, 'data-word-threshold="2"')
+
+    def test_long_regular_subsection_has_no_warning(self):
+        subsection = self.make_warning_subsection(callout_box=False)
+        response = self.client.get(self.edit_url(subsection))
+        self.assertFalse(response.context["show_callout_word_warning"])
+
+    def test_unnamed_long_callout_has_warning(self):
+        subsection = self.make_warning_subsection(name="", tag="")
+        response = self.client.get(self.edit_url(subsection))
+        self.assertTrue(response.context["show_callout_word_warning"])
+
+    def test_long_callout_can_still_be_saved(self):
+        subsection = self.make_warning_subsection(body="Short content")
+        body = " ".join(["word"] * 101)
+        response = self.post_subsection(subsection, callout_box=True, body=body)
+        self.assertEqual(response.status_code, 302)
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.body, body)
+        self.assertTrue(subsection.callout_box)
+
+    def test_invalid_form_uses_submitted_body_and_callout_state(self):
+        subsection = self.make_warning_subsection(body="Short", callout_box=False)
+        response = self.post_subsection(
+            subsection, callout_box=True, name="", body="word " * 101
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["show_callout_word_warning"])
+        subsection.refresh_from_db()
+        self.assertEqual(subsection.body, "Short")
+        self.assertFalse(subsection.callout_box)
+
+    def test_invalid_form_can_hide_previous_warning(self):
+        subsection = self.make_warning_subsection()
+        for callout_box, body in [(False, subsection.body), (True, "Short")]:
+            with self.subTest(callout_box=callout_box):
+                response = self.post_subsection(
+                    subsection, callout_box=callout_box, name="", body=body
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertFalse(response.context["show_callout_word_warning"])
 
 
 class SubsectionCalloutRenderingTests(TestCase):

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -2472,6 +2472,11 @@ class NofoSubsectionCreateView(
         return context
 
 
+# Key facts/dates callouts are structured fact lists, not narrative content,
+# and routinely exceed the word-count guidance by design.
+CALLOUT_WORD_WARNING_EXEMPT_NAMES = ("Key facts", "Key Facts", "Key dates", "Key Dates")
+
+
 class NofoSubsectionEditView(
     PreventIfArchivedOrCancelledMixin,
     PreventIfPublishedMixin,
@@ -2521,10 +2526,13 @@ class NofoSubsectionEditView(
         form = context["form"]
         threshold = settings.CALLOUT_WORD_WARNING_THRESHOLD
         context["callout_word_warning_threshold"] = threshold
+        name = (form["name"].value() or "").strip()
         # Use bound form values so a validation error preserves the guidance for
         # the submitted text and checkbox, rather than the previous saved state.
-        context["show_callout_word_warning"] = bool(form["callout_box"].value()) and (
-            len((form["body"].value() or "").split()) > threshold
+        context["show_callout_word_warning"] = (
+            bool(form["callout_box"].value())
+            and name not in CALLOUT_WORD_WARNING_EXEMPT_NAMES
+            and len((form["body"].value() or "").split()) > threshold
         )
         return context
 

--- a/nofos/nofos/views.py
+++ b/nofos/nofos/views.py
@@ -2518,6 +2518,14 @@ class NofoSubsectionEditView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["nofo"] = self.nofo
+        form = context["form"]
+        threshold = settings.CALLOUT_WORD_WARNING_THRESHOLD
+        context["callout_word_warning_threshold"] = threshold
+        # Use bound form values so a validation error preserves the guidance for
+        # the submitted text and checkbox, rather than the previous saved state.
+        context["show_callout_word_warning"] = bool(form["callout_box"].value()) and (
+            len((form["body"].value() or "").split()) > threshold
+        )
         return context
 
 

--- a/tests/js/subsection_edit.test.cjs
+++ b/tests/js/subsection_edit.test.cjs
@@ -1,0 +1,92 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { runInNewContext } = require("node:vm");
+
+const source = readFileSync(join(__dirname,
+  "../../nofos/bloom_nofos/static/js/nofos/subsection_edit.js"), "utf8");
+
+function setup({ text = "word ".repeat(101), checked = true, threshold = 100,
+  aceReady = true } = {}) {
+  const ready = [], timers = [];
+  const checkbox = { checked, addEventListener: (_, fn) => checkbox.change = fn };
+  const body = { value: text, addEventListener: (_, fn) => body.input = fn };
+  const warning = { hidden: true, dataset: { wordThreshold: String(threshold) } };
+  const editor = { getValue: () => text, on: (_, fn) => editor.change = fn };
+  const elements = { callout_box: checkbox, "callout-word-warning": warning };
+  const window = { ace: { edit: () => editor } };
+  const document = {
+    addEventListener: (_, fn) => ready.push(fn),
+    getElementById: (id) => elements[id], // Deliberately no heading-copy button.
+    querySelector: (selector) => {
+      if (selector === '.main-martor--container textarea[name="body"]') return body;
+      if (selector === '.main-martor--container .ace_editor') return aceReady ? {} : null;
+      throw new Error(`Unexpected selector: ${selector}`);
+    },
+  };
+  runInNewContext(source, { document, window, setTimeout: (fn) => timers.push(fn) });
+  ready.forEach((fn) => fn());
+  return { checkbox, body, warning, timers,
+    edit(value) { text = value; editor.change(); },
+    attach() { aceReady = true; timers.shift()(); },
+  };
+}
+
+test("long unnamed callout shows guidance without a heading-copy button", () => {
+  assert.equal(setup().warning.hidden, false);
+});
+
+test("empty, short and exactly-threshold callouts do not show guidance", () => {
+  for (const count of [0, 99, 100]) {
+    assert.equal(setup({ text: "word ".repeat(count) }).warning.hidden, true);
+  }
+});
+
+test("ordinary body content does not show guidance", () => {
+  assert.equal(setup({ checked: false }).warning.hidden, true);
+});
+
+test("toggling the checkbox updates guidance without saving", () => {
+  const state = setup({ checked: false });
+  state.checkbox.checked = true;
+  state.checkbox.change();
+  assert.equal(state.warning.hidden, false);
+  state.checkbox.checked = false;
+  state.checkbox.change();
+  assert.equal(state.warning.hidden, true);
+});
+
+test("editing text across the threshold updates guidance in both directions", () => {
+  const state = setup();
+  state.edit("word ".repeat(100));
+  assert.equal(state.warning.hidden, true);
+  state.edit("word ".repeat(101));
+  assert.equal(state.warning.hidden, false);
+  state.edit("");
+  assert.equal(state.warning.hidden, true);
+});
+
+test("configured threshold and mixed whitespace are respected", () => {
+  const state = setup({ threshold: 2, text: "  First\n\nsecond\tthird\u00a0 " });
+  assert.equal(state.warning.hidden, false);
+  state.edit("First\u00a0second");
+  assert.equal(state.warning.hidden, true);
+});
+
+test("delayed Martor initialization attaches the live editor listener", () => {
+  const state = setup({ aceReady: false });
+  assert.equal(state.warning.hidden, false);
+  state.attach();
+  state.edit("Short");
+  assert.equal(state.warning.hidden, true);
+});
+
+test("textarea fallback works and polling stops if Ace never initializes", () => {
+  const state = setup({ aceReady: false });
+  state.body.value = "Short";
+  state.body.input();
+  assert.equal(state.warning.hidden, true);
+  for (let attempt = 0; attempt < 50; attempt++) state.timers.shift()();
+  assert.equal(state.timers.length, 0);
+});

--- a/tests/js/subsection_edit.test.cjs
+++ b/tests/js/subsection_edit.test.cjs
@@ -8,13 +8,17 @@ const source = readFileSync(join(__dirname,
   "../../nofos/bloom_nofos/static/js/nofos/subsection_edit.js"), "utf8");
 
 function setup({ text = "word ".repeat(101), checked = true, threshold = 100,
-  aceReady = true } = {}) {
+  aceReady = true, name } = {}) {
   const ready = [], timers = [];
   const checkbox = { checked, addEventListener: (_, fn) => checkbox.change = fn };
   const body = { value: text, addEventListener: (_, fn) => body.input = fn };
   const warning = { hidden: true, dataset: { wordThreshold: String(threshold) } };
   const editor = { getValue: () => text, on: (_, fn) => editor.change = fn };
   const elements = { callout_box: checkbox, "callout-word-warning": warning };
+  // Unnamed subsections have no name field in the DOM; omit `name` to mimic that.
+  const nameEl = name === undefined ? undefined
+    : { value: name, addEventListener: (_, fn) => nameEl.input = fn };
+  if (nameEl) elements.name = nameEl;
   const window = { ace: { edit: () => editor } };
   const document = {
     addEventListener: (_, fn) => ready.push(fn),
@@ -27,9 +31,10 @@ function setup({ text = "word ".repeat(101), checked = true, threshold = 100,
   };
   runInNewContext(source, { document, window, setTimeout: (fn) => timers.push(fn) });
   ready.forEach((fn) => fn());
-  return { checkbox, body, warning, timers,
+  return { checkbox, body, warning, timers, nameEl,
     edit(value) { text = value; editor.change(); },
     attach() { aceReady = true; timers.shift()(); },
+    rename(value) { nameEl.value = value; nameEl.input(); },
   };
 }
 
@@ -89,4 +94,25 @@ test("textarea fallback works and polling stops if Ace never initializes", () =>
   assert.equal(state.warning.hidden, true);
   for (let attempt = 0; attempt < 50; attempt++) state.timers.shift()();
   assert.equal(state.timers.length, 0);
+});
+
+test("Key facts and Key dates subsections never show guidance", () => {
+  for (const name of ["Key facts", "Key Facts", "Key dates", "Key Dates"]) {
+    assert.equal(setup({ name }).warning.hidden, true);
+  }
+});
+
+test("similarly named subsections still show guidance", () => {
+  for (const name of ["key facts", "Key Fact", "Key facts and figures"]) {
+    assert.equal(setup({ name }).warning.hidden, false);
+  }
+});
+
+test("renaming into and out of an exempt name toggles guidance live", () => {
+  const state = setup({ name: "Required format" });
+  assert.equal(state.warning.hidden, false);
+  state.rename("Key facts");
+  assert.equal(state.warning.hidden, true);
+  state.rename("Required format");
+  assert.equal(state.warning.hidden, false);
 });


### PR DESCRIPTION
## Summary

Closes #852.

Add a non-blocking warning beside the callout checkbox in the subsection editor when the body exceeds a configurable estimated word count.

- Default threshold: **more than 100 words**. `CALLOUT_WORD_WARNING_THRESHOLD` can tune it per environment. This is a starting content-guidance heuristic, not an approved length limit.
- Use the same whitespace-separated Markdown source count as existing floating callouts. Markdown syntax can contribute to the estimate; this does not estimate rendered height or evaluate content quality.
- Update immediately when authors edit the body or toggle the checkbox, including unnamed subsections. Render the initial state on the server and preserve submitted values after validation errors.
- Reuse the existing warning style with a polite live region. No save/publish blocking, model migration, output/CSS changes, AI calls, or new application dependencies.

## Verification

- Local full Django suite: 1,856 tests passed.
- Eight dependency-free JavaScript unit tests passed; included in CI.
- Changed Python files pass Black/isort; `git diff --check` passes.
- Local browser: reproduced the missing warning on main with a synthetic 130-word callout; verified the new warning, mouse/keyboard toggles, live shortening, the 100/101-word boundary, unnamed subsections, and saving above the threshold.
- Before/after screenshots and the detailed verification record are in the PR comment.

## Review focus

Please review the warning copy and the initial 100-word threshold. The warning stays editor-only; adding list-page guidance or changing callout layout remains out of scope.
