### PR TITLE
fix: increase spacing below PDF H3 headings

### DIFF
--- a/nofos/bloom_nofos/static/theme-base.css
+++ b/nofos/bloom_nofos/static/theme-base.css
@@ -454,6 +454,7 @@ h2 {
 h3 {
   font-size: 28pt;
   font-weight: 700;
+  margin-bottom: 10px;
   margin-top: 20px;
   line-height: 1.2;
 }

--- a/nofos/nofos/tests_nofos/test_theme_css.py
+++ b/nofos/nofos/tests_nofos/test_theme_css.py
@@ -1,0 +1,19 @@
+import re
+
+from django.contrib.staticfiles import finders
+from django.test import SimpleTestCase
+
+
+class SharedThemeHeadingSpacingTests(SimpleTestCase):
+    def test_h3_has_extra_space_before_following_content(self):
+        css_path = finders.find("theme-base.css")
+        self.assertIsNotNone(
+            css_path, "theme-base.css not found by staticfiles finders"
+        )
+
+        with open(css_path, encoding="utf-8") as css_file:
+            css = css_file.read()
+
+        rule_match = re.search(r"^h3\s*\{([^}]*)\}", css, re.MULTILINE)
+        self.assertIsNotNone(rule_match, "No h3 rule found")
+        self.assertIn("margin-bottom: 10px", rule_match.group(1))


### PR DESCRIPTION
## Summary

Closes #863.

- increase the bottom margin below H3 headings from 5px to 10px in the PDF stylesheet
- leave H2 and H4-H6 heading spacing unchanged
- preserve the existing paragraph spacing rhythm
- add regression coverage for the H3-specific rule

The H3 and first-paragraph margins previously collapsed to a single 5px gap. The larger H3 margin now produces a 10px gap, giving descenders such as the lowercase `p` in `Find the application package` balanced visual separation from the following paragraph.

## Verification

- focused heading-spacing regression test passes
- formatting hooks pass
- full local Django suite: **1,889 tests passed**
- browser-rendered the production PDF stylesheet with the reported heading and paragraph content

## Before and after

The following synthetic browser-rendered comparison uses the production PDF stylesheet. No real NOFO data is included.

<img width="1360" height="1760" alt="Before and after comparison of spacing below a PDF H3 heading" src="https://github.com/user-attachments/assets/7dcefe46-1403-44b5-8a35-d2c98974e9f0" />